### PR TITLE
Removed hard coded c extentions lib/include paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,9 @@ Build
 
     python setup.by build
 
+If librdkafka is installed in a non-standard location provide the include and library directories with:
 
+    CPLUS_INCLUDE_PATH=/path/to/include LIBRARY_PATH=/path/to/lib python setup.py ...
 
 
 Tests

--- a/setup.py
+++ b/setup.py
@@ -5,9 +5,7 @@ from distutils.core import Extension
 
 
 module = Extension('confluent_kafka.cimpl',
-                    include_dirs = ['/usr/local/include'],
                     libraries= ['rdkafka'],
-                    library_dirs = ['/usr/local/lib'],
                     sources=['confluent_kafka/src/confluent_kafka.c',
                              'confluent_kafka/src/Producer.c',
                              'confluent_kafka/src/Consumer.c'])


### PR DESCRIPTION
With packaging systems like conda users need to be able to specify the location of librdkafka. 

If users have compiled librdkafka to a non standard location you can build with:

    CPLUS_INCLUDE_PATH=/path/to/include LIBRARY_PATH=/path/to/lib $PYTHON setup.py install