### PR TITLE
Fix 32-bit arch build warnings

### DIFF
--- a/confluent_kafka/src/Consumer.c
+++ b/confluent_kafka/src/Consumer.c
@@ -108,7 +108,7 @@ static PyObject *Consumer_subscribe (Handle *self, PyObject *args,
 		return NULL;
 	}
 
-	topics = rd_kafka_topic_partition_list_new(PyList_Size(tlist));
+	topics = rd_kafka_topic_partition_list_new((int)PyList_Size(tlist));
 	for (pos = 0 ; pos < PyList_Size(tlist) ; pos++) {
 		PyObject *o = PyList_GetItem(tlist, pos);
 		PyObject *uo;

--- a/confluent_kafka/src/Producer.c
+++ b/confluent_kafka/src/Producer.c
@@ -219,7 +219,6 @@ int32_t Producer_partitioner_cb (const rd_kafka_topic_t *rkt,
 	if (!args) {
 		cfl_PyErr_Format(RD_KAFKA_RESP_ERR__FAIL,
 				 "Unable to build callback args");
-		printf("Failed to build args\n");
 		goto done;
 	}
 
@@ -228,7 +227,7 @@ int32_t Producer_partitioner_cb (const rd_kafka_topic_t *rkt,
 	Py_DECREF(args);
 
 	if (result) {
-		r = PyLong_AsLong(result);
+		r = (int32_t)PyLong_AsLong(result);
 		if (PyErr_Occurred())
 			printf("FIXME: partition_cb returned wrong type "
 			       "(expected long), how to propagate?\n");

--- a/confluent_kafka/src/confluent_kafka.c
+++ b/confluent_kafka/src/confluent_kafka.c
@@ -133,7 +133,7 @@ static PyObject* KafkaError_richcompare (KafkaError *self, PyObject *o2,
 	if (Py_TYPE(o2) == &KafkaErrorType)
 		code2 = ((KafkaError *)o2)->code;
 	else
-		code2 = PyLong_AsLong(o2);
+		code2 = (int)PyLong_AsLong(o2);
 
 	switch (op)
 	{
@@ -320,7 +320,7 @@ static PyObject *Message_partition (Message *self, PyObject *ignore) {
 
 static PyObject *Message_offset (Message *self, PyObject *ignore) {
 	if (self->offset >= 0)
-		return PyLong_FromLong(self->offset);
+		return PyLong_FromLongLong(self->offset);
 	else
 		Py_RETURN_NONE;
 }
@@ -776,7 +776,7 @@ rd_kafka_topic_partition_list_t *py_to_c_parts (PyObject *plist) {
 		return NULL;
 	}
 
-	c_parts = rd_kafka_topic_partition_list_new(PyList_Size(plist));
+	c_parts = rd_kafka_topic_partition_list_new((int)PyList_Size(plist));
 
 	for (i = 0 ; i < PyList_Size(plist) ; i++) {
 		TopicPartition *tp = (TopicPartition *)


### PR DESCRIPTION
Fixes the compilation warnings when doing fat builds (32+64 bit) on OSX.
