### PR TITLE
Add timestamp() to librdkafka messages

### DIFF
--- a/confluent_kafka/src/confluent_kafka.c
+++ b/confluent_kafka/src/confluent_kafka.c
@@ -327,10 +327,15 @@ static PyObject *Message_offset (Message *self, PyObject *ignore) {
 
 
 static PyObject *Message_timestamp (Message *self, PyObject *ignore) {
-	if (self->timestamp > 0)
+	if (self->tstype != RD_KAFKA_TIMESTAMP_NOT_AVAILABLE)
 		return PyLong_FromLong(self->timestamp);
 	else
 		Py_RETURN_NONE;
+}
+
+
+static PyObject *Message_tstype (Message *self, PyObject *ignore) {
+  return PyLong_FromLong(self->tstype);
 }
 
 
@@ -373,6 +378,11 @@ static PyMethodDef Message_methods[] = {
 	{ "timestamp", (PyCFunction)Message_timestamp, METH_NOARGS,
 	  "  :returns: message timestamp or None if not available.\n"
 	  "  :rtype: int or None\n"
+	  "\n"
+	},
+	{ "tstype", (PyCFunction)Message_tstype, METH_NOARGS,
+	  "  :returns: message timestamp type.\n"
+	  "  :rtype: int\n"
 	  "\n"
 	},
 	{ NULL }
@@ -508,11 +518,7 @@ PyObject *Message_new0 (const rd_kafka_message_t *rkm) {
 	self->partition = rkm->partition;
 	self->offset = rkm->offset;
 
-	rd_kafka_timestamp_type_t tstype;
-	self->timestamp = rd_kafka_message_timestamp(rkm, &tstype);
-	if (tstype != RD_KAFKA_TIMESTAMP_NOT_AVAILABLE) {
-		// todo: make tstype available to python api
-	}
+	self->timestamp = rd_kafka_message_timestamp(rkm, &self->tstype);
 
 	return (PyObject *)self;
 }

--- a/confluent_kafka/src/confluent_kafka.c
+++ b/confluent_kafka/src/confluent_kafka.c
@@ -326,6 +326,14 @@ static PyObject *Message_offset (Message *self, PyObject *ignore) {
 }
 
 
+static PyObject *Message_timestamp (Message *self, PyObject *ignore) {
+	if (self->timestamp > 0)
+		return PyLong_FromLong(self->timestamp);
+	else
+		Py_RETURN_NONE;
+}
+
+
 static PyMethodDef Message_methods[] = {
 	{ "error", (PyCFunction)Message_error, METH_NOARGS,
 	  "  The message object is also used to propagate errors and events, "
@@ -359,6 +367,11 @@ static PyMethodDef Message_methods[] = {
 	},
 	{ "offset", (PyCFunction)Message_offset, METH_NOARGS,
 	  "  :returns: message offset or None if not available.\n"
+	  "  :rtype: int or None\n"
+	  "\n"
+	},
+	{ "timestamp", (PyCFunction)Message_timestamp, METH_NOARGS,
+	  "  :returns: message timestamp or None if not available.\n"
 	  "  :rtype: int or None\n"
 	  "\n"
 	},
@@ -494,6 +507,12 @@ PyObject *Message_new0 (const rd_kafka_message_t *rkm) {
 
 	self->partition = rkm->partition;
 	self->offset = rkm->offset;
+
+	rd_kafka_timestamp_type_t tstype;
+	self->timestamp = rd_kafka_message_timestamp(rkm, &tstype);
+	if (tstype != RD_KAFKA_TIMESTAMP_NOT_AVAILABLE) {
+		// todo: make tstype available to python api
+	}
 
 	return (PyObject *)self;
 }

--- a/confluent_kafka/src/confluent_kafka.c
+++ b/confluent_kafka/src/confluent_kafka.c
@@ -327,15 +327,9 @@ static PyObject *Message_offset (Message *self, PyObject *ignore) {
 
 
 static PyObject *Message_timestamp (Message *self, PyObject *ignore) {
-	if (self->tstype != RD_KAFKA_TIMESTAMP_NOT_AVAILABLE)
-		return PyLong_FromLong(self->timestamp);
-	else
-		Py_RETURN_NONE;
-}
-
-
-static PyObject *Message_tstype (Message *self, PyObject *ignore) {
-  return PyLong_FromLong(self->tstype);
+	return Py_BuildValue("iL",
+			     self->tstype,
+			     self->timestamp);
 }
 
 
@@ -376,13 +370,8 @@ static PyMethodDef Message_methods[] = {
 	  "\n"
 	},
 	{ "timestamp", (PyCFunction)Message_timestamp, METH_NOARGS,
-	  "  :returns: message timestamp or None if not available.\n"
-	  "  :rtype: int or None\n"
-	  "\n"
-	},
-	{ "tstype", (PyCFunction)Message_tstype, METH_NOARGS,
-	  "  :returns: message timestamp type.\n"
-	  "  :rtype: int\n"
+	  "  :returns: tuple of message tstype, and timestamp.\n"
+	  "  :rtype: (int, int)\n"
 	  "\n"
 	},
 	{ NULL }
@@ -1443,6 +1432,10 @@ static PyObject *_init_cimpl (void) {
 		NULL, NULL);
 	Py_INCREF(KafkaException);
 	PyModule_AddObject(m, "KafkaException", KafkaException);
+
+	PyModule_AddIntConstant(m, "TIMESTAMP_NOT_AVAILABLE", RD_KAFKA_TIMESTAMP_NOT_AVAILABLE);
+	PyModule_AddIntConstant(m, "TIMESTAMP_CREATE_TIME", RD_KAFKA_TIMESTAMP_CREATE_TIME);
+	PyModule_AddIntConstant(m, "TIMESTAMP_LOG_APPEND_TIME", RD_KAFKA_TIMESTAMP_LOG_APPEND_TIME);
 
 	return m;
 }

--- a/confluent_kafka/src/confluent_kafka.h
+++ b/confluent_kafka/src/confluent_kafka.h
@@ -220,6 +220,7 @@ typedef struct {
 	int32_t partition;
 	int64_t offset;
 	int64_t timestamp;
+	rd_kafka_timestamp_type_t tstype;
 } Message;
 
 extern PyTypeObject MessageType;

--- a/confluent_kafka/src/confluent_kafka.h
+++ b/confluent_kafka/src/confluent_kafka.h
@@ -219,6 +219,7 @@ typedef struct {
 	PyObject *error;
 	int32_t partition;
 	int64_t offset;
+	int64_t timestamp;
 } Message;
 
 extern PyTypeObject MessageType;

--- a/examples/integration_test.py
+++ b/examples/integration_test.py
@@ -210,6 +210,7 @@ def verify_consumer():
             'group.id': 'test.py',
             'session.timeout.ms': 6000,
             'enable.auto.commit': False,
+            'api.version.request': True,
             'on_commit': print_commit_result,
             'error_cb': error_cb,
             'default.topic.config': {
@@ -243,9 +244,9 @@ def verify_consumer():
                 break
 
         if False:
-            print('%s[%d]@%d: key=%s, value=%s' % \
+            print('%s[%d]@%d: key=%s, value=%s, tstype=%d, timestamp=%s' % \
                   (msg.topic(), msg.partition(), msg.offset(),
-                   msg.key(), msg.value()))
+                   msg.key(), msg.value(), msg.tstype(), repr(msg.timestamp())))
 
         if (msg.offset() % 5) == 0:
             # Async commit

--- a/examples/integration_test.py
+++ b/examples/integration_test.py
@@ -244,9 +244,10 @@ def verify_consumer():
                 break
 
         if False:
+            tstype, timestamp = msg.timestamp()
             print('%s[%d]@%d: key=%s, value=%s, tstype=%d, timestamp=%s' % \
                   (msg.topic(), msg.partition(), msg.offset(),
-                   msg.key(), msg.value(), msg.tstype(), repr(msg.timestamp())))
+                   msg.key(), msg.value(), tstype, timestamp))
 
         if (msg.offset() % 5) == 0:
             # Async commit

--- a/tests/test_Consumer.py
+++ b/tests/test_Consumer.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-from confluent_kafka import Consumer, TopicPartition, KafkaError, KafkaException
+from confluent_kafka import Consumer, TopicPartition, KafkaError, KafkaException, TIMESTAMP_NOT_AVAILABLE
 
 
 def test_basic_api():
@@ -35,6 +35,9 @@ def test_basic_api():
         print('OK: consumer error: %s' % msg.error().str())
     else:
         print('OK: consumed message')
+
+    if msg is not None:
+        assert msg.timestamp() == (TIMESTAMP_NOT_AVAILABLE, -1)
 
     partitions = list(map(lambda p: TopicPartition("test", p), range(0,100,3)))
     kc.assign(partitions)

--- a/tests/test_enums.py
+++ b/tests/test_enums.py
@@ -7,3 +7,9 @@ def test_enums():
         KafkaError class without an instantiated object. """
     print(confluent_kafka.KafkaError._NO_OFFSET)
     print(confluent_kafka.KafkaError.REBALANCE_IN_PROGRESS)
+
+def test_tstype_enums():
+    """ Make sure librdkafka tstype enums are available. """
+    assert confluent_kafka.TIMESTAMP_NOT_AVAILABLE == 0
+    assert confluent_kafka.TIMESTAMP_CREATE_TIME == 1
+    assert confluent_kafka.TIMESTAMP_LOG_APPEND_TIME == 2


### PR DESCRIPTION
`tstype` still needs to be exposed somehow, not sure of the best way to do that.

The whitespace in `confluent_kafka.c` is a mix of tabs/spaces as well as spaces in blank lines which my editor automatically removed.
