### PR TITLE
replace from .cimpl import * with explicit names.

### DIFF
--- a/confluent_kafka/__init__.py
+++ b/confluent_kafka/__init__.py
@@ -1,2 +1,2 @@
 __all__ = ['cimpl', 'avro', 'kafkatest']
-from .cimpl import Consumer, KafkaError, KafkaException, Message, Producer, TopicPartition, libversion, version
+from .cimpl import Consumer, KafkaError, KafkaException, Message, Producer, TopicPartition, libversion, version, TIMESTAMP_NOT_AVAILABLE

--- a/confluent_kafka/__init__.py
+++ b/confluent_kafka/__init__.py
@@ -1,2 +1,2 @@
 __all__ = ['cimpl', 'avro', 'kafkatest']
-from .cimpl import *
+from .cimpl import Consumer, KafkaError, KafkaException, Message, Producer, TopicPartition, libversion, version

--- a/confluent_kafka/__init__.py
+++ b/confluent_kafka/__init__.py
@@ -1,2 +1,3 @@
 __all__ = ['cimpl', 'avro', 'kafkatest']
-from .cimpl import Consumer, KafkaError, KafkaException, Message, Producer, TopicPartition, libversion, version, TIMESTAMP_NOT_AVAILABLE
+from .cimpl import (Consumer, KafkaError, KafkaException, Message, Producer, TopicPartition, libversion, version, 
+                    TIMESTAMP_NOT_AVAILABLE, TIMESTAMP_CREATE_TIME, TIMESTAMP_LOG_APPEND_TIME)


### PR DESCRIPTION
pylint complains there is no Consumer in confluent_kafka
better explicit on what's imported than *.