### PR TITLE
Proper error string handling in Producer, issue #129

### DIFF
--- a/confluent_kafka/src/Consumer.c
+++ b/confluent_kafka/src/Consumer.c
@@ -463,7 +463,7 @@ static PyObject *Consumer_poll (Handle *self, PyObject *args,
         if (!rkm)
                 Py_RETURN_NONE;
 
-        msgobj = Message_new0(rkm);
+        msgobj = Message_new0(self, rkm);
         rd_kafka_message_destroy(rkm);
 
         return msgobj;
@@ -769,6 +769,8 @@ static int Consumer_init (PyObject *selfobj, PyObject *args, PyObject *kwargs) {
                                 "Consumer already __init__:ialized");
                 return -1;
         }
+
+        self->type = RD_KAFKA_CONSUMER;
 
         if (!(conf = common_conf_setup(RD_KAFKA_CONSUMER, self,
                                        args, kwargs)))

--- a/confluent_kafka/src/Producer.c
+++ b/confluent_kafka/src/Producer.c
@@ -152,7 +152,7 @@ static void dr_msg_cb (rd_kafka_t *rk, const rd_kafka_message_t *rkm,
 		goto done;
 	}
 
-	msgobj = Message_new0(rkm);
+	msgobj = Message_new0(self, rkm);
 	
 	args = Py_BuildValue("(OO)",
 			     Message_error((Message *)msgobj, NULL),
@@ -526,6 +526,8 @@ static int Producer_init (PyObject *selfobj, PyObject *args, PyObject *kwargs) {
                                 "Producer already __init__:ialized");
                 return -1;
         }
+
+        self->type = RD_KAFKA_PRODUCER;
 
         if (!(conf = common_conf_setup(RD_KAFKA_PRODUCER, self,
                                        args, kwargs)))

--- a/confluent_kafka/src/confluent_kafka.c
+++ b/confluent_kafka/src/confluent_kafka.c
@@ -258,7 +258,10 @@ PyObject *KafkaError_new0 (rd_kafka_resp_err_t err, const char *fmt, ...) {
  PyObject *KafkaError_new_or_None (rd_kafka_resp_err_t err, const char *str) {
 	if (!err)
 		Py_RETURN_NONE;
-	return KafkaError_new0(err, "%s", str);
+        if (str)
+                return KafkaError_new0(err, "%s", str);
+        else
+                return KafkaError_new0(err, NULL);
 }
 
 

--- a/confluent_kafka/src/confluent_kafka.h
+++ b/confluent_kafka/src/confluent_kafka.h
@@ -125,6 +125,7 @@ typedef struct {
 	PyObject *stats_cb;
         int initiated;
         int tlskey;  /* Thread-Local-Storage key */
+        rd_kafka_type_t type; /* Producer or consumer */
 
 	union {
 		/**
@@ -255,7 +256,7 @@ typedef struct {
 
 extern PyTypeObject MessageType;
 
-PyObject *Message_new0 (const rd_kafka_message_t *rkm);
+PyObject *Message_new0 (const Handle *handle, const rd_kafka_message_t *rkm);
 PyObject *Message_error (Message *self, PyObject *ignore);
 
 


### PR DESCRIPTION
Previous to this fix, when a message failed delivery the err.str() in the delivery report callback would actually return the message payload (due to librdkafka struct member reuse).

In cases where the payload was not unicode safe this would lead to a UnicodeDecodeException.

Additionally, no payload length was enforced so the payload to error string conversion could , if unlucky, continue into unmapped or unrelated memory, possibly crashing.
See #129 