### PR TITLE
Handle delivery.report.only.error in Python (#84)

### DIFF
--- a/confluent_kafka/src/Producer.c
+++ b/confluent_kafka/src/Producer.c
@@ -152,6 +152,10 @@ static void dr_msg_cb (rd_kafka_t *rk, const rd_kafka_message_t *rkm,
 		goto done;
 	}
 
+        /* Skip callback if delivery.report.only.error=true */
+        if (self->u.Producer.dr_only_error && !rkm->err)
+                goto done;
+
 	msgobj = Message_new0(self, rkm);
 	
 	args = Py_BuildValue("(OO)",

--- a/confluent_kafka/src/confluent_kafka.h
+++ b/confluent_kafka/src/confluent_kafka.h
@@ -138,6 +138,8 @@ typedef struct {
 				const rd_kafka_topic_t *,
 				const void *, size_t, int32_t,
 				void *, void *);  /**< Fallback C partitioner*/
+
+                        int dr_only_error; /**< delivery.report.only.error */
 		} Producer;
 
 		/**


### PR DESCRIPTION
@ewencp There is a FIXME in the test code for the success dr callback which is not supposed to get called and there are verifications for that, but I'd like to also make sure that the callable object reference is properly removed and GC:ed. Do you have any idea how this could be done?