### PR TITLE
Fix memory leak on errors.

### DIFF
--- a/confluent_kafka/src/confluent_kafka.h
+++ b/confluent_kafka/src/confluent_kafka.h
@@ -105,6 +105,7 @@ PyObject *KafkaError_new_or_None (rd_kafka_resp_err_t err, const char *str);
 #define cfl_PyErr_Format(err,...) do {					\
 		PyObject *_eo = KafkaError_new0(err, __VA_ARGS__);	\
 		PyErr_SetObject(KafkaException, _eo);			\
+		Py_XDECREF(_eo); \
 	} while (0)
 
 

--- a/confluent_kafka/src/confluent_kafka.h
+++ b/confluent_kafka/src/confluent_kafka.h
@@ -105,7 +105,7 @@ PyObject *KafkaError_new_or_None (rd_kafka_resp_err_t err, const char *str);
 #define cfl_PyErr_Format(err,...) do {					\
 		PyObject *_eo = KafkaError_new0(err, __VA_ARGS__);	\
 		PyErr_SetObject(KafkaException, _eo);			\
-		Py_XDECREF(_eo); \
+		Py_DECREF(_eo); \
 	} while (0)
 
 


### PR DESCRIPTION
The reference count handling in `cfl_PyErr_Format` is not done right.
The count of `_eo` must be decreased after calling `PyErr_SetObject`, otherwise the object is leaking.
