### PR TITLE
Change the version no. returned by confluent kafka_version

### DIFF
--- a/confluent_kafka/src/confluent_kafka.c
+++ b/confluent_kafka/src/confluent_kafka.c
@@ -1422,7 +1422,7 @@ static PyObject *libversion (PyObject *self, PyObject *args) {
 }
 
 static PyObject *version (PyObject *self, PyObject *args) {
-	return Py_BuildValue("si", "0.9.5", 0x00090100);
+	return Py_BuildValue("si", "0.9.4", 0x00090400);
 }
 
 static PyMethodDef cimpl_methods[] = {

--- a/confluent_kafka/src/confluent_kafka.c
+++ b/confluent_kafka/src/confluent_kafka.c
@@ -1422,7 +1422,7 @@ static PyObject *libversion (PyObject *self, PyObject *args) {
 }
 
 static PyObject *version (PyObject *self, PyObject *args) {
-	return Py_BuildValue("si", "0.9.2", 0x00090100);
+	return Py_BuildValue("si", "0.9.5", 0x00090100);
 }
 
 static PyMethodDef cimpl_methods[] = {


### PR DESCRIPTION
I hope this is okay? A pull request to fix the version number returned by confluent_kafka.version()
as documented by this bug here: https://github.com/confluentinc/confluent-kafka-python/issues/151

I changed the 2 to a 5 since its marked for the  v0.9.5 milestone 