### PR TITLE
ENH Allow to pass custom schema registry instance.

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ In order to run full test suite, simply execute:
 
 **Run integration tests:**
 
-To run the integration tests, uncomment the following line from `tox.ini` and add the paths to your Kafka and Confluent Schema Registry instances. If no Schema Registry path is provided then no AVRO tests will by run. You can also run the integration tests outside of `tox` by running this command from the source root.
+To run the integration tests, uncomment the following line from `tox.ini` and add the paths to your Kafka and Confluent Schema Registry instances. You can also run the integration tests outside of `tox` by running this command from the source root.
 
     examples/integration_test.py <kafka-broker> [<test-topic>] [<schema-registry>]
 

--- a/tests/avro/test_avro_producer.py
+++ b/tests/avro/test_avro_producer.py
@@ -29,6 +29,10 @@ import unittest
 from confluent_kafka.avro import AvroProducer
 from confluent_kafka.avro.serializer import (KeySerializerError,
                                              ValueSerializerError)
+
+from tests.avro.mock_schema_registry_client import MockSchemaRegistryClient
+
+
 avsc_dir = os.path.dirname(os.path.realpath(__file__))
 
 
@@ -82,3 +86,15 @@ class TestAvroProducer(unittest.TestCase):
         producer = AvroProducer({'schema.registry.url': 'http://127.0.0.1:9001'})
         with self.assertRaises(ConnectionError):  # Unexistent schema-registry
             producer.produce(topic='test', value=32., value_schema=value_schema, key='mykey', key_schema=key_schema)
+
+    def test_produce_with_custom_registry(self):
+        schema_registry = MockSchemaRegistryClient()
+        value_schema = avro.load(os.path.join(avsc_dir, "basic_schema.avsc"))
+        key_schema = avro.load(os.path.join(avsc_dir, "primitive_string.avsc"))
+        producer = AvroProducer({}, schema_registry=schema_registry)
+        producer.produce(topic='test', value={"name": 'abc"'}, value_schema=value_schema, key='mykey', key_schema=key_schema)
+
+    def test_produce_with_custom_registry_and_registry_url(self):
+        schema_registry = MockSchemaRegistryClient()
+        with self.assertRaises(ValueError):
+            producer = AvroProducer({'schema.registry.url': 'http://127.0.0.1:9001'}, schema_registry=schema_registry)


### PR DESCRIPTION
This allows, for example, to use a static schema registry.