### PR TITLE
Fastavro Producer + Better Consumer Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,15 @@ Prerequisites
 
  * Python >= 2.7 or Python 3.x
  * [librdkafka](https://github.com/edenhill/librdkafka) >= 0.9.1
+ 
+ 
+For **Debian/Ubuntu**** based systems, add this APT repo and then do `sudo apt-get install librdkafka-dev python-dev`:
+http://docs.confluent.io/current/installation.html#installation-apt
+
+For **RedHat** and **RPM**-based distros, add this YUM repo and then do `sudo yum install librdkafka-devel python-devel`:
+http://docs.confluent.io/current/installation.html#rpm-packages-via-yum
+
+On **OSX**, use **homebrew** and do `sudo brew install librdkafka`
 
 
 Install

--- a/confluent_kafka/avro/cached_schema_registry_client.py
+++ b/confluent_kafka/avro/cached_schema_registry_client.py
@@ -36,7 +36,7 @@ log = logging.getLogger(__name__)
 
 HAS_FAST = False
 try:
-    from fastavro.reader import read_data
+    import fastavro  # noqa: F401
 
     HAS_FAST = True
 except:

--- a/confluent_kafka/avro/cached_schema_registry_client.py
+++ b/confluent_kafka/avro/cached_schema_registry_client.py
@@ -32,6 +32,14 @@ from . import loads
 ACCEPT_HDR = "application/vnd.schemaregistry.v1+json, application/vnd.schemaregistry+json, application/json"
 log = logging.getLogger(__name__)
 
+HAS_FAST = False
+try:
+    from fastavro.reader import read_data
+
+    HAS_FAST = True
+except:
+    pass
+
 
 class CachedSchemaRegistryClient(object):
     """
@@ -50,11 +58,13 @@ class CachedSchemaRegistryClient(object):
         self.url = url.rstrip('/')
 
         self.max_schemas_per_subject = max_schemas_per_subject
-        # subj => { schema => id }
+        # subj => { avro_schema => id }
         self.subject_to_schema_ids = defaultdict(dict)
         # id => avro_schema
         self.id_to_schema = defaultdict(dict)
-        # subj => { schema => version }
+        # id => json_schema
+        self.id_to_json_schema = defaultdict(dict)
+        # subj => { avro_schema => version }
         self.subject_to_schema_versions = defaultdict(dict)
 
     def _send_request(self, url, method='GET', body=None, headers=None):
@@ -102,6 +112,10 @@ class CachedSchemaRegistryClient(object):
                 self._add_to_cache(self.subject_to_schema_versions,
                                    subject, schema, version)
 
+    def _cache_json_schema(self, schema, schema_id):
+        if schema_id not in self.id_to_schema:
+            self.id_to_json_schema[schema_id] = schema.to_json()
+
     def register(self, subject, avro_schema):
         """
         POST /subjects/(string: subject)/versions
@@ -137,17 +151,22 @@ class CachedSchemaRegistryClient(object):
         schema_id = result['id']
         # cache it
         self._cache_schema(avro_schema, schema_id, subject)
+
         return schema_id
 
-    def get_by_id(self, schema_id):
+    def get_by_id(self, schema_id, json_format=False):
         """
         GET /schemas/ids/{int: id}
         Retrieve a parsed avro schema by id or None if not found
         @:param: schema_id: int value
         @:returns: Avro schema
         """
-        if schema_id in self.id_to_schema:
-            return self.id_to_schema[schema_id]
+        if json_format:
+            if schema_id in self.id_to_json_schema:
+                return self.id_to_json_schema[schema_id]
+        else:
+            if schema_id in self.id_to_schema:
+                return self.id_to_schema[schema_id]
         # fetch from the registry
         url = '/'.join([self.url, 'schemas', 'ids', str(schema_id)])
 
@@ -162,10 +181,18 @@ class CachedSchemaRegistryClient(object):
             # need to parse the schema
             schema_str = result.get("schema")
             try:
-                result = loads(schema_str)
+                avro_schema = loads(schema_str)
                 # cache it
-                self._cache_schema(result, schema_id)
-                return result
+                self._cache_schema(avro_schema, schema_id)
+
+                if HAS_FAST:
+                    json_schema = json.loads(schema_str)
+                    self._cache_json_schema(json_schema, schema_id)
+
+                    if json_format:
+                        return json_schema
+                return avro_schema
+
             except:
                 # bad schema - should not happen
                 raise ClientError("Received bad schema from registry.")

--- a/tests/avro/mock_schema_registry_client.py
+++ b/tests/avro/mock_schema_registry_client.py
@@ -36,6 +36,8 @@ class MockSchemaRegistryClient(object):
         self.subject_to_schema_ids = {}
         # id => avro_schema
         self.id_to_schema = {}
+        # id => json_schema
+        self.id_to_json_schema = {}
         # subj => { schema => version }
         self.subject_to_schema_versions = {}
 
@@ -74,6 +76,7 @@ class MockSchemaRegistryClient(object):
             schema = self.id_to_schema[schema_id]
         else:
             self.id_to_schema[schema_id] = schema
+            self.id_to_json_schema[schema_id] = schema.to_json()
 
         self._add_to_cache(self.subject_to_schema_ids,
                            subject, schema, schema_id)
@@ -109,9 +112,12 @@ class MockSchemaRegistryClient(object):
         self._cache_schema(avro_schema, schema_id, subject, version)
         return schema_id
 
-    def get_by_id(self, schema_id):
+    def get_by_id(self, schema_id, json_format=False):
         """Retrieve a parsed avro schema by id or None if not found"""
-        return self.id_to_schema.get(schema_id, None)
+        if json_format:
+            return self.id_to_json_schema.get(schema_id, None)
+        else:
+            return self.id_to_schema.get(schema_id, None)
 
     def get_latest_schema(self, subject):
         """


### PR DESCRIPTION
Adding support to the AvroProducer to use the `schemaless_writer` from fastavro - we've seen write speed for large records improve by a factor of 4.

The key difference between `fastavro` and `avro` is that fastavro expects the schema to be a python dict, so I've added an `id_to_json_schema` cache to the CachedSchemaRegistryClient.

Trying to use `schema.to_json()` for large and complex schemas (unions, lists of record objects etc) gave the following error:

```
  File "confluent-kafka-python-1/avro-load-test.py", line 97, in test_fastavro
    fastavro.schemaless_writer(b, schema.to_json(), record)
  File "fastavro/_writer.py", line 498, in fastavro._writer.schemaless_writer (fastavro/_writer.c:13154)
  File "fastavro/_writer.py", line 511, in fastavro._writer.schemaless_writer (fastavro/_writer.c:13012)
  File "fastavro/_writer.py", line 366, in fastavro._writer.acquaint_schema (fastavro/_writer.c:10916)
  File "fastavro/_schema.py", line 57, in fastavro._schema.extract_named_schemas_into_repo (fastavro/_schema.c:2862)
  File "fastavro/_schema.py", line 109, in fastavro._schema.extract_named_schemas_into_repo (fastavro/_schema.c:2696)
  File "fastavro/_schema.py", line 60, in fastavro._schema.extract_named_schemas_into_repo (fastavro/_schema.c:2032)
  File "fastavro/_schema.py", line 109, in fastavro._schema.extract_named_schemas_into_repo (fastavro/_schema.c:2696)
  File "fastavro/_schema.py", line 60, in fastavro._schema.extract_named_schemas_into_repo (fastavro/_schema.c:2032)
  File "fastavro/_schema.py", line 74, in fastavro._schema.extract_named_schemas_into_repo (fastavro/_schema.c:2117)
TypeError: unhashable type: 'ImmutableDict'
```
This issue occurred with the reading records as well - using fastavro was consistently failing in the schema and falling back to the default avro implementation.

Calling `schema.to_json()` was also significantly slower than  using a stored json schema, hence also using the `id_to_json_schema` cache in the fastavro consumer. In one test, calling `schem.to_json()` every time cancelled out the performance improvements of using fastavro.