### PR TITLE
Fix utf8 string conversion memory leak on Python 2 (#198)

### DIFF
--- a/confluent_kafka/src/Consumer.c
+++ b/confluent_kafka/src/Consumer.c
@@ -123,7 +123,7 @@ static PyObject *Consumer_subscribe (Handle *self, PyObject *args,
 	topics = rd_kafka_topic_partition_list_new((int)PyList_Size(tlist));
 	for (pos = 0 ; pos < PyList_Size(tlist) ; pos++) {
 		PyObject *o = PyList_GetItem(tlist, pos);
-		PyObject *uo;
+		PyObject *uo, *uo8;
 		if (!(uo = cfl_PyObject_Unistr(o))) {
 			PyErr_Format(PyExc_TypeError,
 				     "expected list of unicode strings");
@@ -131,8 +131,9 @@ static PyObject *Consumer_subscribe (Handle *self, PyObject *args,
 			return NULL;
 		}
 		rd_kafka_topic_partition_list_add(topics,
-						  cfl_PyUnistr_AsUTF8(uo),
+						  cfl_PyUnistr_AsUTF8(uo, &uo8),
 						  RD_KAFKA_PARTITION_UA);
+                Py_XDECREF(uo8);
 		Py_DECREF(uo);
 	}
 
@@ -284,6 +285,7 @@ static PyObject *Consumer_commit (Handle *self, PyObject *args,
 			return NULL;
 	} else if (msg) {
 		Message *m;
+                PyObject *uo8;
 
 		if (PyObject_Type((PyObject *)msg) !=
 		    (PyObject *)&MessageType) {
@@ -296,8 +298,9 @@ static PyObject *Consumer_commit (Handle *self, PyObject *args,
 
 		c_offsets = rd_kafka_topic_partition_list_new(1);
 		rd_kafka_topic_partition_list_add(
-			c_offsets, cfl_PyUnistr_AsUTF8(m->topic),
+			c_offsets, cfl_PyUnistr_AsUTF8(m->topic, &uo8),
 			m->partition)->offset =m->offset + 1;
+                Py_XDECREF(uo8);
 
 	} else {
 		c_offsets = NULL;

--- a/confluent_kafka/src/confluent_kafka.h
+++ b/confluent_kafka/src/confluent_kafka.h
@@ -64,8 +64,15 @@
 
 /**
  * @returns Unicode Python object as char * in UTF-8 encoding
+ * @param uobjp might be set to NULL or a new object reference (depending
+ *              on Python version) which needs to be cleaned up with
+ *              Py_XDECREF() after finished use of the returned string.
  */
-#define cfl_PyUnistr_AsUTF8(X)  PyUnicode_AsUTF8(X)
+static __inline const char *
+cfl_PyUnistr_AsUTF8 (PyObject *o, PyObject **uobjp) {
+        *uobjp = NULL; /* No intermediary object needed in Py3 */
+        return PyUnicode_AsUTF8(o);
+}
 
 /**
  * @returns Unicode Python string object
@@ -77,7 +84,11 @@
 /* See comments above */
 #define cfl_PyBin(X)    PyString ## X
 #define cfl_PyUnistr(X) PyUnicode ## X
-#define cfl_PyUnistr_AsUTF8(X) PyBytes_AsString(PyUnicode_AsUTF8String(X))
+static __inline const char *
+cfl_PyUnistr_AsUTF8 (PyObject *o, PyObject **uobjp) {
+        *uobjp = PyUnicode_AsUTF8String(o); /*UTF8 intermediary object on Py2*/
+        return PyBytes_AsString(*uobjp);
+}
 #define cfl_PyObject_Unistr(X) PyObject_Unicode(X)
 #endif
 


### PR DESCRIPTION
We need to keep and destroy the intermediary utf8 object on Python 2.