### PR TITLE
Build autonomous binary wheels for Linux and OSX

### DIFF
--- a/.appveyor-disabled.yml
+++ b/.appveyor-disabled.yml
@@ -1,0 +1,25 @@
+environment:
+  global:
+    CIBW_TEST_REQUIRES: pytest requests avro
+    CIBW_TEST_COMMAND: "pytest --import-mode=append --ignore={project}\\tests\\avro {project}\\tests"
+    # SDK v7.0 MSVC Express 2008's SetEnv.cmd script will fail if the
+    # /E:ON and /V:ON options are not enabled in the batch script intepreter
+    # See: http://stackoverflow.com/a/13751649/163740
+    CMD_IN_ENV: "cmd /E:ON /V:ON /C .\\tools\\appveyor\\run_with_env.cmd"
+
+#install:
+
+build_script:
+  - dir c:\python27
+  - dir c:\python27\include
+  - "curl https://raw.githubusercontent.com/chemeris/msinttypes/master/inttypes.h -o c:\\python27\\include\\inttypes.h"
+  - "curl https://raw.githubusercontent.com/chemeris/msinttypes/master/stdint.h -o c:\\python27\\include\\stdint.h"
+  - nuget install librdkafka.redist -OutputDirectory dest
+  - pip install https://github.com/joerick/cibuildwheel/archive/master.zip
+  - set INCLUDE=C:\\projects\\confluent-kafka-python\\dest\\librdkafka.redist.0.11.0\\build\\native\\include\\;%INCLUDE%
+  - set LIB=C:\\projects\\confluent-kafka-python\\dest\\librdkafka.redist.0.11.0\\runtimes\\win7-x64\\native;%LIB%
+  - cibuildwheel --output-dir wheelhouse
+
+artifacts:
+  - path: "wheelhouse\\*.whl"
+    name: Wheels

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ confluent?kafka.egg-info
 confluent-kafka-0.*.*
 tmp-build
 .tox
+wheelhouse

--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,8 @@ confluent?kafka.egg-info
 *.pyc
 .cache
 *.log
-confluent-kafka-0.*.*
+confluent-kafka-*.*.*
 tmp-build
 .tox
 wheelhouse
+dl-*

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,23 +1,40 @@
-language: python
-sudo: required
-python:
-  - "2.7"
-  - "3.4"
-  - "3.5"
-env:
- global:
-    - LD_LIBRARY_PATH=$PWD/tmp-build/lib
- matrix:
-  - LIBRDKAFKA_VERSION=v0.9.2
-  - LIBRDKAFKA_VERSION=master
-before_install:
-  - rm -rf tmp-build
-  - bash tools/bootstrap-librdkafka.sh ${LIBRDKAFKA_VERSION} tmp-build
-  - pip install --upgrade pip
-  - pip install pytest-timeout
+#env:
+#  global:
+  # Wheel tests are not working due to some .cimpl import weirdness.
+  #- CIBW_TEST_REQUIRES="pytest requests avro"
+  #- CIBW_TEST_COMMAND="pytest {project}/tests"
+
+matrix:
+ include:
+  - os: osx
+    env: CIBW_BEFORE_BUILD="tools/bootstrap-librdkafka.sh master tmp" CFLAGS="-Itmp/include" LDFLAGS="-Ltmp/lib"
+  - os: linux
+    dist: trusty
+    sudo: required
+    env: CIBW_BEFORE_BUILD="tools/bootstrap-librdkafka.sh master /usr"
+    language: python
+    python: "2.7"
+    services: docker
+
 install:
-  - pip install flake8
-  - pip install -v --global-option=build_ext --global-option="-Itmp-build/include/" --global-option="-Ltmp-build/lib" . .[avro]
+- pip install cibuildwheel==0.4.1
+
 script:
-  - flake8
-  - py.test -v --timeout 20 --ignore=tmp-build --import-mode append
+- cibuildwheel --output-dir wheelhouse
+- ls -la wheelhouse/
+
+deploy:
+  provider: s3
+  access_key_id:
+    secure: TWG1fsfD+kWkTHB5RQNW9HDw6i7j7WlYs5oTPLLevOjFmuYhG4qCylp9ZYGqjMzL8Jl4MxydmNDSL/gXYDnNplOX9CA1qbp/pKIG1AjTda12JM6mxs9uZNUOrl4FYRteSfPP+N+25VhPA+ix8ffC/jZ/9wypdQMorn5aC6Ln0LlR3ZdG+JeiOdX2JeqO7d429iDyTzFWYZKJssW8GHGQj07OSVc3vQWBCUPJOaaVRsALKa3VZJgVXooXsjI2SORSnC4GAJhVgqzHLcs7AFVNaS2rrlF23mRcN8ePEnS76uIVk7Y2K90OeHcPgFfsTqrxFuLtHZYY68H2os+DamiERxD2xDpM28G2f3Ltb/bG7NGhuv0YHFWtwCbzB+aSJbGtUuFKqwdOwnD2PnQsVU0aX8N1lna3Fv4WVBBNXNeyKD0fbNYcTPvaOm+KSxN5/0l/BKyohjrTcVsn+6ZLdE6D5A0JfaX4sc3Lv2X+sdIc1ZLOL1OWg3eE1z4aAtKu3da8sPcP2Rb5V18uF0cBICdWP6kKtjRr+meCGw9S0Z2P3I1OLj+KfKmjrqtI7KXUTsz03npwOkbmFVprS5cXoW54kKhjrf99OhBXX7LhwJ5oKokBIDeXmUdyA+ettq5+5w5J8GgQ4MxIoY+vhy/wmcuM3yieASiftRPLFyJTr9/I6i8=
+  secret_access_key:
+    secure: G3KBqzmG7HaBznDMwNRq0qGIWiF3n96RgRnZzyvSfhRSqZq2Vv8llFo5GuCE0azzLA6Iot33x+Rugba3PbLReYoFOO87yWYT62Deq+lTwQHSEutcA1tNrW4ho+GPs2av/AhHE9e2r/xhp++2wHEvnj7Vp1HeVcmpAxkggZDkiS15GYiaVNEUa8tPL6GOcH3e8Xwcurr7dAi6KZnBFvylx0eADVPH3EAfN8TxapkT89FKjEtPZOV/srSFi5m561rW/P4+MwzBu0x01ouANdAKoAhEMubcEHANr1x8yuXlr99eapqnbfYMpaITyDbKIDSV/mVR5e/9G6xQEXs59FJJJ1bRCLF9uxIht3rlijED7WEElHJ1j2Ip9JZH0iKEPykw9vGNnjUZK2Hw4D8MvD+6jHbauZGsTeqTbh74tGxsIe/tpAZ2kmueqdO5iYK/R8louWjgmwGf+veqqQXCUw0UBnJoL5x+axp5nszQiepU/EnnyJ5bH1IB5qRUqesTYFWU/dxF7JQYie1wuAqn3ag40ir/Vg8stfjyNk8Ht0Ajpp+rgODzuURDiGutiblVpXffh83R5UZb21pI7oL6eE3HaeH20Ob6c8ELvWskM24EzS7baSJbrzatFtDw8hi0W3eeYIPqoeKC2btUavNnDkkP5mKPYQv0dsy754Yg3956SJw=
+  bucket: librdkafka-ci-packages
+  region: us-west-1
+  local-dir: wheelhouse
+  upload-dir: confluent-kafka-python/p-confluent-kafka-python__bld-travis__plat-${TRAVIS_OS_NAME}__tag-${TRAVIS_TAG}__sha-${TRAVIS_COMMIT}__bid-${TRAVIS_BUILD_ID}__
+  acl: public_read
+  skip_cleanup: true
+  on:
+    repo: confluentinc/confluent-kafka-python
+    branch: manylinux_test

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ c.close()
 **AvroProducer**
 
 ```python
-from confluent_kafka import avro 
+from confluent_kafka import avro
 from confluent_kafka.avro import AvroProducer
 
 value_schema = avro.load('ValueSchema.avsc')
@@ -103,7 +103,7 @@ while running:
     except SerializerError as e:
         print("Message deserialization failed for %s: %s" % (msg, e))
         running = False
-        
+
 c.close()
 ```
 
@@ -120,12 +120,12 @@ by the broker, thus you will need to hint the Python client what protocol
 version it may use. This is done through two configuration settings:
 
  * `broker.version.fallback=YOUR_BROKER_VERSION` (default 0.9.0.1)
- * `api.version.request=true|false` (default false)
+ * `api.version.request=true|false` (default true)
 
-When using a Kafka 0.10 broker or later you only need to set
-`api.version.request=true`.
-If you use Kafka broker 0.9 or 0.8 you should leave
-`api.version.request=false` (default) and set
+When using a Kafka 0.10 broker or later you don't need to do anything
+(`api.version.request=true` is the default).
+If you use Kafka broker 0.9 or 0.8 you must set
+`api.version.request=false` and set
 `broker.version.fallback` to your broker version,
 e.g `broker.version.fallback=0.9.0.1`.
 
@@ -136,17 +136,19 @@ https://github.com/edenhill/librdkafka/wiki/Broker-version-compatibility
 Prerequisites
 =============
 
- * Python >= 2.7 or Python 3.x
- * [librdkafka](https://github.com/edenhill/librdkafka) >= 0.9.1
- 
- 
-For **Debian/Ubuntu**** based systems, add this APT repo and then do `sudo apt-get install librdkafka-dev python-dev`:
+ * Python >= 2.6 or Python 3.x
+ * [librdkafka](https://github.com/edenhill/librdkafka) >= 0.9.1 (embedded in Linux wheels)
+
+librdkafka is embedded in the manylinux wheels, for other platforms or
+when a specific version of librdkafka is desired, following these guidelines:
+
+  * For **Debian/Ubuntu**** based systems, add this APT repo and then do `sudo apt-get install librdkafka-dev python-dev`:
 http://docs.confluent.io/current/installation.html#installation-apt
 
-For **RedHat** and **RPM**-based distros, add this YUM repo and then do `sudo yum install librdkafka-devel python-devel`:
+ * For **RedHat** and **RPM**-based distros, add this YUM repo and then do `sudo yum install librdkafka-devel python-devel`:
 http://docs.confluent.io/current/installation.html#rpm-packages-via-yum
 
-On **OSX**, use **homebrew** and do `sudo brew install librdkafka`
+ * On **OSX**, use **homebrew** and do `sudo brew install librdkafka`
 
 
 Install
@@ -155,7 +157,7 @@ Install
 **Install from PyPi:**
 
     $ pip install confluent-kafka
-    
+
     # for AvroProducer or AvroConsumer
     $ pip install confluent-kafka[avro]
 

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ module = Extension('confluent_kafka.cimpl',
                             'confluent_kafka/src/Consumer.c'])
 
 setup(name='confluent-kafka',
-      version='0.11.0',
+      version='0.11.0.1rc1',
       description='Confluent\'s Apache Kafka client for Python',
       author='Confluent Inc',
       author_email='support@confluent.io',

--- a/tools/README.md
+++ b/tools/README.md
@@ -1,0 +1,13 @@
+# Tools
+
+
+## download-s3.py
+
+To download CI build artifacts from S3, set up your AWS credentials
+and run `tools/download-s3.py <tag|sha1>`, the artifacts will be downloaded
+into `dl-<tag|sha1>`.
+
+To upload packages to PyPi (test.pypi.org in this example to be safe), do:
+
+    $ twine upload -r test dl-<tag|sha1>/*
+

--- a/tools/bootstrap-librdkafka.sh
+++ b/tools/bootstrap-librdkafka.sh
@@ -29,6 +29,8 @@ test -f configure ||
 curl -sL "https://github.com/edenhill/librdkafka/archive/${VERSION}.tar.gz" | \
     tar -xz --strip-components=1 -f -
 
+./configure --clean
+make clean
 ./configure --prefix="$PREFIXDIR"
 make -j
 make install

--- a/tools/build-manylinux.sh
+++ b/tools/build-manylinux.sh
@@ -1,0 +1,108 @@
+#!/bin/bash
+#
+#
+# Builds autonomous Python packages including all dependencies
+# using the excellent manylinux docker images and the equally awesome
+# auditwheel tool.
+#
+# This script should be run in a docker image where the confluent-kafka-python
+# directory is mapped as /io .
+#
+# Usage on host:
+#  tools/build-manylinux.sh <librdkafka_tag>
+#
+# Usage in container:
+#  docker run -t -v $(pwd):/io quay.io/pypa/manylinux1_x86_64:latest  /io/tools/build-manylinux.sh <librdkafka_tag>
+
+# NOTE: Keep this updated to make sure we always build the latest
+#       version of OpenSSL in the 1.0 release train.
+OPENSSL_VERSION=1.0.2l
+
+LIBRDKAFKA_VERSION=$1
+
+if [[ -z "$LIBRDKAFKA_VERSION" ]]; then
+    echo "Usage: $0 <librdkafka_tag>"
+    exit 1
+fi
+
+set -ex
+
+if [[ ! -f /.dockerenv ]]; then
+    #
+    # Running on host, fire up a docker container a run it.
+    #
+
+    if [[ ! -f tools/$(basename $0) ]]; then
+        echo "Must be called from confluent-kafka-python root directory"
+        exit 1
+    fi
+
+    docker run -t -v $(pwd):/io quay.io/pypa/manylinux1_x86_64:latest  /io/tools/build-manylinux.sh "$LIBRDKAFKA_VERSION"
+
+    exit $?
+fi
+
+
+#
+# Running in container
+#
+
+function install_openssl {
+    rm -rf build-openssl
+    mkdir -p build-openssl
+    pushd build-openssl
+    curl -s -l https://www.openssl.org/source/openssl-${OPENSSL_VERSION}.tar.gz | \
+        tar -xz --strip-components=1 -f -
+    ./config --prefix=/usr/local zlib no-krb5 zlib shared
+    echo "## building openssl"
+    make 2>&1 | tail -50
+    echo "## testing openssl"
+    make test 2>&1 | tail -50
+    echo "## installing openssl"
+    make install 2>&1 | tail -50
+    popd
+}
+
+echo "# Installing basic system dependencies"
+yum install -y zlib-devel gcc-c++
+
+echo "# Building OpenSSL ${OPENSSL_VERSION}"
+install_openssl
+
+echo "# Building librdkafka ${LIBRDKAFKA_VERSION}"
+$(dirname $0)/bootstrap-librdkafka.sh ${LIBRDKAFKA_VERSION} /usr/local
+
+# Compile wheels
+echo "# Compile"
+for PYBIN in /opt/python/*/bin; do
+    echo "## Compiling $PYBIN"
+    CFLAGS="-Werror -Wno-strict-aliasing -Wno-parentheses" \
+          "${PYBIN}/pip" wheel /io/ -w unrepaired-wheelhouse/
+done
+
+# Bundle external shared libraries into the wheels
+echo "# auditwheel repair"
+mkdir -p /io/wheelhouse
+for whl in unrepaired-wheelhouse/*.whl; do
+    echo "## Repairing $whl"
+    auditwheel repair "$whl" -w /io/wheelhouse
+done
+
+echo "# Repaired wheels"
+for whl in /io/wheelhouse/*.whl; do
+    echo "## Repaired wheel $whl"
+    auditwheel show "$whl"
+done
+
+# Install packages and test
+echo "# Installing wheels"
+for PYBIN in /opt/python/*/bin/; do
+    echo "## Installing $PYBIN"
+    "${PYBIN}/pip" install confluent_kafka --no-index -f /io/wheelhouse
+    "${PYBIN}/python" -c 'import confluent_kafka; print(confluent_kafka.libversion())'
+    echo "## Uninstalling $PYBIN"
+    "${PYBIN}/pip" uninstall -y confluent_kafka
+done
+
+
+

--- a/tools/test-manylinux.sh
+++ b/tools/test-manylinux.sh
@@ -1,0 +1,85 @@
+#!/bin/bash
+#
+#
+# Tests the manylinux wheels on a plethora of bare-bone Linux docker images.
+
+set -ex
+
+
+function setup_centos {
+    # CentOS container setup
+    yum install -q -y python epel-release
+    yum install -q -y python-pip
+}
+
+function setup_ubuntu {
+    # Ubuntu container setup
+    apt-get update
+    apt-get install -y python python-pip
+}
+
+
+function run_single_in_docker {
+    # Run single test inside docker container
+
+    # Detect OS
+    if grep -qi centos /etc/system-release ; then
+        setup_centos
+    elif grep -qi ubuntu /etc/os-release ; then
+        setup_ubuntu
+    else
+        echo "WARNING: Don't know what platform I'm on: $(uname -a)"
+    fi
+
+    # Make sure pip itself is up to date
+    pip install -U pip
+    hash -r # let go of previous 'pip'
+
+    # Install modules
+    pip install confluent_kafka --no-index -f /io/wheelhouse
+    pip install pytest
+
+
+    pushd /io/tests
+    # Remove cached files from previous runs
+    rm -rf __pycache__ *.pyc
+    # Test
+    pytest --import-mode=append --ignore=avro
+    popd
+
+}
+
+function run_all_with_docker {
+    # Run tests in all listed docker containers.
+    # This is executed on the host.
+
+    [[ ! -z $DOCKER_IMAGES ]] || \
+        DOCKER_IMAGES="ubuntu:14.04 ubuntu:devel centos:6.6 centos:latest"
+
+
+    _wheels="wheelhouse/*manylinux*.whl"
+    if [[ -z $_wheels ]]; then
+        echo "No wheels in wheelhouse/, must run build-manylinux.sh first"
+        exit 1
+    fi
+
+    for DOCKER_IMAGE in $DOCKER_IMAGES; do
+        echo "# Testing on $DOCKER_IMAGE"
+        docker run -v $(pwd):/io $DOCKER_IMAGE /io/tools/test-manylinux.sh || \
+            (echo "Failed on $DOCKER_IMAGE" ; false)
+
+    done
+}
+
+
+
+if [[ -f /.dockerenv && -d /io ]]; then
+    # Called from within a docker container
+    run_single_in_docker
+
+else
+    # Run from host, trigger runs for all docker images.
+    run_all_with_docker
+fi
+
+


### PR DESCRIPTION
There's a bunch of stuff going on and not going on here:
 * Uses [cibuildwheel](https://github.com/joerick/cibuildwheel) to build manylinux and osx wheels on Travis
 * The wheels are uploaded from Travis to S3.
 * Disabled support for the same on AppVeyor due to messed up Python/C toolchain, will be tended to in the future.
 * Some scripts to build and test manylinux locally using docker, these can be used for later use in packaging.
 * The .travis.yml file is rewritten to only cater to wheel building, before the merge it will be adjusted to do what it does on master (mainly code verification across Python versions) and the new wheel building stuff when a tag is available.
 * There's a script in tools/download-s3.py that fetches the wheels from S3 by tag or git sha. This is used to collect the wheels to publish to PyPi.
 * Some corresponding README changes.

Proof-of-concept packages are published to test.pypiy.org as confluent-kafka version 0.11.0.1rc1. Please try them out using the following little snippet:
```
virtualenv /tmp/pyenv      # Create a throw-away virtualenv
source /tmp/pyenv/bin/activate
pip install -i https://test.pypi.org/simple confluent-kafka==0.11.0.1rc1
python -c 'from confluent_kafka import libversion; assert libversion() == ("0.11.0", 0xb00ff), libversion()'
deactivate
 ```
