### PR TITLE
AvroProducer: fetch schema to cache by id during produce

### DIFF
--- a/confluent_kafka/avro/__init__.py
+++ b/confluent_kafka/avro/__init__.py
@@ -27,9 +27,9 @@ class AvroProducer(Producer):
 
     def __init__(self, config, default_key_schema=None,
                  default_value_schema=None,
-                 default_value_schema_id=None,
+                 schema_registry=None,
                  default_key_schema_id=None,
-                 schema_registry=None):
+                 default_value_schema_id=None):
         schema_registry_url = config.pop("schema.registry.url", None)
         if schema_registry is None:
             if schema_registry_url is None:

--- a/confluent_kafka/avro/__init__.py
+++ b/confluent_kafka/avro/__init__.py
@@ -26,7 +26,10 @@ class AvroProducer(Producer):
     """
 
     def __init__(self, config, default_key_schema=None,
-                 default_value_schema=None, schema_registry=None):
+                 default_value_schema=None,
+                 default_value_schema_id=None,
+                 default_key_schema_id=None,
+                 schema_registry=None):
         schema_registry_url = config.pop("schema.registry.url", None)
         if schema_registry is None:
             if schema_registry_url is None:
@@ -39,6 +42,8 @@ class AvroProducer(Producer):
         self._serializer = MessageSerializer(schema_registry)
         self._key_schema = default_key_schema
         self._value_schema = default_value_schema
+        self._key_schema_id = default_key_schema_id
+        self._value_schema_id = default_value_schema_id
 
     def produce(self, **kwargs):
         """
@@ -53,6 +58,8 @@ class AvroProducer(Producer):
         # get schemas from  kwargs if defined
         key_schema = kwargs.pop('key_schema', self._key_schema)
         value_schema = kwargs.pop('value_schema', self._value_schema)
+        key_schema_id = kwargs.pop('key_schema_id', self._key_schema_id)
+        value_schema_id = kwargs.pop('value_schema_id', self._value_schema_id)
         topic = kwargs.pop('topic', None)
         if not topic:
             raise ClientError("Topic name not specified.")
@@ -62,12 +69,16 @@ class AvroProducer(Producer):
         if value:
             if value_schema:
                 value = self._serializer.encode_record_with_schema(topic, value_schema, value)
+            elif value_schema_id:
+                value = self._serializer.encode_record_with_schema_id(value_schema_id, value)
             else:
                 raise ValueSerializerError("Avro schema required for values")
 
         if key:
             if key_schema:
                 key = self._serializer.encode_record_with_schema(topic, key_schema, key, True)
+            elif key_schema_id:
+                key = self._serializer.encode_record_with_schema_id(key_schema_id, key, True)
             else:
                 raise KeySerializerError("Avro schema required for key")
 

--- a/tests/avro/test_avro_producer.py
+++ b/tests/avro/test_avro_producer.py
@@ -101,3 +101,16 @@ class TestAvroProducer(unittest.TestCase):
         schema_registry = MockSchemaRegistryClient()
         with self.assertRaises(ValueError):
             AvroProducer({'schema.registry.url': 'http://127.0.0.1:9001'}, schema_registry=schema_registry)
+
+    def test_produce_fetch_schema_by_id(self):
+        schema_registry = MockSchemaRegistryClient()
+        value_schema = avro.load(os.path.join(avsc_dir, "basic_schema.avsc"))
+        key_schema = avro.load(os.path.join(avsc_dir, "primitive_string.avsc"))
+        topic = 'test'
+        # register schemas outside of AvroProducer
+        value_schema_id = schema_registry.register(topic+'-value', value_schema)
+        key_schema_id = schema_registry.register(topic+'-key', key_schema)
+        producer = AvroProducer({}, schema_registry=schema_registry)
+        # fetch schemas based on ids during produce
+        producer.produce(topic=topic, value={"name": 'abc"'}, key='mykey', value_schema_id=value_schema_id,
+                         key_schema_id=key_schema_id)


### PR DESCRIPTION
This pull request allows an `AvroProducer` to fetch a schema from the schema registry by schema id, if missing from the local registry cache.
For issue #248