### PR TITLE
Use schemaless reader to handle complex schema

### DIFF
--- a/confluent_kafka/avro/serializer/message_serializer.py
+++ b/confluent_kafka/avro/serializer/message_serializer.py
@@ -39,7 +39,7 @@ MAGIC_BYTE = 0
 
 HAS_FAST = False
 try:
-    from fastavro.reader import read_data
+    from fastavro.reader import schemaless_reader
 
     HAS_FAST = True
 except:
@@ -170,7 +170,7 @@ class MessageSerializer(object):
             # try to use fast avro
             try:
                 schema_dict = schema.to_json()
-                read_data(payload, schema_dict)
+                schemaless_reader(payload, schema_dict)
 
                 # If we reach this point, this means we have fastavro and it can
                 # do this deserialization. Rewind since this method just determines
@@ -178,7 +178,7 @@ class MessageSerializer(object):
                 # normal path.
                 payload.seek(curr_pos)
 
-                self.id_to_decoder_func[schema_id] = lambda p: read_data(p, schema_dict)
+                self.id_to_decoder_func[schema_id] = lambda p: schemaless_reader(p, schema_dict)
                 return self.id_to_decoder_func[schema_id]
             except:
                 pass

--- a/confluent_kafka/avro/serializer/message_serializer.py
+++ b/confluent_kafka/avro/serializer/message_serializer.py
@@ -39,7 +39,7 @@ MAGIC_BYTE = 0
 
 HAS_FAST = False
 try:
-    from fastavro.reader import schemaless_reader
+    from fastavro import schemaless_reader
 
     HAS_FAST = True
 except:


### PR DESCRIPTION
I bumped into an issue lately trying to decode payloads coming from Debezium (MySQL binlogs). Fastavro wasn't used because of a `KeyError` exception in the library.

I discussed the issue [here](https://github.com/tebeka/fastavro/issues/101) and found out `read_data()` wasn't able to decode avro messages with named types in their schema.

Here I replaced it with `schemaless_reader()` which acquire the schema tp be able to decode it:
https://github.com/tebeka/fastavro/blob/master/fastavro/reader.py#L596-L607