### PR TITLE
Makes calling consumer.close() multiple times safe

### DIFF
--- a/confluent_kafka/src/Consumer.c
+++ b/confluent_kafka/src/Consumer.c
@@ -550,17 +550,24 @@ static PyObject *Consumer_poll (Handle *self, PyObject *args,
 
 
 static PyObject *Consumer_close (Handle *self, PyObject *ignore) {
-	CallState cs;
 
-	CallState_begin(self, &cs);
+	if (!self->rk) {
+            PyErr_SetString(PyExc_RuntimeError,
+                            "Consumer already closed");
+            return NULL;
+    }
 
-	rd_kafka_consumer_close(self->rk);
+    CallState cs;
 
-	rd_kafka_destroy(self->rk);
-	self->rk = NULL;
+    CallState_begin(self, &cs);
 
-        if (!CallState_end(self, &cs))
-                return NULL;
+    rd_kafka_consumer_close(self->rk);
+
+    rd_kafka_destroy(self->rk);
+    self->rk = NULL;
+
+    if (!CallState_end(self, &cs))
+            return NULL;
 
 	Py_RETURN_NONE;
 }

--- a/confluent_kafka/src/Consumer.c
+++ b/confluent_kafka/src/Consumer.c
@@ -743,6 +743,7 @@ static PyMethodDef Consumer_methods[] = {
 	  "see :py:func::`poll()` for more info.\n"
 	  "\n"
 	  "  :rtype: None\n"
+      "  :raises: RuntimeError if called on a closed consumer\n"
 	  "\n"
 	},
 	{ NULL }

--- a/confluent_kafka/src/Consumer.c
+++ b/confluent_kafka/src/Consumer.c
@@ -550,26 +550,25 @@ static PyObject *Consumer_poll (Handle *self, PyObject *args,
 
 
 static PyObject *Consumer_close (Handle *self, PyObject *ignore) {
+        CallState cs;
 
-	if (!self->rk) {
-            PyErr_SetString(PyExc_RuntimeError,
-                            "Consumer already closed");
-            return NULL;
-    }
+        if (!self->rk) {
+                PyErr_SetString(PyExc_RuntimeError,
+                                "Consumer already closed");
+                return NULL;
+        }
 
-    CallState cs;
+        CallState_begin(self, &cs);
 
-    CallState_begin(self, &cs);
+        rd_kafka_consumer_close(self->rk);
 
-    rd_kafka_consumer_close(self->rk);
+        rd_kafka_destroy(self->rk);
+        self->rk = NULL;
 
-    rd_kafka_destroy(self->rk);
-    self->rk = NULL;
+        if (!CallState_end(self, &cs))
+                return NULL;
 
-    if (!CallState_end(self, &cs))
-            return NULL;
-
-	Py_RETURN_NONE;
+        Py_RETURN_NONE;
 }
 
 

--- a/tests/test_Consumer.py
+++ b/tests/test_Consumer.py
@@ -158,3 +158,22 @@ def test_subclassing():
     sc = SubConsumer({"group.id": "test", "session.timeout.ms": "90"})
     sc.poll("astring")
     sc.close()
+
+
+def test_multiple_close_throw_exception():
+    """ Calling Consumer.close() multiple times should throw Runtime Exception
+    """
+    c = Consumer({'group.id': 'test',
+                  'enable.auto.commit': True,
+                  'enable.auto.offset.store': False,
+                  'socket.timeout.ms': 50,
+                  'session.timeout.ms': 100})
+
+    c.subscribe(["test"])
+
+    c.unsubscribe()
+    c.close()
+
+    with pytest.raises(RuntimeError) as ex:
+        c.close()
+        assert 'Consumer already closed' == str(ex.value)


### PR DESCRIPTION
Currently if you call `consumer.close()` more then once you get a segfault.

This PR just makes calling `close` a second time a noop. 