### PR TITLE
Enable produce.offset.report by default (#266)

### DIFF
--- a/confluent_kafka/src/confluent_kafka.c
+++ b/confluent_kafka/src/confluent_kafka.c
@@ -1231,6 +1231,13 @@ rd_kafka_conf_t *common_conf_setup (rd_kafka_type_t ktype,
 	conf = rd_kafka_conf_new();
 	tconf = rd_kafka_topic_conf_new();
 
+        /*
+         * Default config (overridable by user)
+         */
+
+        /* Enable valid offsets in delivery reports */
+        rd_kafka_topic_conf_set(tconf, "produce.offset.report", "true", NULL, 0);
+
 	/* Convert kwargs dict to config key-value pairs. */
 	while (PyDict_Next(kwargs, &pos, &ko, &vo)) {
 		PyObject *ks, *ks8;

--- a/examples/producer.py
+++ b/examples/producer.py
@@ -45,8 +45,8 @@ if __name__ == '__main__':
         if err:
             sys.stderr.write('%% Message failed delivery: %s\n' % err)
         else:
-            sys.stderr.write('%% Message delivered to %s [%d]\n' %
-                             (msg.topic(), msg.partition()))
+            sys.stderr.write('%% Message delivered to %s [%d] @ %o\n' %
+                             (msg.topic(), msg.partition(), msg.offset()))
 
     # Read lines from stdin, produce each line to Kafka
     for line in sys.stdin:


### PR DESCRIPTION
Without this enabled:
```
% Message delivered to test [0] @ 0
% Message delivered to test [0] @ 0
% Message delivered to test [0] @ 0
% Message delivered to test [0] @ 0
% Message delivered to test [0] @ 0
% Message delivered to test [0] @ 0
% Message delivered to test [0] @ 0
% Message delivered to test [0] @ 0
% Message delivered to test [0] @ 0
% Message delivered to test [0] @ 0
% Message delivered to test [0] @ 0
% Message delivered to test [0] @ 0
% Message delivered to test [0] @ 113
```

With this enabled:
```
% Message delivered to test [0] @ 157
% Message delivered to test [0] @ 160
% Message delivered to test [0] @ 161
% Message delivered to test [0] @ 162
% Message delivered to test [0] @ 163
% Message delivered to test [0] @ 164
% Message delivered to test [0] @ 165
% Message delivered to test [0] @ 166
% Message delivered to test [0] @ 167
% Message delivered to test [0] @ 170
% Message delivered to test [0] @ 171
% Message delivered to test [0] @ 172
% Message delivered to test [0] @ 173
% Message delivered to test [0] @ 174
% Message delivered to test [0] @ 175
% Message delivered to test [0] @ 176
% Message delivered to test [0] @ 177
% Message delivered to test [0] @ 200
```