### PR TITLE
message header support

### DIFF
--- a/confluent_kafka/src/Consumer.c
+++ b/confluent_kafka/src/Consumer.c
@@ -885,6 +885,9 @@ static PyObject *Consumer_poll (Handle *self, PyObject *args,
                 Py_RETURN_NONE;
 
         msgobj = Message_new0(self, rkm);
+        // Have to deatch headers outside Message_new0 because it declares the
+        // rk message as a const
+        rd_kafka_message_detach_headers(rkm, &((Message *)msgobj)->c_headers);
         rd_kafka_message_destroy(rkm);
 
         return msgobj;
@@ -946,6 +949,9 @@ static PyObject *Consumer_consume (Handle *self, PyObject *args,
 
         for (i = 0; i < n; i++) {
                 PyObject *msgobj = Message_new0(self, rkmessages[i]);
+                // Have to deatch headers outside Message_new0 because it declares the
+                // rk message as a const
+                rd_kafka_message_detach_headers(rkm, &((Message *)msgobj)->c_headers);
                 PyList_SET_ITEM(msglist, i, msgobj);
                 rd_kafka_message_destroy(rkmessages[i]);
         }

--- a/confluent_kafka/src/Consumer.c
+++ b/confluent_kafka/src/Consumer.c
@@ -951,7 +951,7 @@ static PyObject *Consumer_consume (Handle *self, PyObject *args,
                 PyObject *msgobj = Message_new0(self, rkmessages[i]);
                 // Have to deatch headers outside Message_new0 because it declares the
                 // rk message as a const
-                rd_kafka_message_detach_headers(rkm, &((Message *)msgobj)->c_headers);
+                rd_kafka_message_detach_headers(rkmessages[i], &((Message *)msgobj)->c_headers);
                 PyList_SET_ITEM(msglist, i, msgobj);
                 rd_kafka_message_destroy(rkmessages[i]);
         }

--- a/confluent_kafka/src/Consumer.c
+++ b/confluent_kafka/src/Consumer.c
@@ -885,9 +885,11 @@ static PyObject *Consumer_poll (Handle *self, PyObject *args,
                 Py_RETURN_NONE;
 
         msgobj = Message_new0(self, rkm);
+#ifdef RD_KAFKA_V_HEADERS
         // Have to deatch headers outside Message_new0 because it declares the
         // rk message as a const
         rd_kafka_message_detach_headers(rkm, &((Message *)msgobj)->c_headers);
+#endif
         rd_kafka_message_destroy(rkm);
 
         return msgobj;
@@ -949,9 +951,11 @@ static PyObject *Consumer_consume (Handle *self, PyObject *args,
 
         for (i = 0; i < n; i++) {
                 PyObject *msgobj = Message_new0(self, rkmessages[i]);
+#ifdef RD_KAFKA_V_HEADERS
                 // Have to deatch headers outside Message_new0 because it declares the
                 // rk message as a const
                 rd_kafka_message_detach_headers(rkmessages[i], &((Message *)msgobj)->c_headers);
+#endif
                 PyList_SET_ITEM(msglist, i, msgobj);
                 rd_kafka_message_destroy(rkmessages[i]);
         }

--- a/confluent_kafka/src/Producer.c
+++ b/confluent_kafka/src/Producer.c
@@ -308,7 +308,10 @@ static PyObject *Producer_produce (Handle *self, PyObject *args,
         long long timestamp = 0;
         rd_kafka_resp_err_t err;
 	struct Producer_msgstate *msgstate;
+#ifdef RD_KAFKA_V_HEADERS
     rd_kafka_headers_t *rd_headers = NULL;
+#endif
+
 	static char *kws[] = { "topic",
 			       "value",
 			       "key",
@@ -361,10 +364,12 @@ static PyObject *Producer_produce (Handle *self, PyObject *args,
 	if (!partitioner_cb || partitioner_cb == Py_None)
 		partitioner_cb = self->u.Producer.partitioner_cb;
 
+#ifdef RD_KAFKA_V_HEADERS
     if (headers) {
         if(!(rd_headers = py_headers_to_c(headers)))
             return NULL;
     }
+#endif
 
 	/* Create msgstate if necessary, may return NULL if no callbacks
 	 * are wanted. */

--- a/confluent_kafka/src/Producer.c
+++ b/confluent_kafka/src/Producer.c
@@ -133,7 +133,7 @@ static int Producer_traverse (Handle *self,
 }
 
 
-static void dr_msg_cb (rd_kafka_t *rk, const rd_kafka_message_t *rkm,
+static void dr_msg_cb (rd_kafka_t *rk, rd_kafka_message_t *rkm,
 			   void *opaque) {
 	struct Producer_msgstate *msgstate = rkm->_private;
 	Handle *self = opaque;

--- a/confluent_kafka/src/Producer.c
+++ b/confluent_kafka/src/Producer.c
@@ -362,22 +362,22 @@ static PyObject *Producer_produce (Handle *self, PyObject *args,
             len = PyList_Size(headers);
             rd_headers = rd_kafka_headers_new(len);
             for (i = 0; i < len; i++) {
-                //item = PySequence_Fast_GET_ITEM(seq, i);
                 const char *header_key, *header_value = NULL;
                 int header_key_len = 0, header_value_len = 0;
 
                 PyArg_ParseTuple(PyList_GET_ITEM(headers, i), "s#z#", &header_key,
                         &header_key_len, &header_value, &header_value_len);
-                printf("GOT HEADER KEY %s with len: %i \n", header_key, header_key_len);
 
                 err = rd_kafka_header_add(rd_headers, header_key, header_key_len, header_value, header_value_len);
                 if (err) {
-                    printf("GOT AND ERROR\n");
+                    cfl_PyErr_Format(err,
+                             "Unable to produce message: %s",
+                             rd_kafka_err2str(err));
+                    return NULL;
                 }
-                printf("ON %i header\n", i);
             }
-
         }
+
         err = Producer_producev(self, topic, partition,
                                 value, value_len,
                                 key, key_len,

--- a/confluent_kafka/src/Producer.c
+++ b/confluent_kafka/src/Producer.c
@@ -133,7 +133,7 @@ static int Producer_traverse (Handle *self,
 }
 
 
-static void dr_msg_cb (rd_kafka_t *rk, rd_kafka_message_t *rkm,
+static void dr_msg_cb (rd_kafka_t *rk, const rd_kafka_message_t *rkm,
 			   void *opaque) {
 	struct Producer_msgstate *msgstate = rkm->_private;
 	Handle *self = opaque;
@@ -480,6 +480,10 @@ static PyMethodDef Producer_methods[] = {
 	  "``callback`` (alias ``on_delivery``) argument to pass a function "
 	  "(or lambda) that will be called from :py:func:`poll()` when the "
 	  "message has been successfully delivered or permanently fails delivery.\n"
+      "\n"
+      "  Currently message headers are not supported on the message returned to the "
+      "callback. The ``msg.headers()`` will return None even if the original message "
+      "had headers set.\n"
 	  "\n"
 	  "  :param str topic: Topic to produce message to\n"
 	  "  :param str|bytes value: Message payload\n"

--- a/confluent_kafka/src/Producer.c
+++ b/confluent_kafka/src/Producer.c
@@ -334,7 +334,7 @@ static PyObject *Producer_produce (Handle *self, PyObject *args,
             PyErr_Format(PyExc_NotImplementedError,
                          "Producer message headers requires "
                          "confluent-kafka-python built for librdkafka "
-                         "version >=v0.11.3 (librdkafka runtime 0x%x, "
+                         "version >=v0.11.4 (librdkafka runtime 0x%x, "
                          "buildtime 0x%x)",
                          rd_kafka_version(), RD_KAFKA_VERSION);
             return NULL;
@@ -361,17 +361,17 @@ static PyObject *Producer_produce (Handle *self, PyObject *args,
 	if (!partitioner_cb || partitioner_cb == Py_None)
 		partitioner_cb = self->u.Producer.partitioner_cb;
 
+    if (headers) {
+        if(!(rd_headers = py_headers_to_c(headers)))
+            return NULL;
+    }
+
 	/* Create msgstate if necessary, may return NULL if no callbacks
 	 * are wanted. */
 	msgstate = Producer_msgstate_new(self, dr_cb, partitioner_cb);
 
         /* Produce message */
 #if HAVE_PRODUCEV
-        if (headers) {
-            if(!(rd_headers = py_headers_to_c(headers)))
-                return NULL;
-        }
-
         err = Producer_producev(self, topic, partition,
                                 value, value_len,
                                 key, key_len,

--- a/confluent_kafka/src/confluent_kafka.c
+++ b/confluent_kafka/src/confluent_kafka.c
@@ -581,9 +581,8 @@ PyTypeObject MessageType = {
 /**
  * @brief Internal factory to create Message object from message_t
  */
-PyObject *Message_new0 (const Handle *handle, const rd_kafka_message_t *rkm) {
+PyObject *Message_new0 (const Handle *handle, rd_kafka_message_t *rkm) {
 	Message *self;
-    rd_kafka_headers_t *hdrs;
 
 	self = (Message *)MessageType.tp_alloc(&MessageType, 0);
 	if (!self)
@@ -611,9 +610,7 @@ PyObject *Message_new0 (const Handle *handle, const rd_kafka_message_t *rkm) {
 
 	self->timestamp = rd_kafka_message_timestamp(rkm, &self->tstype);
 
-    if (!rd_kafka_message_headers(rkm, &hdrs)) {
-        self->c_headers = rd_kafka_headers_copy(hdrs);
-    }
+    rd_kafka_message_detach_headers(rkm, &self->c_headers);
 
 	return (PyObject *)self;
 }

--- a/confluent_kafka/src/confluent_kafka.c
+++ b/confluent_kafka/src/confluent_kafka.c
@@ -334,6 +334,7 @@ static PyObject *Message_timestamp (Message *self, PyObject *ignore) {
 }
 
 static PyObject *Message_headers (Message *self, PyObject *ignore) {
+#ifdef RD_KAFKA_V_HEADERS
 	if (self->headers) {
         Py_INCREF(self->headers);
 		return self->headers;
@@ -346,6 +347,9 @@ static PyObject *Message_headers (Message *self, PyObject *ignore) {
 	} else {
 		Py_RETURN_NONE;
     }
+#else
+		Py_RETURN_NONE;
+#endif
 }
 
 static PyObject *Message_set_headers (Message *self, PyObject *new_headers) {
@@ -486,10 +490,12 @@ static int Message_clear (Message *self) {
 		Py_DECREF(self->headers);
 		self->headers = NULL;
 	}
+#ifdef RD_KAFKA_V_HEADERS
     if (self->c_headers){
         rd_kafka_headers_destroy(self->c_headers);
         self->c_headers = NULL;
     }
+#endif
 	return 0;
 }
 
@@ -932,6 +938,7 @@ rd_kafka_topic_partition_list_t *py_to_c_parts (PyObject *plist) {
 	return c_parts;
 }
 
+#ifdef RD_KAFKA_V_HEADERS
 /**
  * @brief Convert Python list[(header_key, header_value),...]) to C rd_kafka_topic_partition_list_t.
  *
@@ -1005,6 +1012,7 @@ PyObject *c_headers_to_py (rd_kafka_headers_t *headers) {
 
     return header_list;
 }
+#endif
 
 /****************************************************************************
  *

--- a/confluent_kafka/src/confluent_kafka.c
+++ b/confluent_kafka/src/confluent_kafka.c
@@ -581,7 +581,7 @@ PyTypeObject MessageType = {
 /**
  * @brief Internal factory to create Message object from message_t
  */
-PyObject *Message_new0 (const Handle *handle, rd_kafka_message_t *rkm) {
+PyObject *Message_new0 (const Handle *handle, const rd_kafka_message_t *rkm) {
 	Message *self;
 
 	self = (Message *)MessageType.tp_alloc(&MessageType, 0);
@@ -609,8 +609,6 @@ PyObject *Message_new0 (const Handle *handle, rd_kafka_message_t *rkm) {
 	self->offset = rkm->offset;
 
 	self->timestamp = rd_kafka_message_timestamp(rkm, &self->tstype);
-
-    rd_kafka_message_detach_headers(rkm, &self->c_headers);
 
 	return (PyObject *)self;
 }

--- a/confluent_kafka/src/confluent_kafka.c
+++ b/confluent_kafka/src/confluent_kafka.c
@@ -418,7 +418,11 @@ static PyMethodDef Message_methods[] = {
 	  "\n"
 	},
 	{ "headers", (PyCFunction)Message_headers, METH_NOARGS,
-//TODO
+      "  Retrieve the headers set on a message. Each header is a key value"
+      "pair. Please note that header keys are ordered and can repeat.\n"
+      "\n"
+	  "  :returns: list of two-tuples, one (key, value) pair for each header.\n"
+	  "  :rtype: [(str, bytes),...] or None.\n"
 	  "\n"
 	},
 	{ "set_value", (PyCFunction)Message_set_value, METH_O,

--- a/confluent_kafka/src/confluent_kafka.c
+++ b/confluent_kafka/src/confluent_kafka.c
@@ -590,13 +590,10 @@ PyObject *Message_new0 (const Handle *handle, const rd_kafka_message_t *rkm) {
         size_t header_value_size;
         PyObject *header_list;
 
-        //HACK to figure out size of headers
-        while (!rd_kafka_header_iter_all(hdrs, header_size++,
-                                         &header_key, &header_value, &header_value_size)) {
-        }
-        header_list = PyList_New(header_size - 1);
+        header_size = rd_kafka_header_cnt(hdrs); 
+        header_list = PyList_New(header_size);
 
-        while (!rd_kafka_header_iter_all(hdrs, idx++,
+        while (!rd_kafka_header_get_all(hdrs, idx++,
                                          &header_key, &header_value, &header_value_size)) {
                 // Create one (key, value) tuple for each header
                 PyObject *header_tuple = PyTuple_New(2);

--- a/confluent_kafka/src/confluent_kafka.h
+++ b/confluent_kafka/src/confluent_kafka.h
@@ -298,7 +298,7 @@ typedef struct {
 
 extern PyTypeObject MessageType;
 
-PyObject *Message_new0 (const Handle *handle, const rd_kafka_message_t *rkm);
+PyObject *Message_new0 (const Handle *handle, rd_kafka_message_t *rkm);
 PyObject *Message_error (Message *self, PyObject *ignore);
 
 

--- a/confluent_kafka/src/confluent_kafka.h
+++ b/confluent_kafka/src/confluent_kafka.h
@@ -286,6 +286,7 @@ typedef struct {
 	PyObject *topic;
 	PyObject *value;
 	PyObject *key;
+	PyObject *headers;
 	PyObject *error;
 	int32_t partition;
 	int64_t offset;

--- a/confluent_kafka/src/confluent_kafka.h
+++ b/confluent_kafka/src/confluent_kafka.h
@@ -288,6 +288,7 @@ typedef struct {
 	PyObject *value;
 	PyObject *key;
 	PyObject *headers;
+	rd_kafka_headers_t *c_headers;
 	PyObject *error;
 	int32_t partition;
 	int64_t offset;

--- a/confluent_kafka/src/confluent_kafka.h
+++ b/confluent_kafka/src/confluent_kafka.h
@@ -266,9 +266,11 @@ rd_kafka_conf_t *common_conf_setup (rd_kafka_type_t ktype,
 				    PyObject *kwargs);
 PyObject *c_parts_to_py (const rd_kafka_topic_partition_list_t *c_parts);
 rd_kafka_topic_partition_list_t *py_to_c_parts (PyObject *plist);
+
+#ifdef RD_KAFKA_V_HEADERS
 rd_kafka_headers_t *py_headers_to_c (PyObject *headers_plist);
 PyObject *c_headers_to_py (rd_kafka_headers_t *headers);
-
+#endif
 /****************************************************************************
  *
  *
@@ -288,7 +290,9 @@ typedef struct {
 	PyObject *value;
 	PyObject *key;
 	PyObject *headers;
+#ifdef RD_KAFKA_V_HEADERS
 	rd_kafka_headers_t *c_headers;
+#endif
 	PyObject *error;
 	int32_t partition;
 	int64_t offset;

--- a/confluent_kafka/src/confluent_kafka.h
+++ b/confluent_kafka/src/confluent_kafka.h
@@ -298,7 +298,7 @@ typedef struct {
 
 extern PyTypeObject MessageType;
 
-PyObject *Message_new0 (const Handle *handle, rd_kafka_message_t *rkm);
+PyObject *Message_new0 (const Handle *handle, const rd_kafka_message_t *rkm);
 PyObject *Message_error (Message *self, PyObject *ignore);
 
 

--- a/confluent_kafka/src/confluent_kafka.h
+++ b/confluent_kafka/src/confluent_kafka.h
@@ -266,7 +266,8 @@ rd_kafka_conf_t *common_conf_setup (rd_kafka_type_t ktype,
 				    PyObject *kwargs);
 PyObject *c_parts_to_py (const rd_kafka_topic_partition_list_t *c_parts);
 rd_kafka_topic_partition_list_t *py_to_c_parts (PyObject *plist);
-
+rd_kafka_headers_t *py_headers_to_c (PyObject *headers_plist);
+PyObject *c_headers_to_py (rd_kafka_headers_t *headers);
 
 /****************************************************************************
  *

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -101,6 +101,9 @@ The Python bindings also provide some additional configuration properties:
   delivery result (success or failure).
   This property may also be set per-message by passing ``callback=callable``
   (or ``on_delivery=callable``) to the confluent_kafka.Producer.produce() function.
+  Currently message headers are not supported on the message returned to the
+  callback. The ``msg.headers()`` will return None even if the original message
+  had headers set.
 
 * ``on_commit(kafka.KafkaError, list(kafka.TopicPartition))`` (**Consumer**): Callback used to indicate success or failure
   of commit requests.

--- a/examples/integration_test.py
+++ b/examples/integration_test.py
@@ -41,7 +41,7 @@ bootstrap_servers = None
 schema_registry_url = None
 
 # Topic to use
-topic = 'test'
+topic = str(uuid.uuid4())
 
 # API version requests are only implemented in Kafka broker >=0.10
 # but the client handles failed API version requests gracefully for older
@@ -117,8 +117,10 @@ def verify_producer():
     p = confluent_kafka.Producer(**conf)
     print('producer at %s' % p)
 
+    headers = [('foo1', 'bar'), ('population_producer_id', b'1')]
+
     # Produce some messages
-    p.produce(topic, 'Hello Python!')
+    p.produce(topic, 'Hello Python!', headers=headers)
     p.produce(topic, key='Just a key')
     p.produce(topic, partition=1, value='Strictly for partition 1',
               key='mykey')
@@ -477,6 +479,7 @@ def verify_consumer():
             else:
                 print('Consumer error: %s: ignoring' % msg.error())
                 break
+        import ipdb; ipdb.set_trace()
 
         tstype, timestamp = msg.timestamp()
         print('%s[%d]@%d: key=%s, value=%s, tstype=%d, timestamp=%s' %
@@ -885,10 +888,10 @@ if __name__ == '__main__':
 
     if len(sys.argv) > 1:
         bootstrap_servers = sys.argv[1]
-        if len(sys.argv) > 2:
-            topic = sys.argv[2]
-        if len(sys.argv) > 3:
-            schema_registry_url = sys.argv[3]
+        # if len(sys.argv) > 2:
+            # topic = sys.argv[2]
+        # if len(sys.argv) > 3:
+            # schema_registry_url = sys.argv[3]
     else:
         print_usage(1)
 

--- a/examples/integration_test.py
+++ b/examples/integration_test.py
@@ -121,9 +121,9 @@ def verify_producer():
 
     # Produce some messages
     p.produce(topic, 'Hello Python!', headers=headers)
-    p.produce(topic, key='Just a key')
+    p.produce(topic, key='Just a key', headers=headers)
     p.produce(topic, partition=1, value='Strictly for partition 1',
-              key='mykey')
+              key='mykey', headers=headers)
 
     # Produce more messages, now with delivery report callbacks in various forms.
     mydr = MyTestDr()
@@ -479,12 +479,13 @@ def verify_consumer():
             else:
                 print('Consumer error: %s: ignoring' % msg.error())
                 break
-        import ipdb; ipdb.set_trace()
 
         tstype, timestamp = msg.timestamp()
-        print('%s[%d]@%d: key=%s, value=%s, tstype=%d, timestamp=%s' %
+        headers = msg.headers()
+
+        print('%s[%d]@%d: key=%s, value=%s, tstype=%d, timestamp=%s headers=%s' %
               (msg.topic(), msg.partition(), msg.offset(),
-               msg.key(), msg.value(), tstype, timestamp))
+               msg.key(), msg.value(), tstype, timestamp, headers))
 
         if first_msg is None:
             first_msg = msg

--- a/examples/integration_test.py
+++ b/examples/integration_test.py
@@ -117,7 +117,7 @@ def verify_producer():
     p = confluent_kafka.Producer(**conf)
     print('producer at %s' % p)
 
-    headers = [('foo1', 'bar'), ('foo2', b'1')]
+    headers = [('foo1', 'bar'), ('foo1', 'bar2'), ('foo2', b'1')]
 
     # Produce some messages
     p.produce(topic, 'Hello Python!', headers=headers)
@@ -486,6 +486,9 @@ def verify_consumer():
         if headers:
             example_header = headers
 
+        msg.set_headers([('foo', 'bar')])
+        assert msg.headers() == [('foo', 'bar')]
+
         print('%s[%d]@%d: key=%s, value=%s, tstype=%d, timestamp=%s headers=%s' %
               (msg.topic(), msg.partition(), msg.offset(),
                msg.key(), msg.value(), tstype, timestamp, headers))
@@ -519,7 +522,7 @@ def verify_consumer():
             break
 
     assert example_header, "We should have received at least one header"
-    assert example_header == [(u'foo1', 'bar'), (u'foo2', '1')]
+    assert example_header == [(u'foo1', 'bar'), (u'foo1', 'bar2'), (u'foo2', '1')]
 
     # Get current assignment
     assignment = c.assignment()

--- a/examples/integration_test.py
+++ b/examples/integration_test.py
@@ -117,11 +117,12 @@ def verify_producer():
     p = confluent_kafka.Producer(**conf)
     print('producer at %s' % p)
 
-    headers = [('foo1', 'bar'), ('population_producer_id', b'1')]
+    headers = [('foo1', 'bar'), ('foo2', b'1')]
 
     # Produce some messages
     p.produce(topic, 'Hello Python!', headers=headers)
-    p.produce(topic, key='Just a key', headers=headers)
+    p.produce(topic, key='Just a key and headers', headers=headers)
+    p.produce(topic, key='Just a key')
     p.produce(topic, partition=1, value='Strictly for partition 1',
               key='mykey', headers=headers)
 
@@ -482,6 +483,8 @@ def verify_consumer():
 
         tstype, timestamp = msg.timestamp()
         headers = msg.headers()
+        if headers:
+            example_header = headers
 
         print('%s[%d]@%d: key=%s, value=%s, tstype=%d, timestamp=%s headers=%s' %
               (msg.topic(), msg.partition(), msg.offset(),
@@ -514,6 +517,9 @@ def verify_consumer():
         if msgcnt >= max_msgcnt:
             print('max_msgcnt %d reached' % msgcnt)
             break
+
+    assert example_header, "We should have received at least one header"
+    assert example_header == [(u'foo1', 'bar'), (u'foo2', '1')]
 
     # Get current assignment
     assignment = c.assignment()

--- a/examples/integration_test.py
+++ b/examples/integration_test.py
@@ -41,7 +41,7 @@ bootstrap_servers = None
 schema_registry_url = None
 
 # Topic to use
-topic = str(uuid.uuid4())
+topic = 'test'
 
 # API version requests are only implemented in Kafka broker >=0.10
 # but the client handles failed API version requests gracefully for older
@@ -889,10 +889,10 @@ if __name__ == '__main__':
 
     if len(sys.argv) > 1:
         bootstrap_servers = sys.argv[1]
-        # if len(sys.argv) > 2:
-            # topic = sys.argv[2]
-        # if len(sys.argv) > 3:
-            # schema_registry_url = sys.argv[3]
+        if len(sys.argv) > 2:
+            topic = sys.argv[2]
+        if len(sys.argv) > 3:
+            schema_registry_url = sys.argv[3]
     else:
         print_usage(1)
 

--- a/tests/test_Producer.py
+++ b/tests/test_Producer.py
@@ -22,6 +22,7 @@ def test_basic_api():
 
     p.produce('mytopic')
     p.produce('mytopic', value='somedata', key='a key')
+    p.produce('mytopic', value='somedata', key='a key', headers=[('headerkey', 'headervalue')])
 
     def on_delivery(err, msg):
         print('delivery', str)

--- a/tests/test_Producer.py
+++ b/tests/test_Producer.py
@@ -25,7 +25,7 @@ def test_basic_api():
     p.produce('mytopic', value='somedata', key='a key')
     p.produce('mytopic', value='somedata', key='a key', headers=[('headerkey', 'headervalue')])
     p.produce('mytopic', value='somedata', key='a key', headers=[('dupkey', 'dupvalue'), ('dupkey', 'dupvalue')])
-    p.produce('mytopic', value='somedata', key='a key', headers=[('dupkey', None)])
+    p.produce('mytopic', value='somedata', key='a key', headers=[('key_with_null_value', None)])
     p.produce('mytopic', value='somedata', key='a key', headers=[])
 
     with pytest.raises(TypeError) as ex:

--- a/tests/test_Producer.py
+++ b/tests/test_Producer.py
@@ -77,6 +77,7 @@ def test_produce_headers():
 
     p.flush()
 
+
 # Should be updated to 0.11.4 when it is released
 @pytest.mark.skipif(libversion()[1] >= 0x000b0000,
                     reason="Old versions should fail when using headers")

--- a/tests/test_Producer.py
+++ b/tests/test_Producer.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+import pytest
 
 from confluent_kafka import Producer, KafkaError, KafkaException, libversion
 
@@ -23,6 +24,13 @@ def test_basic_api():
     p.produce('mytopic')
     p.produce('mytopic', value='somedata', key='a key')
     p.produce('mytopic', value='somedata', key='a key', headers=[('headerkey', 'headervalue')])
+    p.produce('mytopic', value='somedata', key='a key', headers=[('dupkey', 'dupvalue'), ('dupkey', 'dupvalue')])
+    p.produce('mytopic', value='somedata', key='a key', headers=[('dupkey', None)])
+    p.produce('mytopic', value='somedata', key='a key', headers=[])
+
+    with pytest.raises(TypeError) as ex:
+        p.produce('mytopic', value='somedata', key='a key', headers=[('malformed_header')])
+    assert 'Headers are expected to be a tuple of (key, value)' == str(ex.value)
 
     def on_delivery(err, msg):
         print('delivery', str)

--- a/tests/test_Producer.py
+++ b/tests/test_Producer.py
@@ -23,15 +23,6 @@ def test_basic_api():
 
     p.produce('mytopic')
     p.produce('mytopic', value='somedata', key='a key')
-    p.produce('mytopic', value='somedata', key='a key', headers=[('headerkey', 'headervalue')])
-    p.produce('mytopic', value='somedata', key='a key', headers=[('dupkey', 'dupvalue'), ('dupkey', 'dupvalue')])
-    p.produce('mytopic', value='somedata', key='a key', headers=[('dupkey', 'dupvalue'), ('dupkey', 'diffvalue')])
-    p.produce('mytopic', value='somedata', key='a key', headers=[('key_with_null_value', None)])
-    p.produce('mytopic', value='somedata', key='a key', headers=[])
-
-    with pytest.raises(TypeError) as ex:
-        p.produce('mytopic', value='somedata', key='a key', headers=[('malformed_header')])
-    assert 'Headers are expected to be a tuple of (key, value)' == str(ex.value)
 
     def on_delivery(err, msg):
         print('delivery', str)
@@ -63,6 +54,41 @@ def test_produce_timestamp():
             raise
 
     p.flush()
+
+
+# Should be updated to 0.11.4 when it is released
+@pytest.mark.skipif(libversion()[1] < 0x000b0000,
+                    reason="requires librdkafka >=0.11.4")
+def test_produce_headers():
+    """ Test produce() with timestamp arg """
+    p = Producer({'socket.timeout.ms': 10,
+                  'error_cb': error_cb,
+                  'default.topic.config': {'message.timeout.ms': 10}})
+
+    p.produce('mytopic', value='somedata', key='a key', headers=[('headerkey', 'headervalue')])
+    p.produce('mytopic', value='somedata', key='a key', headers=[('dupkey', 'dupvalue'), ('dupkey', 'dupvalue')])
+    p.produce('mytopic', value='somedata', key='a key', headers=[('dupkey', 'dupvalue'), ('dupkey', 'diffvalue')])
+    p.produce('mytopic', value='somedata', key='a key', headers=[('key_with_null_value', None)])
+    p.produce('mytopic', value='somedata', key='a key', headers=[])
+
+    with pytest.raises(TypeError) as ex:
+        p.produce('mytopic', value='somedata', key='a key', headers=[('malformed_header')])
+    assert 'Headers are expected to be a tuple of (key, value)' == str(ex.value)
+
+    p.flush()
+
+# Should be updated to 0.11.4 when it is released
+@pytest.mark.skipif(libversion()[1] >= 0x000b0000,
+                    reason="Old versions should fail when using headers")
+def test_produce_headers_should_fail():
+    """ Test produce() with timestamp arg """
+    p = Producer({'socket.timeout.ms': 10,
+                  'error_cb': error_cb,
+                  'default.topic.config': {'message.timeout.ms': 10}})
+
+    with pytest.raises(NotImplementedError) as e:
+        p.produce('mytopic', value='somedata', key='a key', headers=[('headerkey', 'headervalue')])
+    assert 'Producer message headers requires confluent-kafka-python built for librdkafka version >=v0.11.4' in str(e)
 
 
 def test_subclassing():

--- a/tests/test_Producer.py
+++ b/tests/test_Producer.py
@@ -25,6 +25,7 @@ def test_basic_api():
     p.produce('mytopic', value='somedata', key='a key')
     p.produce('mytopic', value='somedata', key='a key', headers=[('headerkey', 'headervalue')])
     p.produce('mytopic', value='somedata', key='a key', headers=[('dupkey', 'dupvalue'), ('dupkey', 'dupvalue')])
+    p.produce('mytopic', value='somedata', key='a key', headers=[('dupkey', 'dupvalue'), ('dupkey', 'diffvalue')])
     p.produce('mytopic', value='somedata', key='a key', headers=[('key_with_null_value', None)])
     p.produce('mytopic', value='somedata', key='a key', headers=[])
 

--- a/tests/test_Producer.py
+++ b/tests/test_Producer.py
@@ -57,7 +57,7 @@ def test_produce_timestamp():
 
 
 # Should be updated to 0.11.4 when it is released
-@pytest.mark.skipif(libversion()[1] < 0x000b0000,
+@pytest.mark.skipif(libversion()[1] < 0x000b0400,
                     reason="requires librdkafka >=0.11.4")
 def test_produce_headers():
     """ Test produce() with timestamp arg """
@@ -79,7 +79,7 @@ def test_produce_headers():
 
 
 # Should be updated to 0.11.4 when it is released
-@pytest.mark.skipif(libversion()[1] >= 0x000b0000,
+@pytest.mark.skipif(libversion()[1] >= 0x000b0400,
                     reason="Old versions should fail when using headers")
 def test_produce_headers_should_fail():
     """ Test produce() with timestamp arg """

--- a/tox.ini
+++ b/tox.ini
@@ -3,18 +3,24 @@ envlist = flake8,py27,py34,py35
 
 [testenv]
 setenv =
-    CPPFLAGS=-I{toxinidir}/tmp-build/include
-    LDFLAGS=-L{toxinidir}/tmp-build/lib
-    C_INCLUDE_PATH={toxinidir}/tmp-build/include
-    LD_LIBRARY_PATH={toxinidir}/tmp-build/lib
+    ;CPPFLAGS=-I{toxinidir}/tmp-build/include
+    ;LDFLAGS=-L{toxinidir}/tmp-build/lib
+    ;C_INCLUDE_PATH={toxinidir}/tmp-build/include
+    ;LD_LIBRARY_PATH={toxinidir}/tmp-build/lib
+
+    CPPFLAGS=-I/home/vagrant/repos/librdkafka/out/include
+    LDFLAGS=-L/home/vagrant/repos/librdkafka/out/lib
+    C_INCLUDE_PATH=/home/vagrant/repos/librdkafka/out/include
+    LD_LIBRARY_PATH=/home/vagrant/repos/librdkafka/out/lib
 commands =
     pip install -v .
-    py.test -v --timeout 20 --ignore=tmp-build --import-mode append {posargs}
-    #python examples/integration_test.py [yourhost:yourport] confluent-kafka-testing http://yourhost:yourport
+    ;py.test -v --timeout 20 --ignore=tmp-build --import-mode append {posargs}
+    python examples/integration_test.py localhost:9092 confluent-kafka-testing
 
 [base]
 deps =
     pytest
+    ipdb
     pytest-timeout
     fastavro
     requests

--- a/tox.ini
+++ b/tox.ini
@@ -3,24 +3,19 @@ envlist = flake8,py27,py34,py35
 
 [testenv]
 setenv =
-    ;CPPFLAGS=-I{toxinidir}/tmp-build/include
-    ;LDFLAGS=-L{toxinidir}/tmp-build/lib
-    ;C_INCLUDE_PATH={toxinidir}/tmp-build/include
-    ;LD_LIBRARY_PATH={toxinidir}/tmp-build/lib
-
-    CPPFLAGS=-I/home/vagrant/repos/librdkafka/out/include
-    LDFLAGS=-L/home/vagrant/repos/librdkafka/out/lib
-    C_INCLUDE_PATH=/home/vagrant/repos/librdkafka/out/include
-    LD_LIBRARY_PATH=/home/vagrant/repos/librdkafka/out/lib
+    CPPFLAGS=-I{toxinidir}/tmp-build/include
+    LDFLAGS=-L{toxinidir}/tmp-build/lib
+    C_INCLUDE_PATH={toxinidir}/tmp-build/include
+    LD_LIBRARY_PATH={toxinidir}/tmp-build/lib
 commands =
     pip install -v .
-    ;py.test -v --timeout 20 --ignore=tmp-build --import-mode append {posargs}
-    python examples/integration_test.py localhost:9092 confluent-kafka-testing
+    py.test -v --timeout 20 --ignore=tmp-build --import-mode append {posargs}
+    #python examples/integration_test.py [yourhost:yourport] confluent-kafka-testing http://yourhost:yourport
+
 
 [base]
 deps =
     pytest
-    ipdb
     pytest-timeout
     fastavro
     requests

--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,6 @@ commands =
     py.test -v --timeout 20 --ignore=tmp-build --import-mode append {posargs}
     #python examples/integration_test.py [yourhost:yourport] confluent-kafka-testing http://yourhost:yourport
 
-
 [base]
 deps =
     pytest


### PR DESCRIPTION
Initial stab at closing #287.

This implements the tuple idea mentioned in #287. Each header is a list of tuples `[(header_key, header_value)...]` This was the simplest to implement and I think will cover most use cases. For unique header_keys and user can just `dict(header_list)` for python 3.6 or `OrderedDict(header_tuple)` for before python 3.5. 

This is still a WIP. Need to:

- throw an error on incorrect version if librdkafka
- better testing around malformed headers and incorrect types

Some questions:

- Should the client perform any validation on the shape of the headers or just trust the user.
- Right now the `producer.produce()` only accepts list. We can expand to support any iter that contains key, value pairs.