### PR TITLE
Broker loss example consumer failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ matrix:
 
 install:
  - if [[ -z $CIBW_BEFORE_BUILD ]]; then rm -rf tmp-build ; tools/bootstrap-librdkafka.sh --require-ssl ${LIBRDKAFKA_VERSION} tmp-build ; fi
- - if [[ -z $CIBW_BEFORE_BUILD ]]; then pip install --upgrade pip && pip install pytest-timeout flake8 ; fi
+ - if [[ -z $CIBW_BEFORE_BUILD ]]; then pip install --upgrade pip && pip install pytest-timeout flake8 && pip install docker-compose; fi
  - if [[ -n $TRAVIS_TAG && -n $CIBW_BEFORE_BUILD ]]; then pip install cibuildwheel==0.4.1 ; fi
 
 
@@ -40,6 +40,7 @@ script:
  - if [[ -z $CIBW_BEFORE_BUILD ]]; then pip install -v --global-option=build_ext --global-option="-Itmp-build/include/" --global-option="-Ltmp-build/lib" . .[avro] ; fi
  - if [[ -z $CIBW_BEFORE_BUILD ]]; then flake8 ; fi
  - if [[ -z $CIBW_BEFORE_BUILD ]]; then py.test -v --timeout 20 --ignore=tmp-build --import-mode append ; fi
+ - if [[ -z $CIBW_BEFORE_BUILD ]]; then docker-compose up -d fi
  - if [[ -z $CIBW_BEFORE_BUILD ]]; then py.test -sv --timeout 200 --ignore=tmp-build --import-mode append examples/example_failed_broker.py; fi
  - if [[ -n $TRAVIS_TAG && -n $CIBW_BEFORE_BUILD ]]; then cibuildwheel --output-dir wheelhouse ; ls -la wheelhouse/ ; fi
  - if [[ -n $TRAVIS_TAG && $TRAVIS_OS_NAME == linux && -n $CIBW_BEFORE_BUILD ]]; then tools/test-manylinux.sh ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ script:
  - if [[ -z $CIBW_BEFORE_BUILD ]]; then pip install -v --global-option=build_ext --global-option="-Itmp-build/include/" --global-option="-Ltmp-build/lib" . .[avro] ; fi
  - if [[ -z $CIBW_BEFORE_BUILD ]]; then flake8 ; fi
  - if [[ -z $CIBW_BEFORE_BUILD ]]; then py.test -v --timeout 20 --ignore=tmp-build --import-mode append ; fi
- - if [[ -z $CIBW_BEFORE_BUILD ]]; then docker-compose up -d fi
+ - if [[ -z $CIBW_BEFORE_BUILD ]]; then docker-compose up -d ; fi
  - if [[ -z $CIBW_BEFORE_BUILD ]]; then py.test -sv --timeout 200 --ignore=tmp-build --import-mode append examples/example_failed_broker.py; fi
  - if [[ -n $TRAVIS_TAG && -n $CIBW_BEFORE_BUILD ]]; then cibuildwheel --output-dir wheelhouse ; ls -la wheelhouse/ ; fi
  - if [[ -n $TRAVIS_TAG && $TRAVIS_OS_NAME == linux && -n $CIBW_BEFORE_BUILD ]]; then tools/test-manylinux.sh ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,6 +42,7 @@ script:
  - if [[ -z $CIBW_BEFORE_BUILD ]]; then py.test -v --timeout 20 --ignore=tmp-build --import-mode append ; fi
  - if [[ -z $CIBW_BEFORE_BUILD ]]; then docker-compose build ; fi
  - if [[ -z $CIBW_BEFORE_BUILD ]]; then docker-compose up -d ; fi
+ - if [[ -z $CIBW_BEFORE_BUILD ]]; then sleep 10 ; fi
  - if [[ -z $CIBW_BEFORE_BUILD ]]; then py.test -sv --timeout 200 --ignore=tmp-build --import-mode append examples/example_failed_broker.py; fi
  - if [[ -n $TRAVIS_TAG && -n $CIBW_BEFORE_BUILD ]]; then cibuildwheel --output-dir wheelhouse ; ls -la wheelhouse/ ; fi
  - if [[ -n $TRAVIS_TAG && $TRAVIS_OS_NAME == linux && -n $CIBW_BEFORE_BUILD ]]; then tools/test-manylinux.sh ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,6 +40,7 @@ script:
  - if [[ -z $CIBW_BEFORE_BUILD ]]; then pip install -v --global-option=build_ext --global-option="-Itmp-build/include/" --global-option="-Ltmp-build/lib" . .[avro] ; fi
  - if [[ -z $CIBW_BEFORE_BUILD ]]; then flake8 ; fi
  - if [[ -z $CIBW_BEFORE_BUILD ]]; then py.test -v --timeout 20 --ignore=tmp-build --import-mode append ; fi
+ - if [[ -z $CIBW_BEFORE_BUILD ]]; then docker-compose build ; fi
  - if [[ -z $CIBW_BEFORE_BUILD ]]; then docker-compose up -d ; fi
  - if [[ -z $CIBW_BEFORE_BUILD ]]; then py.test -sv --timeout 200 --ignore=tmp-build --import-mode append examples/example_failed_broker.py; fi
  - if [[ -n $TRAVIS_TAG && -n $CIBW_BEFORE_BUILD ]]; then cibuildwheel --output-dir wheelhouse ; ls -la wheelhouse/ ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,6 +40,7 @@ script:
  - if [[ -z $CIBW_BEFORE_BUILD ]]; then pip install -v --global-option=build_ext --global-option="-Itmp-build/include/" --global-option="-Ltmp-build/lib" . .[avro] ; fi
  - if [[ -z $CIBW_BEFORE_BUILD ]]; then flake8 ; fi
  - if [[ -z $CIBW_BEFORE_BUILD ]]; then py.test -v --timeout 20 --ignore=tmp-build --import-mode append ; fi
+ - if [[ -z $CIBW_BEFORE_BUILD ]]; then py.test -sv --timeout 200 --ignore=tmp-build --import-mode append examples/example_failed_broker.py; fi
  - if [[ -n $TRAVIS_TAG && -n $CIBW_BEFORE_BUILD ]]; then cibuildwheel --output-dir wheelhouse ; ls -la wheelhouse/ ; fi
  - if [[ -n $TRAVIS_TAG && $TRAVIS_OS_NAME == linux && -n $CIBW_BEFORE_BUILD ]]; then tools/test-manylinux.sh ; fi
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,46 @@
+version: '2'
+
+services:
+  zookeeper:
+    image: wurstmeister/zookeeper
+    ports:
+      - "2181:2181"
+
+  image:
+    build:
+      context: ./docker/kafka
+      dockerfile: Dockerfile
+    image: test-kafka
+
+  kafka1:
+    image: test-kafka
+    ports:
+      - "9093:9092"
+    environment:
+      - NUM_PARTITIONS=3
+      - NUM_REPLICATION=3
+      - ADVERTISED_LISTENERS=CLIENT://localhost:9093,REPLICATION://kafka1:10001
+      - LISTENERS=CLIENT://0.0.0.0:9092,REPLICATION://0.0.0.0:10001
+      - ZOOKEEPER_URL=zookeeper:2181
+
+  kafka2:
+    image: test-kafka
+    ports:
+      - "9094:9092"
+    environment:
+      - NUM_PARTITIONS=3
+      - NUM_REPLICATION=3
+      - ADVERTISED_LISTENERS=CLIENT://localhost:9094,REPLICATION://kafka2:10001
+      - LISTENERS=CLIENT://0.0.0.0:9092,REPLICATION://0.0.0.0:10001
+      - ZOOKEEPER_URL=zookeeper:2181
+
+  kafka3:
+    image: test-kafka
+    ports:
+      - "9095:9092"
+    environment:
+      - NUM_PARTITIONS=3
+      - NUM_REPLICATION=3
+      - ADVERTISED_LISTENERS=CLIENT://localhost:9095,REPLICATION://kafka3:10001
+      - LISTENERS=CLIENT://0.0.0.0:9092,REPLICATION://0.0.0.0:10001
+      - ZOOKEEPER_URL=zookeeper:2181

--- a/docker/kafka/Dockerfile
+++ b/docker/kafka/Dockerfile
@@ -1,0 +1,25 @@
+# Kafka and Zookeeper
+
+FROM java:openjdk-8-jre
+
+ENV DEBIAN_FRONTEND noninteractive
+ENV SCALA_VERSION 2.11
+ENV KAFKA_VERSION 1.0.0
+ENV KAFKA_HOME /opt/kafka_"$SCALA_VERSION"-"$KAFKA_VERSION"
+
+# Install Kafka, Zookeeper and other needed things
+RUN apt-get update && \
+    apt-get install -y zookeeper wget supervisor dnsutils && \
+    rm -rf /var/lib/apt/lists/* && \
+    apt-get clean && \
+    wget -q http://apache.mirrors.spacedump.net/kafka/"$KAFKA_VERSION"/kafka_"$SCALA_VERSION"-"$KAFKA_VERSION".tgz -O /tmp/kafka_"$SCALA_VERSION"-"$KAFKA_VERSION".tgz && \
+    tar xfz /tmp/kafka_"$SCALA_VERSION"-"$KAFKA_VERSION".tgz -C /opt && \
+    rm /tmp/kafka_"$SCALA_VERSION"-"$KAFKA_VERSION".tgz
+
+ADD scripts/start-kafka.sh /usr/bin/start-kafka.sh
+ADD config/server.properties $KAFKA_HOME/config/server.properties
+
+# 2181 is zookeeper, 9092 is kafka
+EXPOSE 2181 9092 10001
+
+CMD ["/usr/bin/start-kafka.sh"]

--- a/docker/kafka/config/server.properties
+++ b/docker/kafka/config/server.properties
@@ -1,0 +1,137 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# see kafka.server.KafkaConfig for additional details and defaults
+
+############################# Server Basics #############################
+
+# The id of the broker. This must be set to a unique integer for each broker.
+#broker.id=0
+
+############################# Socket Server Settings #############################
+
+# The address the socket server listens on. It will get the value returned from
+# java.net.InetAddress.getCanonicalHostName() if not configured.
+#   FORMAT:
+#     listeners = listener_name://host_name:port
+#   EXAMPLE:
+#     listeners = PLAINTEXT://your.host.name:9092
+#listeners=PLAINTEXT://:9092
+
+# Hostname and port the broker will advertise to producers and consumers. If not set,
+# it uses the value for "listeners" if configured.  Otherwise, it will use the value
+# returned from java.net.InetAddress.getCanonicalHostName().
+
+# Maps listener names to security protocols, the default is for them to be the same. See the config documentation for more details
+listener.security.protocol.map=CLIENT:PLAINTEXT,REPLICATION:PLAINTEXT
+#advertised.listeners=PLAINTEXT://your.host.name:9092
+inter.broker.listener.name=REPLICATION
+
+# The number of threads that the server uses for receiving requests from the network and sending responses to the network
+num.network.threads=3
+
+# The number of threads that the server uses for processing requests, which may include disk I/O
+num.io.threads=8
+
+# The send buffer (SO_SNDBUF) used by the socket server
+socket.send.buffer.bytes=102400
+
+# The receive buffer (SO_RCVBUF) used by the socket server
+socket.receive.buffer.bytes=102400
+
+# The maximum size of a request that the socket server will accept (protection against OOM)
+socket.request.max.bytes=104857600
+
+
+############################# Log Basics #############################
+
+# A comma seperated list of directories under which to store log files
+log.dirs=/tmp/kafka-logs
+
+# The default number of log partitions per topic. More partitions allow greater
+# parallelism for consumption, but this will also result in more files across
+# the brokers.
+num.partitions=3
+
+# The number of threads per data directory to be used for log recovery at startup and flushing at shutdown.
+# This value is recommended to be increased for installations with data dirs located in RAID array.
+num.recovery.threads.per.data.dir=1
+
+############################# Internal Topic Settings  #############################
+# The replication factor for the group metadata internal topics "__consumer_offsets" and "__transaction_state"
+# For anything other than development testing, a value greater than 1 is recommended for to ensure availability such as 3.
+offsets.topic.replication.factor=1
+transaction.state.log.replication.factor=1
+transaction.state.log.min.isr=1
+
+############################# Log Flush Policy #############################
+
+# Messages are immediately written to the filesystem but by default we only fsync() to sync
+# the OS cache lazily. The following configurations control the flush of data to disk.
+# There are a few important trade-offs here:
+#    1. Durability: Unflushed data may be lost if you are not using replication.
+#    2. Latency: Very large flush intervals may lead to latency spikes when the flush does occur as there will be a lot of data to flush.
+#    3. Throughput: The flush is generally the most expensive operation, and a small flush interval may lead to exceessive seeks.
+# The settings below allow one to configure the flush policy to flush data after a period of time or
+# every N messages (or both). This can be done globally and overridden on a per-topic basis.
+
+# The number of messages to accept before forcing a flush of data to disk
+#log.flush.interval.messages=10000
+
+# The maximum amount of time a message can sit in a log before we force a flush
+#log.flush.interval.ms=1000
+
+############################# Log Retention Policy #############################
+
+# The following configurations control the disposal of log segments. The policy can
+# be set to delete segments after a period of time, or after a given size has accumulated.
+# A segment will be deleted whenever *either* of these criteria are met. Deletion always happens
+# from the end of the log.
+
+# The minimum age of a log file to be eligible for deletion due to age
+log.retention.hours=168
+
+# A size-based retention policy for logs. Segments are pruned from the log unless the remaining
+# segments drop below log.retention.bytes. Functions independently of log.retention.hours.
+#log.retention.bytes=1073741824
+
+# The maximum size of a log segment file. When this size is reached a new log segment will be created.
+log.segment.bytes=1073741824
+
+# The interval at which log segments are checked to see if they can be deleted according
+# to the retention policies
+log.retention.check.interval.ms=300000
+
+############################# Zookeeper #############################
+
+# Zookeeper connection string (see zookeeper docs for details).
+# This is a comma separated host:port pairs, each corresponding to a zk
+# server. e.g. "127.0.0.1:3000,127.0.0.1:3001,127.0.0.1:3002".
+# You can also append an optional chroot string to the urls to specify the
+# root directory for all kafka znodes.
+zookeeper.connect=localhost:2181
+
+# Timeout in ms for connecting to zookeeper
+zookeeper.connection.timeout.ms=6000
+
+
+############################# Group Coordinator Settings #############################
+
+# The following configuration specifies the time, in milliseconds, that the GroupCoordinator will delay the initial consumer rebalance.
+# The rebalance will be further delayed by the value of group.initial.rebalance.delay.ms as new members join the group, up to a maximum of max.poll.interval.ms.
+# The default value for this is 3 seconds.
+# We override this to 0 here as it makes for a better out-of-the-box experience for development and testing.
+# However, in production environments the default value of 3 seconds is more suitable as this will help to avoid unnecessary, and potentially expensive, rebalances during application startup.
+group.initial.rebalance.delay.ms=0

--- a/docker/kafka/scripts/start-kafka.sh
+++ b/docker/kafka/scripts/start-kafka.sh
@@ -1,0 +1,61 @@
+#!/bin/sh
+
+# Optional ENV variables:
+# * ADVERTISED_HOST: the external ip for the container, e.g. `docker-machine ip \`docker-machine active\``
+# * ADVERTISED_PORT: the external port for Kafka, e.g. 9092
+# * ZK_CHROOT: the zookeeper chroot that's used by Kafka (without / prefix), e.g. "kafka"
+# * LOG_RETENTION_HOURS: the minimum age of a log file in hours to be eligible for deletion (default is 168, for 1 week)
+# * LOG_RETENTION_BYTES: configure the size at which segments are pruned from the log, (default is 1073741824, for 1GB)
+# * NUM_PARTITIONS: configure the default number of log partitions per topic
+
+# hack to deal with appending shit to the config file
+echo "\n" >>$KAFKA_HOME/config/server.properties
+
+if [ ! -z "$BROKER_ID" ]; then
+    echo "broker.id=$BROKER_ID" >> $KAFKA_HOME/config/server.properties
+fi
+
+# Set the external host and port
+if [ ! -z "$ADVERTISED_LISTENERS" ]; then
+    echo "advertised listener: $ADVERTISED_LISTENERS"
+    echo "advertised.listeners=$ADVERTISED_LISTENERS" >> $KAFKA_HOME/config/server.properties
+fi
+
+if [ ! -z "$LISTENERS" ]; then
+    echo "advertised listener: $LISTENERS"
+    echo "listeners=$LISTENERS" >> $KAFKA_HOME/config/server.properties
+fi
+
+if [ ! -z "$ZOOKEEPER_URL" ]; then
+    sed -r -i "s/(zookeeper.connect)=(.*)/\1=$ZOOKEEPER_URL/g" $KAFKA_HOME/config/server.properties
+fi
+
+# Allow specification of log retention policies
+if [ ! -z "$LOG_RETENTION_HOURS" ]; then
+    echo "log retention hours: $LOG_RETENTION_HOURS"
+    sed -r -i "s/(log.retention.hours)=(.*)/\1=$LOG_RETENTION_HOURS/g" $KAFKA_HOME/config/server.properties
+fi
+if [ ! -z "$LOG_RETENTION_BYTES" ]; then
+    echo "log retention bytes: $LOG_RETENTION_BYTES"
+    sed -r -i "s/#(log.retention.bytes)=(.*)/\1=$LOG_RETENTION_BYTES/g" $KAFKA_HOME/config/server.properties
+fi
+
+# Configure the default number of log partitions per topic
+if [ ! -z "$NUM_PARTITIONS" ]; then
+    echo "default number of partition: $NUM_PARTITIONS"
+    sed -r -i "s/(num.partitions)=(.*)/\1=$NUM_PARTITIONS/g" $KAFKA_HOME/config/server.properties
+fi
+
+if [ ! -z "$NUM_REPLICATION" ]; then
+    echo "default replication: $NUM_REPLICATION"
+    echo "default.replication.factor=$NUM_REPLICATION" >> $KAFKA_HOME/config/server.properties
+fi
+
+# Enable/disable auto creation of topics
+if [ ! -z "$AUTO_CREATE_TOPICS" ]; then
+    echo "auto.create.topics.enable: $AUTO_CREATE_TOPICS"
+    echo "auto.create.topics.enable=$AUTO_CREATE_TOPICS" >> $KAFKA_HOME/config/server.properties
+fi
+
+# Run Kafka
+exec $KAFKA_HOME/bin/kafka-server-start.sh $KAFKA_HOME/config/server.properties

--- a/docker/kafka/supervisor/kafka.conf
+++ b/docker/kafka/supervisor/kafka.conf
@@ -1,0 +1,4 @@
+[program:kafka]
+command=/usr/bin/start-kafka.sh
+autostart=true
+autorestart=true

--- a/docker/kafka/supervisor/zookeeper.conf
+++ b/docker/kafka/supervisor/zookeeper.conf
@@ -1,0 +1,4 @@
+[program:zookeeper]
+command=/usr/share/zookeeper/bin/zkServer.sh start-foreground
+autostart=true
+autorestart=true

--- a/examples/example_failed_broker.py
+++ b/examples/example_failed_broker.py
@@ -28,7 +28,7 @@ def test_broker(pause_broker):
     producer = Producer(**{
         'bootstrap.servers': 'localhost:9094',
         'compression.codec': 'snappy',
-        'queue.buffering.max.ms': 0,
+        'queue.buffering.max.ms': 1,
         'metadata.request.timeout.ms': 100,
         'topic.metadata.refresh.interval.ms': 100,
         'socket.timeout.ms': 100,
@@ -56,7 +56,16 @@ def test_broker(pause_broker):
         'error_cb': _error_callback,
     })
     new_consumer.subscribe([source_topic_name])
+
     msgs = []
+    def _ensure_assignment():
+        raw_msg = new_consumer.poll(0)
+        # buffer locally for count
+        if raw_msg:
+            msgs.append(raw_msg)
+
+        assert new_consumer.assignment()
+    retry(_ensure_assignment)
 
     def _ensure_delivery():
         while True:

--- a/examples/example_failed_broker.py
+++ b/examples/example_failed_broker.py
@@ -1,0 +1,72 @@
+import time
+import json
+import uuid
+import os
+import pytest
+
+from confluent_kafka import Consumer, KafkaError, Producer
+
+
+def retry(assertion_callable, retry_time=10, wait_between_tries=0.1, exception_to_retry=AssertionError):
+    start = time.time()
+    while True:
+        try:
+            return assertion_callable()
+        except exception_to_retry as e:
+            if time.time() - start >= retry_time:
+                raise e
+            time.sleep(wait_between_tries)
+
+
+@pytest.mark.parametrize("pause_broker", [False, True])
+def test_broker(pause_broker):
+    """
+    Signal handlers do not support threads
+    """
+    source_topic_name = str(uuid.uuid4())
+
+    producer = Producer(**{
+        'bootstrap.servers': 'localhost:9094',
+        'compression.codec': 'snappy',
+        'queue.buffering.max.ms': 0,
+        'metadata.request.timeout.ms': 100,
+        'topic.metadata.refresh.interval.ms': 100,
+        'socket.timeout.ms': 100,
+    })
+
+    n_msgs = 100
+    for i in range(n_msgs):
+        producer.produce(source_topic_name, json.dumps({'foo': i}))
+    producer.flush()
+
+    if pause_broker:
+        os.system('docker-compose pause kafka1')
+
+    def _error_callback(err):
+        print("got err: {}".format(str(err)))
+
+    new_consumer = Consumer(**{
+        'bootstrap.servers': 'localhost:9094',
+        'group.id': str(uuid.uuid4()),
+        'default.topic.config': {'auto.offset.reset': 'smallest'},
+        'enable.auto.commit': False,
+        'metadata.request.timeout.ms': 100,
+        'topic.metadata.refresh.interval.ms': 100,
+        'socket.timeout.ms': 100,
+        'error_cb': _error_callback,
+    })
+    new_consumer.subscribe([source_topic_name])
+    msgs = []
+
+    def _ensure_delivery():
+        while True:
+            raw_msg = new_consumer.poll(0)
+            if raw_msg:
+                msgs.append(raw_msg)
+            else:
+                break
+
+        assert len(msgs) == n_msgs
+
+    retry(_ensure_delivery, retry_time=30)
+    new_consumer.close()

--- a/tox.ini
+++ b/tox.ini
@@ -8,9 +8,12 @@ setenv =
     C_INCLUDE_PATH={toxinidir}/tmp-build/include
     LD_LIBRARY_PATH={toxinidir}/tmp-build/lib
 commands =
+    docker-compose up -d
     pip install -v .
-    py.test -v --timeout 20 --ignore=tmp-build --import-mode append {posargs}
+    ;py.test -v --timeout 20 --ignore=tmp-build --import-mode append {posargs}
     #python examples/integration_test.py [yourhost:yourport] confluent-kafka-testing http://yourhost:yourport
+    py.test examples/example_failed_broker.py -sv
+    docker-compose down
 
 [base]
 deps =


### PR DESCRIPTION
This is a reproduction of an error I am having trouble dealing with. If a broker goes down I am unable to successfully consume from any topic that has that broker as a leader. I know this is a core part of the kafka protocol but i am having issues making the python client gracefully handle broker loss. This is causing much pain for my workers. Am I missing something or is this an issue with the client?

added a docker file and compose to help spin up brokers. tox/travis might work. To run:

```
docker-compose build
docker-compose up -d
py.test examples/example_failed_broker.py -sv
```