### PR TITLE
Support decoding empty string

### DIFF
--- a/confluent_kafka/avro/serializer/message_serializer.py
+++ b/confluent_kafka/avro/serializer/message_serializer.py
@@ -204,6 +204,9 @@ class MessageSerializer(object):
 
         if message is None:
             return None
+          
+        if len(message) == 0:
+            return ""
 
         if len(message) <= 5:
             raise SerializerError("message is too small to decode")


### PR DESCRIPTION
Python client throw the `message is too small to decode` error when trying to consume message with an empty string as key in kafka.

If we allow publishing empty key, we should be able to consume it. So this PR is a fix to allow decode empty string.