### PR TITLE
WIP: Add support for headers as dicts and headers in callback messages.

### DIFF
--- a/confluent_kafka/src/Consumer.c
+++ b/confluent_kafka/src/Consumer.c
@@ -884,12 +884,7 @@ static PyObject *Consumer_poll (Handle *self, PyObject *args,
         if (!rkm)
                 Py_RETURN_NONE;
 
-        msgobj = Message_new0(self, rkm);
-#ifdef RD_KAFKA_V_HEADERS
-        // Have to deatch headers outside Message_new0 because it declares the
-        // rk message as a const
-        rd_kafka_message_detach_headers(rkm, &((Message *)msgobj)->c_headers);
-#endif
+        msgobj = Message_new0(self, rkm, true);
         rd_kafka_message_destroy(rkm);
 
         return msgobj;
@@ -950,12 +945,7 @@ static PyObject *Consumer_consume (Handle *self, PyObject *args,
         msglist = PyList_New(n);
 
         for (i = 0; i < n; i++) {
-                PyObject *msgobj = Message_new0(self, rkmessages[i]);
-#ifdef RD_KAFKA_V_HEADERS
-                // Have to deatch headers outside Message_new0 because it declares the
-                // rk message as a const
-                rd_kafka_message_detach_headers(rkmessages[i], &((Message *)msgobj)->c_headers);
-#endif
+                PyObject *msgobj = Message_new0(self, rkmessages[i], true);
                 PyList_SET_ITEM(msglist, i, msgobj);
                 rd_kafka_message_destroy(rkmessages[i]);
         }

--- a/confluent_kafka/src/Producer.c
+++ b/confluent_kafka/src/Producer.c
@@ -156,7 +156,7 @@ static void dr_msg_cb (rd_kafka_t *rk, const rd_kafka_message_t *rkm,
         if (self->u.Producer.dr_only_error && !rkm->err)
                 goto done;
 
-	msgobj = Message_new0(self, rkm);
+	msgobj = Message_new0(self, (rd_kafka_message_t *)rkm, false);
 	
 	args = Py_BuildValue("(OO)",
 			     Message_error((Message *)msgobj, NULL),
@@ -492,10 +492,6 @@ static PyMethodDef Producer_methods[] = {
 	  "``callback`` (alias ``on_delivery``) argument to pass a function "
 	  "(or lambda) that will be called from :py:func:`poll()` when the "
 	  "message has been successfully delivered or permanently fails delivery.\n"
-      "\n"
-      "  Currently message headers are not supported on the message returned to the "
-      "callback. The ``msg.headers()`` will return None even if the original message "
-      "had headers set.\n"
 	  "\n"
 	  "  :param str topic: Topic to produce message to\n"
 	  "  :param str|bytes value: Message payload\n"
@@ -505,16 +501,15 @@ static PyMethodDef Producer_methods[] = {
 	  "  :param func on_delivery(err,msg): Delivery report callback to call "
 	  "(from :py:func:`poll()` or :py:func:`flush()`) on successful or "
 	  "failed delivery\n"
-          "  :param int timestamp: Message timestamp (CreateTime) in microseconds since epoch UTC (requires librdkafka >= v0.9.4, api.version.request=true, and broker >= 0.10.0.0). Default value is current time.\n"
+	  "  :param int timestamp: Message timestamp (CreateTime) in microseconds since epoch UTC (requires librdkafka >= v0.9.4, api.version.request=true, and broker >= 0.10.0.0). Default value is current time.\n"
 	  "\n"
 	  "  :rtype: None\n"
 	  "  :raises BufferError: if the internal producer message queue is "
 	  "full (``queue.buffering.max.messages`` exceeded)\n"
 	  "  :raises KafkaException: for other errors, see exception code\n"
-          "  :raises NotImplementedError: if timestamp is specified without underlying library support.\n"
+	  "  :raises NotImplementedError: if timestamp is specified without underlying library support.\n"
 	  "\n"
 	},
-
 	{ "poll", (PyCFunction)Producer_poll, METH_VARARGS|METH_KEYWORDS,
 	  ".. py:function:: poll([timeout])\n"
 	  "\n"
@@ -531,17 +526,16 @@ static PyMethodDef Producer_methods[] = {
 	  "  :rtype: int\n"
 	  "\n"
 	},
-
 	{ "flush", (PyCFunction)Producer_flush, METH_VARARGS|METH_KEYWORDS,
-          ".. py:function:: flush([timeout])\n"
-          "\n"
+	  ".. py:function:: flush([timeout])\n"
+	  "\n"
 	  "   Wait for all messages in the Producer queue to be delivered.\n"
 	  "   This is a convenience method that calls :py:func:`poll()` until "
 	  ":py:func:`len()` is zero or the optional timeout elapses.\n"
 	  "\n"
-          "  :param: float timeout: Maximum time to block (requires librdkafka >= v0.9.4). (Seconds)\n"
-          "  :returns: Number of messages still in queue.\n"
-          "\n"
+	  "  :param: float timeout: Maximum time to block (requires librdkafka >= v0.9.4). (Seconds)\n"
+	  "  :returns: Number of messages still in queue.\n"
+	  "\n"
 	  ".. note:: See :py:func:`poll()` for a description on what "
 	  "callbacks may be triggered.\n"
 	  "\n"

--- a/confluent_kafka/src/Producer.c
+++ b/confluent_kafka/src/Producer.c
@@ -259,7 +259,7 @@ Producer_producev (Handle *self,
                    const void *value, size_t value_len,
                    const void *key, size_t key_len,
                    void *opaque, int64_t timestamp
-#if RD_KAFKA_V_HEADERS
+#ifdef RD_KAFKA_V_HEADERS
                    ,rd_kafka_headers_t *headers
 #endif
                    ) {
@@ -272,7 +272,7 @@ Producer_producev (Handle *self,
                                  RD_KAFKA_V_VALUE((void *)value,
                                                   (size_t)value_len),
                                  RD_KAFKA_V_TIMESTAMP(timestamp),
-#if RD_KAFKA_V_HEADERS
+#ifdef RD_KAFKA_V_HEADERS
                                  RD_KAFKA_V_HEADERS(headers),
 #endif
                                  RD_KAFKA_V_OPAQUE(opaque),
@@ -386,7 +386,7 @@ static PyObject *Producer_produce (Handle *self, PyObject *args,
                                 value, value_len,
                                 key, key_len,
                                 msgstate, timestamp
-#if RD_KAFKA_V_HEADERS
+#ifdef RD_KAFKA_V_HEADERS
                                 ,rd_headers
 #endif
                                 );

--- a/confluent_kafka/src/confluent_kafka.c
+++ b/confluent_kafka/src/confluent_kafka.c
@@ -258,10 +258,10 @@ PyObject *KafkaError_new0 (rd_kafka_resp_err_t err, const char *fmt, ...) {
  PyObject *KafkaError_new_or_None (rd_kafka_resp_err_t err, const char *str) {
 	if (!err)
 		Py_RETURN_NONE;
-        if (str)
-                return KafkaError_new0(err, "%s", str);
-        else
-                return KafkaError_new0(err, NULL);
+	if (str)
+		return KafkaError_new0(err, "%s", str);
+	else
+		return KafkaError_new0(err, NULL);
 }
 
 
@@ -336,29 +336,29 @@ static PyObject *Message_timestamp (Message *self, PyObject *ignore) {
 static PyObject *Message_headers (Message *self, PyObject *ignore) {
 #ifdef RD_KAFKA_V_HEADERS
 	if (self->headers) {
-        Py_INCREF(self->headers);
+		Py_INCREF(self->headers);
 		return self->headers;
-    } else if (self->c_headers) {
-        self->headers = c_headers_to_py(self->c_headers);
-        rd_kafka_headers_destroy(self->c_headers);
-        self->c_headers = NULL;
-        Py_INCREF(self->headers);
-        return self->headers;
+	} else if (self->c_headers) {
+		self->headers = c_headers_to_py(self->c_headers);
+		rd_kafka_headers_destroy(self->c_headers);
+		self->c_headers = NULL;
+		Py_INCREF(self->headers);
+		return self->headers;
 	} else {
 		Py_RETURN_NONE;
-    }
+	}
 #else
 		Py_RETURN_NONE;
 #endif
 }
 
 static PyObject *Message_set_headers (Message *self, PyObject *new_headers) {
-   if (self->headers)
-        Py_DECREF(self->headers);
-   self->headers = new_headers;
-   Py_INCREF(self->headers);
+	if (self->headers)
+		Py_DECREF(self->headers);
+	self->headers = new_headers;
+	Py_INCREF(self->headers);
 
-   Py_RETURN_NONE;
+	Py_RETURN_NONE;
 }
 
 static PyObject *Message_set_value (Message *self, PyObject *new_val) {
@@ -389,7 +389,6 @@ static PyMethodDef Message_methods[] = {
 	  "  :rtype: None or :py:class:`KafkaError`\n"
 	  "\n"
 	},
-
 	{ "value", (PyCFunction)Message_value, METH_NOARGS,
 	  "  :returns: message value (payload) or None if not available.\n"
 	  "  :rtype: str|bytes or None\n"
@@ -416,31 +415,31 @@ static PyMethodDef Message_methods[] = {
 	  "\n"
 	},
 	{ "timestamp", (PyCFunction)Message_timestamp, METH_NOARGS,
-          "  Retrieve timestamp type and timestamp from message.\n"
-          "  The timestamp type is one of:\n"
-          "    * :py:const:`TIMESTAMP_NOT_AVAILABLE`"
-          " - Timestamps not supported by broker\n"
-          "    * :py:const:`TIMESTAMP_CREATE_TIME` "
-          " - Message creation time (or source / producer time)\n"
-          "    * :py:const:`TIMESTAMP_LOG_APPEND_TIME` "
-          " - Broker receive time\n"
-          "\n"
-          "  The returned timestamp should be ignored if the timestamp type is "
-          ":py:const:`TIMESTAMP_NOT_AVAILABLE`.\n"
-          "\n"
-          "  The timestamp is the number of milliseconds since the epoch (UTC).\n"
-          "\n"
-          "  Timestamps require broker version 0.10.0.0 or later and \n"
-          "  ``{'api.version.request': True}`` configured on the client.\n"
-          "\n"
+	  "  Retrieve timestamp type and timestamp from message.\n"
+	  "  The timestamp type is one of:\n"
+	  "    * :py:const:`TIMESTAMP_NOT_AVAILABLE`"
+	  " - Timestamps not supported by broker\n"
+	  "    * :py:const:`TIMESTAMP_CREATE_TIME` "
+	  " - Message creation time (or source / producer time)\n"
+	  "    * :py:const:`TIMESTAMP_LOG_APPEND_TIME` "
+	  " - Broker receive time\n"
+	  "\n"
+	  "  The returned timestamp should be ignored if the timestamp type is "
+	  ":py:const:`TIMESTAMP_NOT_AVAILABLE`.\n"
+	  "\n"
+	  "  The timestamp is the number of milliseconds since the epoch (UTC).\n"
+	  "\n"
+	  "  Timestamps require broker version 0.10.0.0 or later and \n"
+	  "  ``{'api.version.request': True}`` configured on the client.\n"
+	  "\n"
 	  "  :returns: tuple of message timestamp type, and timestamp.\n"
 	  "  :rtype: (int, int)\n"
 	  "\n"
 	},
 	{ "headers", (PyCFunction)Message_headers, METH_NOARGS,
-      "  Retrieve the headers set on a message. Each header is a key value"
-      "pair. Please note that header keys are ordered and can repeat.\n"
-      "\n"
+	  "  Retrieve the headers set on a message. Each header is a key value"
+	  "pair. Please note that header keys are ordered and can repeat.\n"
+	  "\n"
 	  "  :returns: list of two-tuples, one (key, value) pair for each header.\n"
 	  "  :rtype: [(str, bytes),...] or None.\n"
 	  "\n"
@@ -491,10 +490,10 @@ static int Message_clear (Message *self) {
 		self->headers = NULL;
 	}
 #ifdef RD_KAFKA_V_HEADERS
-    if (self->c_headers){
-        rd_kafka_headers_destroy(self->c_headers);
-        self->c_headers = NULL;
-    }
+	if (self->c_headers){
+		rd_kafka_headers_destroy(self->c_headers);
+		self->c_headers = NULL;
+	}
 #endif
 	return 0;
 }
@@ -594,12 +593,12 @@ PyObject *Message_new0 (const Handle *handle, const rd_kafka_message_t *rkm) {
 	if (!self)
 		return NULL;
 
-        /* Only use message error string on Consumer, for Producers
-         * it will contain the original message payload. */
-        self->error = KafkaError_new_or_None(
-                rkm->err,
-                (rkm->err && handle->type != RD_KAFKA_PRODUCER) ?
-                rd_kafka_message_errstr(rkm) : NULL);
+	/* Only use message error string on Consumer, for Producers
+	 * it will contain the original message payload. */
+	self->error = KafkaError_new_or_None(
+		rkm->err,
+		(rkm->err && handle->type != RD_KAFKA_PRODUCER) ?
+		rd_kafka_message_errstr(rkm) : NULL);
 
 	if (rkm->rkt)
 		self->topic = cfl_PyUnistr(
@@ -700,37 +699,37 @@ static int TopicPartition_traverse (TopicPartition *self,
 
 
 static PyMemberDef TopicPartition_members[] = {
-        { "topic", T_STRING, offsetof(TopicPartition, topic), READONLY,
-          ":py:attribute:topic - Topic name (string)" },
-        { "partition", T_INT, offsetof(TopicPartition, partition), 0,
-          ":py:attribute: Partition number (int)" },
-        { "offset", T_LONGLONG, offsetof(TopicPartition, offset), 0,
-          " :py:attribute: Offset (long)\n"
-          "Either an absolute offset (>=0) or a logical offset:"
-          " :py:const:`OFFSET_BEGINNING`,"
-          " :py:const:`OFFSET_END`,"
-          " :py:const:`OFFSET_STORED`,"
-          " :py:const:`OFFSET_INVALID`"
-        },
-        { "error", T_OBJECT, offsetof(TopicPartition, error), READONLY,
-          ":py:attribute: Indicates an error (with :py:class:`KafkaError`) unless None." },
-        { NULL }
+	{ "topic", T_STRING, offsetof(TopicPartition, topic), READONLY,
+	  ":py:attribute:topic - Topic name (string)" },
+	{ "partition", T_INT, offsetof(TopicPartition, partition), 0,
+	  ":py:attribute: Partition number (int)" },
+	{ "offset", T_LONGLONG, offsetof(TopicPartition, offset), 0,
+	  " :py:attribute: Offset (long)\n"
+	  "Either an absolute offset (>=0) or a logical offset:"
+	  " :py:const:`OFFSET_BEGINNING`,"
+	  " :py:const:`OFFSET_END`,"
+	  " :py:const:`OFFSET_STORED`,"
+	  " :py:const:`OFFSET_INVALID`"
+	},
+	{ "error", T_OBJECT, offsetof(TopicPartition, error), READONLY,
+	  ":py:attribute: Indicates an error (with :py:class:`KafkaError`) unless None." },
+	{ NULL }
 };
 
 
 static PyObject *TopicPartition_str0 (TopicPartition *self) {
-        PyObject *errstr = NULL;
-        PyObject *errstr8 = NULL;
-        const char *c_errstr = NULL;
+	PyObject *errstr = NULL;
+	PyObject *errstr8 = NULL;
+	const char *c_errstr = NULL;
 	PyObject *ret;
 	char offset_str[40];
 
 	snprintf(offset_str, sizeof(offset_str), "%"PRId64"", self->offset);
 
-        if (self->error != Py_None) {
-                errstr = cfl_PyObject_Unistr(self->error);
-                c_errstr = cfl_PyUnistr_AsUTF8(errstr, &errstr8);
-        }
+	if (self->error != Py_None) {
+		errstr = cfl_PyObject_Unistr(self->error);
+		c_errstr = cfl_PyUnistr_AsUTF8(errstr, &errstr8);
+	}
 
 	ret = cfl_PyUnistr(
 		_FromFormat("TopicPartition{topic=%s,partition=%"PRId32
@@ -738,8 +737,8 @@ static PyObject *TopicPartition_str0 (TopicPartition *self) {
 			    self->topic, self->partition,
 			    offset_str,
 			    c_errstr ? c_errstr : "None"));
-        Py_XDECREF(errstr8);
-        Py_XDECREF(errstr);
+	Py_XDECREF(errstr8);
+	Py_XDECREF(errstr);
 	return ret;
 }
 

--- a/confluent_kafka/src/confluent_kafka.c
+++ b/confluent_kafka/src/confluent_kafka.c
@@ -340,8 +340,6 @@ static PyObject *Message_headers (Message *self, PyObject *ignore) {
 		return self->headers;
 	} else if (self->c_headers) {
 		self->headers = c_headers_to_py(self->c_headers);
-		rd_kafka_headers_destroy(self->c_headers);
-		self->c_headers = NULL;
 		Py_INCREF(self->headers);
 		return self->headers;
 	} else {

--- a/confluent_kafka/src/confluent_kafka.h
+++ b/confluent_kafka/src/confluent_kafka.h
@@ -17,6 +17,7 @@
 #include <Python.h>
 #include <structmember.h>
 #include <pythread.h>
+#include <stdbool.h>
 
 #include <librdkafka/rdkafka.h>
 
@@ -302,7 +303,7 @@ typedef struct {
 
 extern PyTypeObject MessageType;
 
-PyObject *Message_new0 (const Handle *handle, const rd_kafka_message_t *rkm);
+PyObject *Message_new0 (const Handle *handle, rd_kafka_message_t *rkm, bool detach_headers);
 PyObject *Message_error (Message *self, PyObject *ignore);
 
 

--- a/confluent_kafka/src/confluent_kafka.h
+++ b/confluent_kafka/src/confluent_kafka.h
@@ -271,6 +271,7 @@ rd_kafka_topic_partition_list_t *py_to_c_parts (PyObject *plist);
 #ifdef RD_KAFKA_V_HEADERS
 rd_kafka_headers_t *py_headers_to_c (PyObject *headers_plist);
 PyObject *c_headers_to_py (rd_kafka_headers_t *headers);
+rd_kafka_headers_t *parse_dict_headers (PyObject *headers);
 #endif
 /****************************************************************************
  *

--- a/examples/integration_test.py
+++ b/examples/integration_test.py
@@ -522,7 +522,7 @@ def verify_consumer():
             break
 
     assert example_header, "We should have received at least one header"
-    assert example_header == [(u'foo1', 'bar'), (u'foo1', 'bar2'), (u'foo2', '1')]
+    assert example_header == [(u'foo1', b'bar'), (u'foo1', b'bar2'), (u'foo2', b'1')]
 
     # Get current assignment
     assignment = c.assignment()

--- a/examples/integration_test.py
+++ b/examples/integration_test.py
@@ -117,7 +117,7 @@ def verify_producer():
     p = confluent_kafka.Producer(**conf)
     print('producer at %s' % p)
 
-    headers = [('foo1', 'bar'), ('foo1', 'bar2'), ('foo2', b'1')]
+    headers = [('foo1', b'bar'), ('foo1', b'bar2'), ('foo2', b'1')]
 
     # Produce some messages
     p.produce(topic, 'Hello Python!', headers=headers)
@@ -486,8 +486,8 @@ def verify_consumer():
         if headers:
             example_header = headers
 
-        msg.set_headers([('foo', 'bar')])
-        assert msg.headers() == [('foo', 'bar')]
+        msg.set_headers([('foo', b'bar')])
+        assert msg.headers() == [('foo', b'bar')]
 
         print('%s[%d]@%d: key=%s, value=%s, tstype=%d, timestamp=%s headers=%s' %
               (msg.topic(), msg.partition(), msg.offset(),

--- a/tests/test_Producer.py
+++ b/tests/test_Producer.py
@@ -65,9 +65,9 @@ def test_produce_headers():
                   'error_cb': error_cb,
                   'default.topic.config': {'message.timeout.ms': 10}})
 
-    p.produce('mytopic', value='somedata', key='a key', headers=[('headerkey', 'headervalue')])
-    p.produce('mytopic', value='somedata', key='a key', headers=[('dupkey', 'dupvalue'), ('dupkey', 'dupvalue')])
-    p.produce('mytopic', value='somedata', key='a key', headers=[('dupkey', 'dupvalue'), ('dupkey', 'diffvalue')])
+    p.produce('mytopic', value='somedata', key='a key', headers=[('headerkey', b'headervalue')])
+    p.produce('mytopic', value='somedata', key='a key', headers=[('dupkey', b'dupvalue'), ('dupkey', b'dupvalue')])
+    p.produce('mytopic', value='somedata', key='a key', headers=[('dupkey', b'dupvalue'), ('dupkey', b'diffvalue')])
     p.produce('mytopic', value='somedata', key='a key', headers=[('key_with_null_value', None)])
     p.produce('mytopic', value='somedata', key='a key', headers=[])
 
@@ -88,7 +88,7 @@ def test_produce_headers_should_fail():
                   'default.topic.config': {'message.timeout.ms': 10}})
 
     with pytest.raises(NotImplementedError) as e:
-        p.produce('mytopic', value='somedata', key='a key', headers=[('headerkey', 'headervalue')])
+        p.produce('mytopic', value='somedata', key='a key', headers=[('headerkey', b'headervalue')])
     assert 'Producer message headers requires confluent-kafka-python built for librdkafka version >=v0.11.4' in str(e)
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = flake8,py27,py34,py35
+envlist = flake8,py27,py34,py35,py36
 
 [testenv]
 setenv =
@@ -30,6 +30,11 @@ deps =
     avro-python3
 
 [testenv:py35]
+deps =
+    {[base]deps}
+    avro-python3
+
+[testenv:py36]
 deps =
     {[base]deps}
     avro-python3


### PR DESCRIPTION
This is an adaption of the parts from my PR #315 that I think are still useful.  It passes the current tests, but I should add some for `headers_dict()` and passing headers as a dict.  I've tested it primarily in Python 3.6, so I should spend some time with it in Python 2.7.  Usage is similar, but `headers()` is now `headers_dict()`.
```Python
p = Producer(...)
p.produce("topic", "message 1", headers={"k1": b"v1"})
p.produce("topic", "message 2", headers=[("k1", b"v1"), ("k1", b"v2")])

c = Consumer(...)
c.subscribe(['topic'])
m = c.poll()
m.value()
# b'message 1'
m.headers_dict()
# {'k1': b'v1'}
m.headers
# [('k1', b'v1')]
m = c.poll()
m.value()
# b'message 2'
m.headers_dict()
# {'k1': b'v2'}
m.headers()
# [('k1', b'v1'), ('k1', b'v2')]
```