### PR TITLE
Check that produce headers are of correct type

### DIFF
--- a/confluent_kafka/src/confluent_kafka.c
+++ b/confluent_kafka/src/confluent_kafka.c
@@ -951,16 +951,22 @@ rd_kafka_headers_t *py_headers_to_c (PyObject *headers_plist) {
     const char *header_key, *header_value = NULL;
     int header_key_len = 0, header_value_len = 0;
 
+    if (!PyList_Check(headers_plist)) {
+            PyErr_SetString(PyExc_TypeError,
+                            "Headers are expected to be a "
+                            "list of (key,value) tuples");
+            return NULL;
+    }
+
     len = PyList_Size(headers_plist);
     rd_headers = rd_kafka_headers_new(len);
 
     for (i = 0; i < len; i++) {
-
         if(!PyArg_ParseTuple(PyList_GET_ITEM(headers_plist, i), "s#z#", &header_key,
                 &header_key_len, &header_value, &header_value_len)){
             rd_kafka_headers_destroy(rd_headers);
             PyErr_SetString(PyExc_TypeError,
-                    "Headers are expected to be a tuple of (key, value)");
+                    "Headers are expected to be a list of (key,value) tuples");
             return NULL;
         }
 

--- a/tests/test_Producer.py
+++ b/tests/test_Producer.py
@@ -72,8 +72,12 @@ def test_produce_headers():
     p.produce('mytopic', value='somedata', key='a key', headers=[])
 
     with pytest.raises(TypeError) as ex:
+        p.produce('mytopic', value='somedata', key='a key', headers={'my': 'dict'})
+    assert 'Headers are expected to be a list of (key,value) tuples' == str(ex.value)
+
+    with pytest.raises(TypeError) as ex:
         p.produce('mytopic', value='somedata', key='a key', headers=[('malformed_header')])
-    assert 'Headers are expected to be a tuple of (key, value)' == str(ex.value)
+    assert 'Headers are expected to be a list of (key,value) tuples' == str(ex.value)
 
     p.flush()
 


### PR DESCRIPTION
This is a minimal short term fix, PR #345 fixes this and adds support for dict headers.