### PR TITLE
Set owner instead of slackChannel for system test

### DIFF
--- a/tests/system/Jenkinsfile
+++ b/tests/system/Jenkinsfile
@@ -2,7 +2,7 @@ def config = jobConfig {
     cron = '@midnight'
     nodeLabel = 'docker-oraclejdk7'
     realJobPrefixes = ['system-test-python-client']
-    slackChannel = 'clients-eng'
+    owner = 'client'
     timeoutHours = 3
 }
 


### PR DESCRIPTION
When slackChannel is set, message is sent to Slack which triggers delayed ticket creation.
As results are not reviewed from failed job, it is better to just create tickets.

The owner field tells Testbreak who to assign the tickets to.

Depends on https://github.com/confluentinc/kiosk/pull/62