### PR TITLE
[Issues/372] Bad code in schema registry client

### DIFF
--- a/confluent_kafka/avro/cached_schema_registry_client.py
+++ b/confluent_kafka/avro/cached_schema_registry_client.py
@@ -301,6 +301,7 @@ class CachedSchemaRegistryClient(object):
         Get the current compatibility level for a subject.  Result will be one of:
 
         @:param: subject: subject name
+        @:raises: ClientError: if the request was unsuccessful or an invalid compatibility level was returned
         @:return: 'NONE','FULL','FORWARD', or 'BACKWARD'
         """
         url = '/'.join([self.url, 'config'])
@@ -308,10 +309,16 @@ class CachedSchemaRegistryClient(object):
             url += '/' + subject
 
         result, code = self._send_request(url)
-        if code >= 200 and code <= 299:
-            compatibility = result.get('compatibility', None)
+        is_successful_request = code >= 200 and code <= 299
+        if not is_successful_request:
+            raise ClientError('Unable to fetch compatibility level. Error code: %d' % code)
 
-        if not compatibility:
-            compatibility = result.get('compatibilityLevel')
+        compatibility = result.get('compatibility', None)
+        if compatibility not in VALID_LEVELS:
+            if compatibility is None:
+                error_msg_suffix = 'No compatibility was returned'
+            else:
+                error_msg_suffix = str(compatibility)
+            raise ClientError('Invalid compatibility level received: %s' % error_msg_suffix)
 
         return compatibility

--- a/confluent_kafka/avro/cached_schema_registry_client.py
+++ b/confluent_kafka/avro/cached_schema_registry_client.py
@@ -267,8 +267,8 @@ class CachedSchemaRegistryClient(object):
             elif code >= 200 and code <= 299:
                 return result.get('is_compatible')
             else:
-                log.error("Unable to check the compatibility")
-                False
+                log.error("Unable to check the compatibility: " + str(code))
+                return False
         except Exception as e:
             log.error("_send_request() failed: %s", e)
             return False


### PR DESCRIPTION
Fixes #372 

- Return `False` instead of `None` when unable to check compatibility
- Fix unassigned variable problem when request inside `get_compatibility()` returns a non-successful status code.

I tried to implement tests for `get_compatibility()` but I could not figure out what would be a proper way to implement `MockSchemaRegistryClient#get_compatibility()`, as I do not grasp the way the schema registry works and would rather not implement some hardcoded mock value like
```
if subject is None: return { 'compatibility': 'NONE', 'compatibilityLevel': -1}
else ...
```