### PR TITLE
Initial POC for generic serde support

### DIFF
--- a/confluent_kafka/__init__.py
+++ b/confluent_kafka/__init__.py
@@ -1,9 +1,7 @@
 __all__ = ['cimpl', 'avro', 'kafkatest']
-from .cimpl import (Consumer,  # noqa
-                    KafkaError,
+from .cimpl import (KafkaError,  # noqa
                     KafkaException,
                     Message,
-                    Producer,
                     TopicPartition,
                     libversion,
                     version,
@@ -15,5 +13,7 @@ from .cimpl import (Consumer,  # noqa
                     OFFSET_STORED,
                     OFFSET_INVALID)
 
+from confluent_kafka.producer import Producer  # noqa
+from confluent_kafka.consumer import Consumer  # noqa
 
 __version__ = version()[0]

--- a/confluent_kafka/consumer.py
+++ b/confluent_kafka/consumer.py
@@ -1,0 +1,35 @@
+from .cimpl import ConsumerImpl
+from confluent_kafka.serializer import Deserializer
+
+
+class Consumer(ConsumerImpl):
+    def __init__(self, *args, **kwargs):
+        self.conf = {
+            'key_deserializer': Deserializer.verify(kwargs.pop("key_deserializer", None), True),
+            'value_deserializer': Deserializer.verify(kwargs.pop("value_deserializer", None)),
+        }
+        super(Consumer, self).__init__(*args, **kwargs)
+
+    @staticmethod
+    def _decode(s, topic, payload):
+        if s is None or payload is None:
+            return payload
+        return s.deserialize(topic, payload)
+
+    def poll(self, timeout=-1):
+        msg = super(Consumer, self).poll(timeout)
+
+        # Bypass the remaining logic if there are no serializers configured
+        if msg is not None:
+            if self.conf['key_deserializer'] is None and self.conf['value_deserializer'] is None:
+                return msg
+
+            if not msg.value() and not msg.key():
+                return msg
+            if not msg.error():
+                if msg.value() is not None:
+                    msg.set_value(self._decode(self.conf['key_deserializer'], msg.topic(), msg.value()))
+                if msg.key() is not None:
+                    msg.set_key(self._decode(self.conf['value_deserializer'], msg.topic(), msg.key()))
+            return msg
+        return msg

--- a/confluent_kafka/producer.py
+++ b/confluent_kafka/producer.py
@@ -1,0 +1,29 @@
+from .cimpl import ProducerImpl
+from confluent_kafka.serializer import Serializer
+
+
+class Producer(ProducerImpl):
+    def __init__(self, *args, **kwargs):
+        self.conf = {
+            'key_serializer': Serializer.verify(kwargs.pop("key_serializer", None), True),
+            'value_serializer': Serializer.verify(kwargs.pop("value_serializer", None)),
+        }
+        super(Producer, self).__init__(*args, **kwargs)
+
+    @staticmethod
+    def _encode(s, topic, payload):
+        if s is None or payload is None:
+            return payload
+        return s.serialize(topic, payload)
+
+    def produce(self, topic, value=None, key=None, *args, **kwargs):
+        # Bypass the remaining logic if there are no serializers configured
+        if (self.conf['key_serializer'] is None and self.conf['value_serializer']) is None:
+            return super(Producer, self).produce(topic, value, key, *args, **kwargs)
+
+        value_data = self._encode(self.conf['key_serializer'], topic,
+                                  kwargs.pop('value', value))
+        key_data = self._encode(self.conf['key_serializer'], topic,
+                                kwargs.pop('key', key))
+
+        super(Producer, self).produce(topic, value_data, key_data, *args[3:], **kwargs)

--- a/confluent_kafka/serializer/__init__.py
+++ b/confluent_kafka/serializer/__init__.py
@@ -1,0 +1,53 @@
+from abc import ABCMeta, abstractmethod
+
+
+class Serializer(object):
+    __meta__ = ABCMeta
+
+    def __init__(self, **config):
+        pass
+
+    @abstractmethod
+    def serialize(self, topic, value):
+        pass
+
+    @classmethod
+    def verify(cls, obj, is_key=False):
+        if obj is None:
+            return None
+
+        if isinstance(obj, Serializer):
+            return obj
+
+        raise ValueError(
+            '{}_serializer must register with or extend Serialize abstract base class'.format('key' if is_key
+                                                                                              else 'value'))
+
+    def close(self):
+        pass
+
+
+class Deserializer(object):
+    __meta__ = ABCMeta
+
+    def __init__(self, **config):
+        pass
+
+    @abstractmethod
+    def deserialize(self, topic, value):
+        pass
+
+    @classmethod
+    def verify(cls, obj, is_key=False):
+        if obj is None:
+            return None
+
+        if isinstance(obj, Deserializer):
+            return obj
+
+        raise ValueError(
+            '{}_deserializer must implement Deserializer abstract base class'.format('key' if is_key
+                                                                                     else 'value'))
+
+    def close(self):
+        pass

--- a/confluent_kafka/src/Consumer.c
+++ b/confluent_kafka/src/Consumer.c
@@ -1383,7 +1383,7 @@ static PyObject *Consumer_new (PyTypeObject *type, PyObject *args,
 
 PyTypeObject ConsumerType = {
 	PyVarObject_HEAD_INIT(NULL, 0)
-	"cimpl.Consumer",        /*tp_name*/
+        "cimpl.ConsumerImpl",        /*tp_name*/
 	sizeof(Handle),          /*tp_basicsize*/
 	0,                         /*tp_itemsize*/
 	(destructor)Consumer_dealloc, /*tp_dealloc*/

--- a/confluent_kafka/src/Producer.c
+++ b/confluent_kafka/src/Producer.c
@@ -605,7 +605,7 @@ static PyObject *Producer_new (PyTypeObject *type, PyObject *args,
 
 PyTypeObject ProducerType = {
 	PyVarObject_HEAD_INIT(NULL, 0)
-	"cimpl.Producer",        /*tp_name*/
+        "cimpl.ProducerImpl",        /*tp_name*/
 	sizeof(Handle),      /*tp_basicsize*/
 	0,                         /*tp_itemsize*/
 	(destructor)Producer_dealloc, /*tp_dealloc*/

--- a/confluent_kafka/src/confluent_kafka.c
+++ b/confluent_kafka/src/confluent_kafka.c
@@ -1904,10 +1904,10 @@ static PyObject *_init_cimpl (void) {
 			   (PyObject *)&TopicPartitionType);
 
 	Py_INCREF(&ProducerType);
-	PyModule_AddObject(m, "Producer", (PyObject *)&ProducerType);
+        PyModule_AddObject(m, "ProducerImpl", (PyObject *)&ProducerType);
 
 	Py_INCREF(&ConsumerType);
-	PyModule_AddObject(m, "Consumer", (PyObject *)&ConsumerType);
+        PyModule_AddObject(m, "ConsumerImpl", (PyObject *)&ConsumerType);
 
 #if PY_VERSION_HEX >= 0x02070000
 	KafkaException = PyErr_NewExceptionWithDoc(


### PR DESCRIPTION
Rough draft for Generic SERDE support. In retrospect its probably a good idea to allow simply passing a dict to the serializer as serializer_opts from the application. This adds a lot more flexibility and could facilitate per produce request overrides such as the schemas passed to the AvroProducer.produce() function. 

i.e. `serialize(**kwargs)` 

Before going to deep into this I wanted get some initial comments on the implementation though. 