### PR TITLE
Allow non avro schema key in avro producer

### DIFF
--- a/confluent_kafka/avro/__init__.py
+++ b/confluent_kafka/avro/__init__.py
@@ -2,6 +2,7 @@
     Avro schema registry module: Deals with encoding and decoding of messages with avro schemas
 
 """
+from six import string_types
 
 from confluent_kafka import Producer, Consumer
 from confluent_kafka.avro.error import ClientError
@@ -68,8 +69,8 @@ class AvroProducer(Producer):
         if key is not None:
             if key_schema:
                 key = self._serializer.encode_record_with_schema(topic, key_schema, key, True)
-            else:
-                raise KeySerializerError("Avro schema required for key")
+            elif not isinstance(key, string_types):
+                raise KeySerializerError("Avro schema required for non string type key")
 
         super(AvroProducer, self).produce(topic, value, key, **kwargs)
 

--- a/tests/avro/test_avro_producer.py
+++ b/tests/avro/test_avro_producer.py
@@ -108,14 +108,6 @@ class TestAvroProducer(unittest.TestCase):
         with self.assertRaises(ValueSerializerError):
             producer.produce(topic='test', value='', key='not empty')
 
-    def test_produce_with_empty_key_no_schema(self):
-        value_schema = avro.load(os.path.join(avsc_dir, "primitive_float.avsc"))
-        schema_registry = MockSchemaRegistryClient()
-        producer = AvroProducer({}, schema_registry=schema_registry,
-                                default_value_schema=value_schema)
-        with self.assertRaises(KeySerializerError):
-            producer.produce(topic='test', value=0.0, key='')
-
     def test_produce_with_empty_key_value_with_schema(self):
         key_schema = avro.load(os.path.join(avsc_dir, "primitive_string.avsc"))
         value_schema = avro.load(os.path.join(avsc_dir, "primitive_float.avsc"))
@@ -124,3 +116,10 @@ class TestAvroProducer(unittest.TestCase):
                                 default_key_schema=key_schema,
                                 default_value_schema=value_schema)
         producer.produce(topic='test', value=0.0, key='')
+
+    def test_produce_only_value_with_schema(self):
+        value_schema = avro.load(os.path.join(avsc_dir, "primitive_float.avsc"))
+        schema_registry = MockSchemaRegistryClient()
+        producer = AvroProducer({}, schema_registry=schema_registry,
+                                default_value_schema=value_schema)
+        producer.produce(topic='test', value=0.0, key='test_key_plain_string')


### PR DESCRIPTION
As brought up in #211, as KSQL can only handle topics with plain string keys but avro schema values, the avro producer should allow keys with plain strings. 
This PR drops the explicit check if the key has an avro schema and only throws an KeySerializerError if the key is not a string type.