### PR TITLE
Optionally return schemas with AvroProducer

### DIFF
--- a/confluent_kafka/avro/__init__.py
+++ b/confluent_kafka/avro/__init__.py
@@ -148,7 +148,8 @@ class AvroConsumer(Consumer):
         deserialization using avro schema
 
         :param float timeout: Poll timeout in seconds (default: indefinite)
-        :param boolean with_schema: If true, the key_schema and value_schema are added as properties of the message (default: False)
+        :param boolean with_schema: If true, the key_schema and value_schema are added as properties of the message
+                                    (default: False)
         :returns: message object with deserialized key and value as dict objects
         :rtype: Message or AvroMessage
         """


### PR DESCRIPTION
When calling poll, with_schemas kwarg may be provided to return a proxy for the message.  That proxy includes both the key_schema and value_schema as properties.  The raw message is also available as a property, and all other calls are delegated to the message.

This PR is particularly helpful along with #401.  Together they allow you to push multiple message types to the same topic and to be able to understand what you are getting back when consume from that topic.

Note: #289 suggests making AvroMessage a sub-class of confluent_kafka.cimpl.Message, but I could not find any way to make this work.  This version has it delegate with access to the original if desired for performance reasons.  In order to prevent this being a breaking change, the AvroMessage version of the message is only returned if schemas are explicitly requested. 