### PR TITLE
Support encoding with fastavro, fix minor doc bug

### DIFF
--- a/confluent_kafka/avro/serializer/message_serializer.py
+++ b/confluent_kafka/avro/serializer/message_serializer.py
@@ -108,7 +108,8 @@ class MessageSerializer(object):
             raise serialize_err(message)
 
         # cache writer
-        self.id_to_writers[schema_id] = self.make_datum_writer(schema)
+        if id not in self.id_to_writers:
+            self.id_to_writers[schema_id] = self.make_datum_writer(schema)
 
         return self.encode_record_with_schema_id(schema_id, record, is_key=is_key)
 


### PR DESCRIPTION
This PR adds the ability to encode with fastavro, if it is available. Also, fixes a minor misprecision in the docstring for `encode_record_with_schema_id`.