### PR TITLE
Safely release resources in Handle_clear

### DIFF
--- a/confluent_kafka/src/confluent_kafka.c
+++ b/confluent_kafka/src/confluent_kafka.c
@@ -1324,16 +1324,25 @@ static void log_cb (const rd_kafka_t *rk, int level,
  * Clear Python object references in Handle
  */
 void Handle_clear (Handle *h) {
-	if (h->error_cb)
-		Py_DECREF(h->error_cb);
+        if (h->error_cb) {
+                Py_DECREF(h->error_cb);
+                h->error_cb = NULL;
+        }
 
-        if (h->throttle_cb)
+        if (h->throttle_cb) {
                 Py_DECREF(h->throttle_cb);
+                h->throttle_cb = NULL;
+        }
 
-	if (h->stats_cb)
-		Py_DECREF(h->stats_cb);
+        if (h->stats_cb) {
+                Py_DECREF(h->stats_cb);
+                h->stats_cb = NULL;
+        }
 
-        Py_XDECREF(h->logger);
+        if (h->logger) {
+                Py_DECREF(h->logger);
+                h->logger = NULL;
+        }
 
         if (h->initiated) {
 #ifdef WITH_PY_TSS

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = flake8,py27,py34,py35
+envlist = flake8,py27,py34,py35,py36
 
 [testenv]
 setenv =
@@ -34,6 +34,11 @@ deps =
     avro-python3
 
 [testenv:py35]
+deps =
+    {[base]deps}
+    avro-python3
+
+[testenv:py36]
 deps =
     {[base]deps}
     avro-python3


### PR DESCRIPTION
During tests we create and destroy instances of `Consumer` and `Producer` on every test case. We noticed segfaults and memory corruption (the `logger` pointer was referring to other random objects).

This seems to be due to the case where both `tp_clear` and `tp_dealloc` are called on the handle, resulting in a double release of `error_cb`, `stats_cb` and `logger`. I've tested this locally and have not encountered the segfaults/memory corruption since.