### PR TITLE
travis: Install virtualenv on osx

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ matrix:
     before_install:
         - brew update && brew upgrade pyenv
         - pyenv install -f 2.7.15
+        - pip install virtualenv
         - virtualenv -p ~/.pyenv/versions/2.7.15/bin/python ./env
         - source env/bin/activate
   # Source package verification with Python 3.6 and librdkafka v0.11.5
@@ -28,11 +29,15 @@ matrix:
     before_install:
         - brew update && brew upgrade pyenv
         - pyenv install -f 3.6.5
+        - pip install virtualenv
         - virtualenv -p ~/.pyenv/versions/3.6.5/bin/python ./env
         - source env/bin/activate
   # cibuildwheel for osx
   - os: osx
     env: CIBW_BEFORE_BUILD="tools/bootstrap-librdkafka.sh --require-ssl v0.11.5 tmp" CFLAGS="-Itmp/include" LDFLAGS="-Ltmp/lib"
+    before_install:
+        - brew update && brew upgrade pyenv
+        - pip install virtualenv
   # cibuildwheel for manylinux
   - os: linux
     dist: trusty


### PR DESCRIPTION
travis changed their osx image not to include virtualenv by default, it seems.
