### PR TITLE
Issue #449: AvroConsumer: provide method to get schemas from last message decode

### DIFF
--- a/confluent_kafka/avro/serializer/message_serializer.py
+++ b/confluent_kafka/avro/serializer/message_serializer.py
@@ -74,6 +74,7 @@ class MessageSerializer(object):
         self.id_to_writers = {}
         self.reader_key_schema = reader_key_schema
         self.reader_value_schema = reader_value_schema
+        self.last_decode_schema_id = None
 
     # Encoder support
     def _get_encoder_func(self, writer_schema):
@@ -224,4 +225,5 @@ class MessageSerializer(object):
             if magic != MAGIC_BYTE:
                 raise SerializerError("message does not start with magic byte")
             decoder_func = self._get_decoder_func(schema_id, payload, is_key)
+            self.last_decode_schema_id = schema_id
             return decoder_func(payload)


### PR DESCRIPTION
This is an alternative take on issue #449 that tries to address some concerns raised in PR #453 :
- overhead is minimal (no mixins, no dynamic wrapper type creation and other magic), so not being able to turn it off is less of a concern
- no non-optional `_schema` attribute on the wrapper that might cause collisions or raise code style complaints for accessing a "private" attribute

On the other hand, this solution is conceptually bit uglier than #453 as the schema (id) is not associated with the returned message directly and has to be requested with an explicit calls.

Very rough usage example:
```python
consumer = AvroConsumer()

# Get a message
msg = consumer.poll()

# Get key/value schema ids and schema objects
key_sid, value_sid = consumer.last_decode_schema_ids
key_schema, value_schema = consumer.last_decode_schemas()
```

