### PR TITLE
Remove two default.topic.config uses

### DIFF
--- a/examples/integration_test.py
+++ b/examples/integration_test.py
@@ -1210,7 +1210,8 @@ def verify_avro_explicit_read_schema():
     conf = {'bootstrap.servers': bootstrap_servers,
             'error_cb': error_cb,
             'api.version.request': api_version_request,
-            'default.topic.config': {'produce.offset.report': True}}
+            'produce.offset.report': True
+            }
 
     # Create producer
     if schema_registry_url:
@@ -1247,9 +1248,8 @@ def verify_avro_explicit_read_schema():
                  'api.version.request': api_version_request,
                  'on_commit': print_commit_result,
                  'error_cb': error_cb,
-                 'default.topic.config': {
-                     'auto.offset.reset': 'earliest'
-                 }}
+                 'auto.offset.reset': 'earliest'
+                 }
 
     for i, combo in enumerate(combinations):
         reader_key_schema = combo.pop("reader_key_schema")


### PR DESCRIPTION
as outlined in 34baea6 (#446)

Having to add the `default.topic.config` dictionary really caught me off guard, so I'm really happy to see that this is going to be removed in 1.0 :heart: 