### PR TITLE
update, fix cached registry client and ClientError

### DIFF
--- a/confluent_kafka/avro/cached_schema_registry_client.py
+++ b/confluent_kafka/avro/cached_schema_registry_client.py
@@ -343,10 +343,10 @@ class CachedSchemaRegistryClient(object):
 
         result, code = self._send_request(url, method='POST', body=body)
         if code == 404:
-            log.error("Schema for {} Not found. Error code: {}".format(subject, code))
+            log.error("Schema for subject '{}' not found. Error code: {}".format(subject, code))
             return None
         elif not (200 <= code <= 299):
-            log.error("Unable to get version of the {} schema. Error code: ".format(subject, code))
+            log.error("Unable to get version for the '{}' schema. Error code: ".format(subject, code))
             return None
         schema_id = result['id']
         version = result['version']
@@ -386,11 +386,12 @@ class CachedSchemaRegistryClient(object):
             log.error("_send_request() failed: %s", e)
             return False
 
-    def update_compatibility(self, level):
+    def update_compatibility(self, level, subject=None):
         """
-        PUT /config
+        PUT /config/(string: subject)
 
-        Update the compatibility level for a subject.
+        Update the subject-level compatibility level if subject is specified. Otherwise, update the global
+        compatibility level.
 
         :param str level: ex: 'NONE','FULL','FORWARD', or 'BACKWARD'
         :raises: ClientError: if request was unsuccessful or an invalid compatibility level was provided
@@ -409,10 +410,11 @@ class CachedSchemaRegistryClient(object):
         else:
             raise ClientError("Unable to update level: {}".format(level), code)
 
-    def get_compatibility(self):
+    def get_compatibility(self, subject=None):
         """
-        GET /config
-        Get the current global compatibility level for the schema registry.
+        GET /config/(string: subject)
+        Get the current subject-level compatibility level if subject is specified. Otherwise, get the current global
+        compatibility level for the schema registry.
 
         :raises: ClientError: if the request was unsuccessful or an invalid compatibility level was returned
         :returns: one of 'NONE','FULL','FORWARD', or 'BACKWARD'

--- a/confluent_kafka/avro/cached_schema_registry_client.py
+++ b/confluent_kafka/avro/cached_schema_registry_client.py
@@ -26,8 +26,8 @@ from collections import defaultdict
 
 from requests import Session, utils
 
-from .error import ClientError
 from . import loads
+from .error import ClientError
 
 # Python 2 considers int an instance of str
 try:
@@ -343,7 +343,8 @@ class CachedSchemaRegistryClient(object):
 
         result, code = self._send_request(url, method='POST', body=body)
         if code == 404:
-            log.error("Schema for subject '{}' not found. Error code: {}".format(subject, code))
+            log.error(
+                "Either subject itself or schema for subject '{}' not found. Error code: {}".format(subject, code))
             return None
         elif not (200 <= code <= 299):
             log.error("Unable to get version for the '{}' schema. Error code: ".format(subject, code))

--- a/confluent_kafka/avro/error.py
+++ b/confluent_kafka/avro/error.py
@@ -20,7 +20,10 @@ class ClientError(Exception):
     """ Error thrown by Schema Registry clients """
 
     def __init__(self, message, http_code=None):
-        self.message = message
+        if http_code:
+            self.message = '{}. Error code: {}'.format(message, str(http_code))
+        else:
+            self.message = message
         self.http_code = http_code
         super(ClientError, self).__init__(self.__str__())
 

--- a/confluent_kafka/avro/error.py
+++ b/confluent_kafka/avro/error.py
@@ -20,10 +20,10 @@ class ClientError(Exception):
     """ Error thrown by Schema Registry clients """
 
     def __init__(self, message, http_code=None):
+        self.message = message
         if http_code:
-            self.message = '{}. Error code: {}'.format(message, str(http_code))
-        else:
-            self.message = message
+            self.message += '. Error code: {}'.format(str(http_code))
+
         self.http_code = http_code
         super(ClientError, self).__init__(self.__str__())
 

--- a/confluent_kafka/avro/error.py
+++ b/confluent_kafka/avro/error.py
@@ -21,7 +21,7 @@ class ClientError(Exception):
 
     def __init__(self, message, http_code=None):
         self.message = message
-        if http_code:
+        if http_code is not None:
             self.message += '. Error code: {}'.format(str(http_code))
 
         self.http_code = http_code

--- a/tests/avro/mock_schema_registry_client.py
+++ b/tests/avro/mock_schema_registry_client.py
@@ -142,8 +142,8 @@ class MockSchemaRegistryClient(object):
     def test_compatibility(self, subject, avro_schema, version='latest'):
         raise ClientError("not implemented")
 
-    def update_compatibility(self, level, subject=None):
+    def update_compatibility(self, level):
         raise ClientError("not implemented")
 
-    def get_compatibility(self, subject=None):
+    def get_compatibility(self):
         raise ClientError("not implemented")

--- a/tests/avro/mock_schema_registry_client.py
+++ b/tests/avro/mock_schema_registry_client.py
@@ -142,8 +142,8 @@ class MockSchemaRegistryClient(object):
     def test_compatibility(self, subject, avro_schema, version='latest'):
         raise ClientError("not implemented")
 
-    def update_compatibility(self, level):
+    def update_compatibility(self, level, subject=None):
         raise ClientError("not implemented")
 
-    def get_compatibility(self):
+    def get_compatibility(self, subject=None):
         raise ClientError("not implemented")

--- a/tests/avro/test_cached_client.py
+++ b/tests/avro/test_cached_client.py
@@ -22,10 +22,10 @@
 
 import unittest
 
-from tests.avro import mock_registry
-from tests.avro import data_gen
-from confluent_kafka.avro.cached_schema_registry_client import CachedSchemaRegistryClient
 from confluent_kafka import avro
+from confluent_kafka.avro.cached_schema_registry_client import CachedSchemaRegistryClient
+from tests.avro import data_gen
+from tests.avro import mock_registry
 
 
 class TestCacheSchemaRegistryClient(unittest.TestCase):
@@ -138,16 +138,16 @@ class TestCacheSchemaRegistryClient(unittest.TestCase):
         self.assertTupleEqual(('/path/to/cert', '/path/to/key'), self.client._session.cert)
 
     def test_cert_path(self):
-            self.client = CachedSchemaRegistryClient(url='https://127.0.0.1:65534',
-                                                     ca_location='/path/to/ca')
-            self.assertEqual('/path/to/ca', self.client._session.verify)
+        self.client = CachedSchemaRegistryClient(url='https://127.0.0.1:65534',
+                                                 ca_location='/path/to/ca')
+        self.assertEqual('/path/to/ca', self.client._session.verify)
 
     def test_context(self):
-            with self.client as c:
-                parsed = avro.loads(data_gen.BASIC_SCHEMA)
-                schema_id = c.register('test', parsed)
-                self.assertTrue(schema_id > 0)
-                self.assertEqual(len(c.id_to_schema), 1)
+        with self.client as c:
+            parsed = avro.loads(data_gen.BASIC_SCHEMA)
+            schema_id = c.register('test', parsed)
+            self.assertTrue(schema_id > 0)
+            self.assertEqual(len(c.id_to_schema), 1)
 
     def test_init_with_dict(self):
         self.client = CachedSchemaRegistryClient({
@@ -172,7 +172,7 @@ class TestCacheSchemaRegistryClient(unittest.TestCase):
         with self.assertRaises(TypeError):
             self.client = CachedSchemaRegistryClient({
                 "url": 1
-                })
+            })
 
     def test_invalid_url(self):
         with self.assertRaises(ValueError):

--- a/tests/integration/integration_test.py
+++ b/tests/integration/integration_test.py
@@ -750,9 +750,10 @@ def verify_schema_registry_client():
     latest_id, latest_schema, latest_version = sr.get_latest_schema(subject)
     assert schema == latest_schema
     assert sr.get_version(subject, schema) == latest_version
-    sr.update_compatibility("FULL", subject)
-    assert sr.get_compatibility(subject) == "FULL"
-    assert sr.test_compatibility(subject, schema)
+    new_compatibility = sr.update_compatibility("FULL")
+    assert new_compatibility == "FULL"
+    assert sr.get_compatibility() == "FULL"
+    assert sr.test_compatibility(subject, schema, latest_version)
     assert sr.delete_subject(subject) == [1]
 
 

--- a/tests/integration/integration_test.py
+++ b/tests/integration/integration_test.py
@@ -750,7 +750,7 @@ def verify_schema_registry_client():
     latest_id, latest_schema, latest_version = sr.get_latest_schema(subject)
     assert schema == latest_schema
     assert sr.get_version(subject, schema) == latest_version
-    new_compatibility = sr.update_compatibility("FULL")
+    new_compatibility = sr.update_compatibility("FULL", subject)
     assert new_compatibility == "FULL"
     assert sr.get_compatibility() == "FULL"
     assert sr.test_compatibility(subject, schema, latest_version)


### PR DESCRIPTION
- updated registry client docstrings
- removed ability specify subject when acting on /config endpoint, as it is invalid
- normalized string formatting for log.error and ClientError strings
- changed ClientError calls to use http_code param. error message changed to reflect usage
- updated involved integration test assertions to reflect new signature
- minor formatting changes