### PR TITLE
Use Environment markers instead of version_info

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,8 +5,8 @@ from setuptools import setup, find_packages
 from distutils.core import Extension
 import platform
 
-INSTALL_REQUIRES = ["futures; python_version<'3.3'",
-                    "enum34; python_version<'3.5'",
+INSTALL_REQUIRES = ['futures; python_version<"3.3"',
+                    'enum34; python_version<"3.5"',
                     'requests']
 
 # On Un*x the library is linked as -lrdkafka,
@@ -46,6 +46,6 @@ setup(name='confluent-kafka',
       data_files=[('', ['LICENSE.txt'])],
       install_requires=INSTALL_REQUIRES,
       extras_require={
-          'avro': ['fastavro', 'requests', "avro; python_version<'3'", "avro-python3; python_version>='3'"],
+          'avro': ['fastavro', 'requests', 'avro; python_version<"3"', 'avro-python3; python_version>="3"'],
           'dev': get_install_requirements("test-requirements.txt")
       })

--- a/setup.py
+++ b/setup.py
@@ -6,13 +6,9 @@ from distutils.core import Extension
 import sys
 import platform
 
-INSTALL_REQUIRES = list()
-
-if sys.version_info[0] < 3:
-    avro = 'avro'
-    INSTALL_REQUIRES.extend(['futures', 'enum34', 'requests'])
-else:
-    avro = 'avro-python3'
+INSTALL_REQUIRES = ["futures; python_version<'3.3'", 
+                    "enum34; python_version<'3.5'", 
+                    'requests'] 
 
 # On Un*x the library is linked as -lrdkafka,
 # while on windows we need the full librdkafka name.
@@ -39,7 +35,6 @@ def get_install_requirements(path):
         if req != '' and not req.startswith('#')
     ]
 
-
 setup(name='confluent-kafka',
       version='1.0.0rc7',
       description='Confluent\'s Python client for Apache Kafka',
@@ -51,6 +46,6 @@ setup(name='confluent-kafka',
       data_files=[('', ['LICENSE.txt'])],
       install_requires=INSTALL_REQUIRES,
       extras_require={
-          'avro': ['fastavro', 'requests', avro],
+          'avro': ['fastavro', 'requests', "avro; python_version<'3'", "avro-python3; python_version>='3'"],
           'dev': get_install_requirements("test-requirements.txt")
       })

--- a/setup.py
+++ b/setup.py
@@ -3,12 +3,11 @@
 import os
 from setuptools import setup, find_packages
 from distutils.core import Extension
-import sys
 import platform
 
-INSTALL_REQUIRES = ["futures; python_version<'3.3'", 
-                    "enum34; python_version<'3.5'", 
-                    'requests'] 
+INSTALL_REQUIRES = ["futures; python_version<'3.3'",
+                    "enum34; python_version<'3.5'",
+                    'requests']
 
 # On Un*x the library is linked as -lrdkafka,
 # while on windows we need the full librdkafka name.
@@ -34,6 +33,7 @@ def get_install_requirements(path):
         for req in content.split("\n")
         if req != '' and not req.startswith('#')
     ]
+
 
 setup(name='confluent-kafka',
       version='1.0.0rc7',


### PR DESCRIPTION
PEP-508 recommends Environment markers for better compatibility with modern build tools and dependency managers such as Poetry.

https://www.python.org/dev/peps/pep-0508/#environment-markers

E.g., See also: 
 - https://github.com/sdispater/poetry/issues/844
 - https://github.com/sdispater/poetry/issues/881