### PR TITLE
PyPy compat WIP

### DIFF
--- a/confluent_kafka/src/confluent_kafka.c
+++ b/confluent_kafka/src/confluent_kafka.c
@@ -47,6 +47,14 @@ PyObject *KafkaException;
  *        a new object if a rich error string is provided.
  *
  ****************************************************************************/
+
+#ifndef PyException_HEAD
+#define PyException_HEAD PyObject_HEAD PyObject *dict;\
+             PyObject *args; PyObject *traceback;\
+             PyObject *context; PyObject *cause;\
+             char suppress_context;
+#endif
+
 typedef struct {
 #ifdef PY3
         PyException_HEAD


### PR DESCRIPTION
The `PyException_HEAD` macro doesn't work with PyPy unfortunately, however defining it if it doesn't exist solves compilation problems.
I am unsure if this is a wise approach, I have limited experience with Python extensions.

I tested the consumer, producer and admin client against the following PyPy versions:
```
$ pypy --version
Python 2.7.13 (990cef41fe11e5d46b019a46aa956ff46ea1a234, Mar 18 2019, 17:41:49)
[PyPy 7.1.0 with GCC 4.2.1 Compatible Apple LLVM 10.0.0 (clang-1000.11.45.5)]
$ pypy3 --version
Python 3.6.1 (dab365a465140aa79a5f3ba4db784c4af4d5c195, Feb 18 2019, 10:53:27)
[PyPy 7.0.0-alpha0 with GCC 4.2.1 Compatible Apple LLVM 10.0.0 (clang-1000.11.45.5)]
```

This macro appears to be missing I think due to the fact PyPy only supports CPython's "limited" API.
I am unsure if there is a way to accomplish inheriting from the base exception object that works within the constraints of this API rather than declaring this macro.

If this seems reasonable will add a comment to explain why this is happening and get tox envs setup to test pypy compat.

Thoughts @edenhill ?