### PR TITLE
Add environment markers to python2-only dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,16 +3,8 @@
 import os
 from setuptools import setup, find_packages
 from distutils.core import Extension
-import sys
 import platform
 
-INSTALL_REQUIRES = list()
-
-if sys.version_info[0] < 3:
-    avro = 'avro'
-    INSTALL_REQUIRES.extend(['futures', 'enum34', 'requests'])
-else:
-    avro = 'avro-python3'
 
 # On Un*x the library is linked as -lrdkafka,
 # while on windows we need the full librdkafka name.
@@ -49,8 +41,17 @@ setup(name='confluent-kafka',
       ext_modules=[module],
       packages=find_packages(exclude=("tests", "tests.*")),
       data_files=[('', ['LICENSE.txt'])],
-      install_requires=INSTALL_REQUIRES,
+      install_requires=[
+          'futures; python_version<"3"',
+          'enum34; python_version<"3"',
+          'requests; python_version<"3"',
+      ],
       extras_require={
-          'avro': ['fastavro', 'requests', avro],
+          'avro': [
+              'fastavro',
+              'requests',
+              'avro-python3; python_version>="3"',
+              'avro; python_version<"3"'
+          ],
           'dev': get_install_requirements("test-requirements.txt")
       })


### PR DESCRIPTION
[PEP 496](https://www.python.org/dev/peps/pep-0496/) describes environment markers and [PEP 508](https://www.python.org/dev/peps/pep-0508/) describes the semantics of the python_version environment marker, tools which allow us to mark certain dependencies as necessary only when the user's python interpreter is within a certain version range.