### PR TITLE
ST-1322: Trogdor Produce Runner

### DIFF
--- a/tests/run.sh
+++ b/tests/run.sh
@@ -27,6 +27,12 @@ run_tox() {
     tox -r "$@"
 }
 
+run_trogdor() {
+    start_cluster
+    echo "Executing Trogdor"
+    python ${TEST_SOURCE}/trogdor/trogdor_runner.py --spec ${TEST_SOURCE}/trogdor/example-produce-spec.json
+}
+
 run_native() {
     pip install -v .[avro]
     start_cluster
@@ -55,6 +61,10 @@ case ${1:-} in
         shift
         run_unit $@
         run_native $@
+        ;;
+    "trogdor")
+        shift
+        run_trogdor $@
         ;;
     *)
         run_native $@

--- a/tests/trogdor/example-produce-spec.json
+++ b/tests/trogdor/example-produce-spec.json
@@ -1,0 +1,29 @@
+{
+    "class": "org.apache.kafka.trogdor.workload.ExternalCommandSpec",
+    "command": [
+	"python",
+	"./trogdor-runner.py"
+    ],
+    "durationMs": 10000000,
+    "producerNode": "node0",
+    "workload": {
+	"class": "org.apache.kafka.trogdor.workload.ProduceBenchSpec",
+	"durationMs": 10000000,
+	"producerNode": "node0",
+	"bootstrapServers": "localhost:9092",
+	"targetMessagesPerSec": 10000,
+	"maxMessages": 50000,
+	"activeTopics": {
+	    "foo[1-3]": {
+		"numPartitions": 10,
+		"replicationFactor": 1
+	    }
+	},
+	"inactiveTopics": {
+	    "foo[4-5]": {
+		"numPartitions": 10,
+		"replicationFactor": 1
+	    }
+	}
+    }
+}

--- a/tests/trogdor/example-produce-spec.json
+++ b/tests/trogdor/example-produce-spec.json
@@ -2,28 +2,26 @@
     "class": "org.apache.kafka.trogdor.workload.ExternalCommandSpec",
     "command": [
 	"python",
-	"./trogdor-runner.py"
+	"./tests/trogdor/trogdor-runner.py"
     ],
     "durationMs": 10000000,
     "producerNode": "node0",
     "workload": {
-	"class": "org.apache.kafka.trogdor.workload.ProduceBenchSpec",
-	"durationMs": 10000000,
-	"producerNode": "node0",
-	"bootstrapServers": "localhost:9092",
-	"targetMessagesPerSec": 10000,
-	"maxMessages": 50000,
-	"activeTopics": {
-	    "foo[1-3]": {
-		"numPartitions": 10,
-		"replicationFactor": 1
-	    }
-	},
-	"inactiveTopics": {
-	    "foo[4-5]": {
-		"numPartitions": 10,
-		"replicationFactor": 1
-	    }
+		"class": "org.apache.kafka.trogdor.workload.ProduceBenchSpec",
+		"bootstrapServers": "localhost:29092",
+		"targetMessagesPerSec": 10000,
+		"maxMessages": 50000,
+		"activeTopics": {
+			"foo[1-3]": {
+				"numPartitions": 10,
+				"replicationFactor": 1
+			}
+		},
+		"inactiveTopics": {
+			"foo[4-5]": {
+				"numPartitions": 10,
+				"replicationFactor": 1
+			}
+		}
 	}
-    }
 }

--- a/tests/trogdor/example-produce-spec.json
+++ b/tests/trogdor/example-produce-spec.json
@@ -1,11 +1,11 @@
 {
     "class": "org.apache.kafka.trogdor.workload.ExternalCommandSpec",
     "command": [
-	"python",
-	"./tests/trogdor/trogdor-runner.py"
+	    "python",
+	    "./tests/trogdor/trogdor-runner.py"
     ],
     "durationMs": 10000000,
-    "producerNode": "node0",
+    "commandNode": "node0",
     "workload": {
 		"class": "org.apache.kafka.trogdor.workload.ProduceBenchSpec",
 		"bootstrapServers": "localhost:29092",

--- a/tests/trogdor/produce_spec_runner.py
+++ b/tests/trogdor/produce_spec_runner.py
@@ -1,0 +1,194 @@
+# Copyright 2016 Confluent Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License")
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# One example of a produce Trogdor task, the workload is a JSON object following the ProduceBenchSpec.
+#
+# {
+#     "id": "$TASK_ID",
+#
+#     "spec": {
+#         "class": "org.apache.kafka.trogdor.workload.ExternalCommandSpec",
+#         "command": ["python", "./tests/bin/ExternalCommandExample.py"],
+#         "durationMs": 10000000,
+#         "commandNode": "node0",
+#         "workload":{
+#             "class": "org.apache.kafka.trogdor.workload.ProduceBenchSpec",
+#             "bootstrapServers": "localhost:9092",
+#             "targetMessagesPerSec": 10000,
+#             "maxMessages": 50000,
+#             "activeTopics": {
+#                 "foo[1-3]": {
+#                     "numPartitions": 10,
+#                     "replicationFactor": 1
+#                 }
+#             },
+#             "inactiveTopics": {
+#                 "foo[4-5]": {
+#                     "numPartitions": 10,
+#                     "replicationFactor": 1
+#                 }
+#             }
+#         }
+#     }
+# }
+
+# ProduceBenchSpec:
+# "startMs": #start
+# "bootstrapServers": #string#
+# "targetMessagePerSec": #Java int#
+# "maxMessages": #Java long#
+# "keyGenerator": #Option, sequential generator by default# { "type": "constant" | "sequential" | "uniformRandom" | "null" }
+# "valueGenerator"#Same as the keyGenerator#"
+# "transactionGenerator":#Option, by default empty# {"type":"uniform"}
+# "producerConf": #a JSON object#
+# "commonClientConf": "a JSON object"
+# "adminClientConf": "a JSON object"
+# "activeTopics" : "a JSON object"
+# "inactiveTopics": "a JSON object"
+import threading
+import time
+
+from hdrh.histogram import HdrHistogram
+
+from trogdor_utils import expand_topics, trogdor_log, update_trogdor_error, merge_topics, create_topics, \
+    update_trogdor_status, create_admin_conn, partition_set, PayloadGenerator, SeqGenerator, ConstGenerator, \
+    create_kafka_conf, create_producer_conn
+
+
+def execute_produce_spec(spec):
+    runner = ProduceSpecRunner(spec)
+    runner.monitor()
+
+
+class ProduceSpecRunner:
+    def report_status(self):
+        """ Report Histogram Latency"""
+        exp_status = {"totalSent": self.latency_histogram.get_total_count(),
+                      "totalError": self.nr_failed_messages,
+                      "planQPS": self.qps,
+                      "realQPS": self.real_qps,
+                      "averageLatencyMs": self.latency_histogram.get_mean_value(),
+                      "p50LatencyMs": self.latency_histogram.get_value_at_percentile(59),
+                      "p95LatencyMs": self.latency_histogram.get_value_at_percentile(95),
+                      "p99LatencyMs": self.latency_histogram.get_value_at_percentile(99),
+                      "maxLatencyMs": self.latency_histogram.get_max_value()
+                      }
+        update_trogdor_status(exp_status)
+    def message_on_delivery(self, err, msg, sent_time):
+        self.nr_finished_messages += 1
+        if err is not None:
+            trogdor_log("ProduceSpecRunner: delivery failed: {} [{}]: {}".format(msg.topic(), msg.partition(), err))
+            self.nr_failed_messages += 1
+        now = time.time()
+        latency = now - sent_time
+#        print("latency:{}".format(latency * 1000))
+        self.latency_histogram.record_value(latency * 1000)
+        if now - self.last_report_time > self.report_status_interval:
+            self.last_report_time = now
+            self.report_status()
+    def get_msg_callback(self):
+        product_time = time.time()
+        return lambda err,msg : self.message_on_delivery(err, msg, product_time)
+
+    def execute_spec(self):
+        self.start_produce_time = time.time()
+        nr_topics = len(self.topic_partitions)
+        nr_message = 0
+        pause = 1.0/(self.qps);
+        next_fire_time = self.start_produce_time + pause;
+        while nr_message < self.max_messages:
+            delta = next_fire_time - time.time()
+            if delta > 0:
+                time.sleep(delta)
+            next_fire_time += pause
+            topic_partition = self.topic_partitions[nr_message % nr_topics]
+            topic = topic_partition[0]
+            partition = topic_partition[1]
+            while True:
+                try:
+                    self.producer.produce(topic, self.val_generator.nextVal(),
+                                          self.key_generator.nextVal(), partition,
+                                          on_delivery = self.get_msg_callback())
+                    break
+                except BufferError:
+                    trogdor_log("Producer BufferError, retry")
+                    self.producer.poll(1)
+                    continue
+            nr_message += 1
+
+    def monitor(self):
+        # report status every 10 seconds
+        self.last_report_time = time.time()
+        while self.status == "running" or self.nr_finished_messages != self.max_messages:
+            self.producer.poll(10)
+        self.end_produce_time = time.time()
+        self.real_qps = self.nr_finished_messages / (self.end_produce_time - self.start_produce_time)
+        trogdor_log("Finished all {} messages".format(self.max_messages))
+
+        self.report_status()
+
+    def producer_thread_main(self):
+        """ Producer thread main function """
+        try:
+            self.execute_spec()
+            self.status = "stopped"
+        except KeyboardInterrupt:
+            update_trogdor_status("The producer is interrupted.")
+            self.status = "abort"
+        except Exception as ex:
+            update_trogdor_status("The producer has a fatal exception: " + str(ex))
+            self.status = "exception"
+    def create_spec_topics(self, producer_spec):
+        active_spec_topics = producer_spec.get("activeTopics", {})
+        if len(active_spec_topics.keys()) == 0:
+            raise Exception("You must specify at least one active topic.")
+        inactive_spec_topics = producer_spec.get("inactiveTopics", {})
+        self.active_topics = expand_topics(active_spec_topics)
+        self.inactive_topics = expand_topics(inactive_spec_topics)
+        self.bootstrap_servers = producer_spec.get("bootstrapServers", "")
+        if self.bootstrap_servers == "":
+            raise Exception("You must specify the bootstrap servers")
+        self.producer_conf = producer_spec.get("producerConf", {})
+        self.common_client_conf = producer_spec.get("commonClientConf", {})
+        self.admin_client_conf = producer_spec.get("adminClientConf", {})
+        all_topics = merge_topics(self.active_topics, self.inactive_topics)
+        update_trogdor_status("Creating {} topic(s)".format(len(all_topics.keys())))
+        admin_conn = create_admin_conn(self.bootstrap_servers, self.common_client_conf, self.admin_client_conf)
+        create_topics(admin_conn, all_topics)
+        self.topic_partitions = partition_set(self.active_topics)
+
+    def __init__(self, spec):
+        self.spec = spec
+        self.producer_spec = spec["workload"]
+        self.status = "running"
+        # between (0.000ms, 5000.000ms)
+        self.latency_histogram = HdrHistogram(1, 5000, 3)
+        self.report_status_interval = 10
+        self.start_timestamp = time.time()
+        self.create_spec_topics(self.producer_spec)
+        self.key_generator = PayloadGenerator(SeqGenerator(4, 0))
+        self.val_generator = PayloadGenerator(ConstGenerator(4,0xabcd))
+        self.qps = self.producer_spec.get("targetMessagePerSec", 10000)
+        self.max_messages = self.producer_spec.get("maxMessages", 100000)
+        self.nr_finished_messages = 0
+        self.nr_failed_messages = 0
+        self.producer = create_producer_conn(self.bootstrap_servers, self.common_client_conf, self.producer_conf)
+        trogdor_log("Topics:{}".format(str(self.producer.list_topics())))
+        trogdor_log("Produce {} at message-per-sec {}".format(self.max_messages, self.qps))
+        self.producer_thread = threading.Thread(target=self.producer_thread_main)
+        self.producer_thread.start()
+
+
+
+

--- a/tests/trogdor/produce_spec_runner.py
+++ b/tests/trogdor/produce_spec_runner.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# One example of a produce Trogdor task, the workload is a JSON object following the ProduceBenchSpec.
+# One example of a produce Trogdor task embedded in the ExternalCommandSpec
 #
 # {
 #     "id": "$TASK_ID",
@@ -77,9 +77,9 @@ import time
 
 from hdrh.histogram import HdrHistogram
 
-from trogdor_utils import expand_topics, trogdor_log, update_trogdor_error, merge_topics, create_topics, \
-    update_trogdor_status, create_admin_conn, partition_set, PayloadGenerator, SeqGenerator, ConstGenerator, \
-    create_kafka_conf, create_producer_conn, get_payload_generator
+from trogdor_utils import expand_topics, trogdor_log, merge_topics, create_topics, \
+    update_trogdor_status, create_admin_conn, partition_set, PayloadGenerator, create_producer_conn, \
+    get_payload_generator
 
 
 def execute_produce_spec(spec):
@@ -88,41 +88,88 @@ def execute_produce_spec(spec):
 
 
 class ProduceSpecRunner:
-    def report_status(self):
+    def report_status(self, realQPS = None):
         """ Report Histogram Latency"""
-        exp_status = {"totalSent": self.latency_histogram.get_total_count(),
+        exp_status = {"totalSent": self.nr_finished_messages,
+                      "totalRecorded": self.latency_histogram.get_total_count(),
                       "totalError": self.nr_failed_messages,
                       "planQPS": self.qps,
-                      "realQPS": self.real_qps,
                       "averageLatencyMs": self.latency_histogram.get_mean_value(),
                       "p50LatencyMs": self.latency_histogram.get_value_at_percentile(59),
                       "p95LatencyMs": self.latency_histogram.get_value_at_percentile(95),
                       "p99LatencyMs": self.latency_histogram.get_value_at_percentile(99),
                       "maxLatencyMs": self.latency_histogram.get_max_value()
                       }
+        if realQPS:
+            exp_status["realQPS"] = realQPS
         update_trogdor_status(exp_status)
+
     def message_on_delivery(self, err, msg, sent_time):
-        self.nr_finished_messages += 1
         if err is not None:
             trogdor_log("ProduceSpecRunner: delivery failed: {} [{}]: {}".format(msg.topic(), msg.partition(), err))
             self.nr_failed_messages += 1
         now = time.time()
         latency = now - sent_time
-#        print("latency:{}".format(latency * 1000))
         self.latency_histogram.record_value(latency * 1000)
-        if now - self.last_report_time > self.report_status_interval:
-            self.last_report_time = now
-            self.report_status()
+        self.nr_finished_messages += 1
+
     def get_msg_callback(self):
         product_time = time.time()
         return lambda err,msg : self.message_on_delivery(err, msg, product_time)
 
+    def create_spec_topics(self, producer_spec):
+        active_spec_topics = producer_spec.get("activeTopics", {})
+        if len(active_spec_topics.keys()) == 0:
+            raise Exception("You must specify at least one active topic.")
+        inactive_spec_topics = producer_spec.get("inactiveTopics", {})
+        self.active_topics = expand_topics(active_spec_topics)
+        self.inactive_topics = expand_topics(inactive_spec_topics)
+        self.bootstrap_servers = producer_spec.get("bootstrapServers", "")
+        if self.bootstrap_servers == "":
+            raise Exception("You must specify the bootstrap servers")
+        self.producer_conf = producer_spec.get("producerConf", {})
+        self.common_client_conf = producer_spec.get("commonClientConf", {})
+        self.admin_client_conf = producer_spec.get("adminClientConf", {})
+        all_topics = merge_topics(self.active_topics, self.inactive_topics)
+        update_trogdor_status("Creating {} topic(s)".format(len(all_topics.keys())))
+        admin_conn = create_admin_conn(self.bootstrap_servers, self.common_client_conf, self.admin_client_conf)
+        create_topics(admin_conn, all_topics)
+        self.topic_partitions = partition_set(self.active_topics)
+
+    def monitor(self):
+        """ Called by the main thread """
+        # report status every 10 seconds
+        start_monitoring = time.time()
+        last_report_time = time.time()
+        while self.status == "running" or self.nr_finished_messages != self.max_messages:
+            now = time.time()
+            if now - last_report_time > self.report_status_interval:
+                last_report_time = now
+                self.report_status()
+            self.producer.poll(self.report_status_interval)
+        end_monitoring = time.time()
+        real_qps = int(self.nr_finished_messages / (end_monitoring - start_monitoring))
+        trogdor_log("Finished all {} messages".format(self.max_messages))
+        self.report_status(realQPS=real_qps)
+
+    def producer_thread_main(self):
+        """ Producer thread """
+        try:
+            self.execute_spec()
+            self.status = "stopped"
+        except KeyboardInterrupt:
+            update_trogdor_status("The producer is interrupted.")
+            self.status = "abort"
+        except Exception as ex:
+            update_trogdor_status("The producer has a fatal exception: " + str(ex))
+            self.status = "exception"
+
     def execute_spec(self):
-        self.start_produce_time = time.time()
+        start_produce_time = time.time()
         nr_topics = len(self.topic_partitions)
         nr_message = 0
-        pause = 1.0/(self.qps);
-        next_fire_time = self.start_produce_time + pause;
+        pause = 1.0 / self.qps
+        next_fire_time = start_produce_time + pause
         while nr_message < self.max_messages:
             delta = next_fire_time - time.time()
             if delta > 0:
@@ -143,53 +190,14 @@ class ProduceSpecRunner:
                     continue
             nr_message += 1
 
-    def monitor(self):
-        # report status every 10 seconds
-        self.last_report_time = time.time()
-        while self.status == "running" or self.nr_finished_messages != self.max_messages:
-            self.producer.poll(10)
-        self.end_produce_time = time.time()
-        self.real_qps = self.nr_finished_messages / (self.end_produce_time - self.start_produce_time)
-        trogdor_log("Finished all {} messages".format(self.max_messages))
 
-        self.report_status()
-
-    def producer_thread_main(self):
-        """ Producer thread main function """
-        try:
-            self.execute_spec()
-            self.status = "stopped"
-        except KeyboardInterrupt:
-            update_trogdor_status("The producer is interrupted.")
-            self.status = "abort"
-        except Exception as ex:
-            update_trogdor_status("The producer has a fatal exception: " + str(ex))
-            self.status = "exception"
-    def create_spec_topics(self, producer_spec):
-        active_spec_topics = producer_spec.get("activeTopics", {})
-        if len(active_spec_topics.keys()) == 0:
-            raise Exception("You must specify at least one active topic.")
-        inactive_spec_topics = producer_spec.get("inactiveTopics", {})
-        self.active_topics = expand_topics(active_spec_topics)
-        self.inactive_topics = expand_topics(inactive_spec_topics)
-        self.bootstrap_servers = producer_spec.get("bootstrapServers", "")
-        if self.bootstrap_servers == "":
-            raise Exception("You must specify the bootstrap servers")
-        self.producer_conf = producer_spec.get("producerConf", {})
-        self.common_client_conf = producer_spec.get("commonClientConf", {})
-        self.admin_client_conf = producer_spec.get("adminClientConf", {})
-        all_topics = merge_topics(self.active_topics, self.inactive_topics)
-        update_trogdor_status("Creating {} topic(s)".format(len(all_topics.keys())))
-        admin_conn = create_admin_conn(self.bootstrap_servers, self.common_client_conf, self.admin_client_conf)
-        create_topics(admin_conn, all_topics)
-        self.topic_partitions = partition_set(self.active_topics)
 
     def __init__(self, spec):
         self.spec = spec
         self.producer_spec = spec["workload"]
         self.status = "running"
-        # between (0.000ms, 5000.000ms)
-        self.latency_histogram = HdrHistogram(1, 5000, 3)
+        # between (0.000ms, 50000.000ms)
+        self.latency_histogram = HdrHistogram(1, 50000, 3)
         self.report_status_interval = 10
         self.start_timestamp = time.time()
         self.create_spec_topics(self.producer_spec)
@@ -208,7 +216,3 @@ class ProduceSpecRunner:
         trogdor_log("Produce {} at message-per-sec {}".format(self.max_messages, self.qps))
         self.producer_thread = threading.Thread(target=self.producer_thread_main)
         self.producer_thread.start()
-
-
-
-

--- a/tests/trogdor/trogdor_runner.py
+++ b/tests/trogdor/trogdor_runner.py
@@ -55,8 +55,8 @@ from trogdor_utils import update_trogdor_status
 from trogdor_utils import update_trogdor_error
 from trogdor_utils import trogdor_log
 
-# if passed with --spec spec.json, TrogdorProducer directly executes the task,
-# otherwise, TrogdorProduder waits on the task start command.
+# if the task is passed with the --spec spec.json parameter, TrogdorProducer directly executes the task,
+# otherwise, TrogdorProduder waits for the task on the stdin.
 parser = argparse.ArgumentParser(description='Python Trogdor Producer.');
 parser.add_argument('--spec', dest='spec', required=False);
 args = parser.parse_args()

--- a/tests/trogdor/trogdor_runner.py
+++ b/tests/trogdor/trogdor_runner.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Confluent Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# TrogdorRunner executes one Trogdor ExternalCommandSpec task.
+#
+# One example of the ExternalCommandSpec spec:
+# {
+#     "id": "$TASK_ID",
+#
+#     "spec": {
+#         "class": "org.apache.kafka.trogdor.workload.ExternalCommandSpec",
+#         "command": ["python", "./tests/bin/ExternalCommandExample.py"],
+#         "durationMs": 10000000,
+#         "commandNode": "node0",
+#         "workload":{
+#             "class": "org.apache.kafka.trogdor.workload.ProduceBenchSpec",
+#             "bootstrapServers": "localhost:9092",
+#             "targetMessagesPerSec": 10000,
+#             "maxMessages": 50000,
+#             "activeTopics": {
+#                 "foo[1-3]": {
+#                     "numPartitions": 10,
+#                     "replicationFactor": 1
+#                 }
+#             },
+#             "inactiveTopics": {
+#                 "foo[4-5]": {
+#                     "numPartitions": 10,
+#                     "replicationFactor": 1
+#                 }
+#             }
+#         }
+#     }
+# }
+
+import argparse
+import json
+import sys
+from produce_spec_runner import execute_produce_spec, ProduceSpecRunner
+from trogdor_utils import update_trogdor_status
+from trogdor_utils import update_trogdor_error
+from trogdor_utils import trogdor_log
+
+# if passed with --spec spec.json, TrogdorProducer directly executes the task,
+# otherwise, TrogdorProduder waits on the task start command.
+parser = argparse.ArgumentParser(description='Python Trogdor Producer.');
+parser.add_argument('--spec', dest='spec', required=False);
+args = parser.parse_args()
+
+
+def execute_task(task_spec):
+    try:
+        workload = task_spec["workload"]
+        spec_class = workload["class"]
+        if spec_class == 'org.apache.kafka.trogdor.workload.ProduceBenchSpec':
+            execute_produce_spec(task_spec)
+        else:
+            update_trogdor_error(spec_class + " is not supported.")
+    except Exception as exp:
+        update_trogdor_error("Exception: " + exp)
+
+
+
+def get_task_from_specfile(specFile):
+    specString = "";
+    with open(specFile) as f:
+        for line in f:
+            if line.startswith('#'):
+                continue;
+            specString += line;
+        f.close();
+    if (specString == ""):
+        return None;
+    task = json.loads(specString);
+    return task
+
+def get_task_from_input():
+    for line in sys.stdin:
+        try:
+            comm = json.loads(line)
+            if "action" in comm:
+                action = comm["action"]
+                if action == "stop":
+                    exit(0)
+                elif action == "start":
+                    if "spec" in comm:
+                        task = comm["spec"]
+                        update_trogdor_status("Started to execute the workload.")
+                        return comm["spec"]
+                    else:
+                        update_trogdor_error("No spec in command " + line)
+                else:
+                    trogdor_log("Unknown command action " + action)
+            else:
+                update_trogdor_error("Unknown control command " + line)
+        except ValueError:
+            trogdor_log("Input line " + line + " is not a valid external runner command.")
+
+
+if __name__ == '__main__':
+    spec = None;
+    if args.spec:
+        spec = get_task_from_specfile(args.spec);
+    else:
+        spec = get_task_from_input()
+    execute_task(spec);

--- a/tests/trogdor/trogdor_runner.py
+++ b/tests/trogdor/trogdor_runner.py
@@ -15,106 +15,75 @@
 # limitations under the License.
 #
 
-# TrogdorRunner executes one Trogdor ExternalCommandSpec task.
-#
-# One example of the ExternalCommandSpec spec:
-# {
-#     "id": "$TASK_ID",
-#
-#     "spec": {
-#         "class": "org.apache.kafka.trogdor.workload.ExternalCommandSpec",
-#         "command": ["python", "./tests/bin/ExternalCommandExample.py"],
-#         "durationMs": 10000000,
-#         "commandNode": "node0",
-#         "workload":{
-#             "class": "org.apache.kafka.trogdor.workload.ProduceBenchSpec",
-#             "bootstrapServers": "localhost:9092",
-#             "targetMessagesPerSec": 10000,
-#             "maxMessages": 50000,
-#             "activeTopics": {
-#                 "foo[1-3]": {
-#                     "numPartitions": 10,
-#                     "replicationFactor": 1
-#                 }
-#             },
-#             "inactiveTopics": {
-#                 "foo[4-5]": {
-#                     "numPartitions": 10,
-#                     "replicationFactor": 1
-#                 }
-#             }
-#         }
-#     }
-# }
-
 import argparse
 import json
 import sys
-from produce_spec_runner import execute_produce_spec, ProduceSpecRunner
-from trogdor_utils import update_trogdor_status
+from produce_spec_runner import execute_produce_spec
 from trogdor_utils import update_trogdor_error
 from trogdor_utils import trogdor_log
 
-# if the task is passed with the --spec spec.json parameter, TrogdorProducer directly executes the task,
-# otherwise, TrogdorProduder waits for the task on the stdin.
-parser = argparse.ArgumentParser(description='Python Trogdor Producer.');
-parser.add_argument('--spec', dest='spec', required=False);
+parser = argparse.ArgumentParser(description='Python Trogdor Producer.')
+parser.add_argument('--spec', dest='spec', required=False)
 args = parser.parse_args()
 
 
-def execute_task(task_spec):
+def execute_task(workload):
     try:
-        workload = task_spec["workload"]
         spec_class = workload["class"]
         if spec_class == 'org.apache.kafka.trogdor.workload.ProduceBenchSpec':
-            execute_produce_spec(task_spec)
+            execute_produce_spec(workload)
         else:
             update_trogdor_error(spec_class + " is not supported.")
     except Exception as exp:
         update_trogdor_error("Exception: " + exp)
 
 
-
 def get_task_from_specfile(specFile):
-    specString = "";
+    """
+    :param specFile: One Trogdor ExternalCommandSpec JSON file
+     One example of the ExternalCommandSpec spec:
+
+    :return specFile["spec"]["workload"] or None
+    """
+    specString = ""
+    workload = None
     with open(specFile) as f:
         for line in f:
             if line.startswith('#'):
-                continue;
-            specString += line;
-        f.close();
+                continue
+            specString += line
+        f.close()
     if (specString == ""):
-        return None;
-    task = json.loads(specString);
-    return task
+        return None
+    task = json.loads(specString)
+    if "class" in task and "workload" in task and \
+            task["class"] == "org.apache.kafka.trogdor.workload.ExternalCommandSpec":
+        workload = task["workload"]
+    return workload
+
 
 def get_task_from_input():
+    """
+    Waiting for a new task on stdin, formatted in {"id":<task ID string>, "workload":<configured workload JSON object>}
+    :return: spec["workload"]
+    """
     for line in sys.stdin:
         try:
             comm = json.loads(line)
-            if "action" in comm:
-                action = comm["action"]
-                if action == "stop":
-                    exit(0)
-                elif action == "start":
-                    if "spec" in comm:
-                        task = comm["spec"]
-                        update_trogdor_status("Started to execute the workload.")
-                        return comm["spec"]
-                    else:
-                        update_trogdor_error("No spec in command " + line)
-                else:
-                    trogdor_log("Unknown command action " + action)
-            else:
-                update_trogdor_error("Unknown control command " + line)
+            if "workload" in comm and "id" in comm:
+                trogdor_log("Received one workload:{}".format(comm))
+                return comm["workload"]
         except ValueError:
             trogdor_log("Input line " + line + " is not a valid external runner command.")
 
 
 if __name__ == '__main__':
-    spec = None;
+    spec = None
     if args.spec:
-        spec = get_task_from_specfile(args.spec);
+        spec = get_task_from_specfile(args.spec)
+        if spec is None:
+            update_trogdor_error("Unrecognized task:{}".format(args.spec))
+            exit(1)
     else:
         spec = get_task_from_input()
-    execute_task(spec);
+    execute_task(spec)

--- a/tests/trogdor/trogdor_utils.py
+++ b/tests/trogdor/trogdor_utils.py
@@ -58,11 +58,13 @@ def merge_topics(active_topics, inactive_topics):
     all_topics.update(inactive_topics)
     return all_topics
 
+
 def create_kafka_conf(bootstrap_servers, *args):
     k_conf = {"bootstrap.servers": bootstrap_servers}
     for conf in args:
         k_conf.update(conf)
     return k_conf
+
 
 def create_admin_conf(bootstrap_servers, common_client_config, admin_client_config):
     # Refer Java Trogdor tools/src/main/java/org/apache/kafka/trogdor/common/WorkerUtils.java#L305
@@ -72,15 +74,19 @@ def create_admin_conf(bootstrap_servers, common_client_config, admin_client_conf
     admin_conf["socket.timeout.ms"] = admin_request_timeout_ms
     return admin_conf
 
+
 def create_producer_conn(bootstrap_servers, common_client_config, producer_config):
     producer_conf = create_kafka_conf(bootstrap_servers, common_client_config, producer_config)
     return Producer(**producer_conf)
+
 
 def record_on_delivery(err, msg):
     if err is not None:
         trogdor_log("ProduceSpecRunner: delivery failed: {} [{}]: {}".format(msg.topic(), msg.partition(), err))
     else:
         trogdor_log("ProduceSpecRunner: delivery successed: {}".format(str(msg)))
+
+
 def create_admin_conn(bootstrap_servers, common_client_config, admin_client_config):
     admin_conf = create_admin_conf(bootstrap_servers, common_client_config, admin_client_config)
     admin_conn = AdminClient(admin_conf)

--- a/tests/trogdor/trogdor_utils.py
+++ b/tests/trogdor/trogdor_utils.py
@@ -1,0 +1,159 @@
+# Copyright 2016 Confluent Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License")
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import re
+import sys
+import json
+
+from confluent_kafka.cimpl import KafkaException, KafkaError, Producer
+
+from confluent_kafka.admin import AdminClient, NewTopic
+
+
+def partition_set(topics):
+    """ Return a set of TopicPartition """
+    topic_partitions = []
+    for t_name in topics:
+        t = topics[t_name]
+        nr_partitions = t.get("numPartitions", 1)
+        for i in range(0, nr_partitions):
+            topic_partitions.append((t_name, i))
+    return topic_partitions
+
+
+def expand_topics(topics):
+    topic_expand_matter = re.compile(r'(.*?)\[([0-9]*)\-([0-9]*)\](.*)')
+    expanded = {}
+    for topicName in topics:
+        match = topic_expand_matter.match(topicName)
+        if (match):
+            pre = match.group(1)
+            start = int(match.group(2))
+            end = int(match.group(3))
+            last = match.group(4)
+            if end >= start:
+                for t in range(start, end + 1):
+                    newTopicName = "%s%d%s" % (pre, t, last)
+                    expanded[newTopicName] = topics[topicName]
+            else:
+                raise Exception('Invalid range in the topic name %s' % (topicName))
+        else:
+            expanded[topicName] = topics[topicName]
+    return expanded
+
+
+def merge_topics(active_topics, inactive_topics):
+    all_topics = active_topics.copy()
+    all_topics.update(inactive_topics)
+    return all_topics
+
+def create_kafka_conf(bootstrap_servers, *args):
+    k_conf = {"bootstrap.servers": bootstrap_servers}
+    for conf in args:
+        k_conf.update(conf)
+    return k_conf
+
+def create_admin_conf(bootstrap_servers, common_client_config, admin_client_config):
+    # Refer Java Trogdor tools/src/main/java/org/apache/kafka/trogdor/common/WorkerUtils.java#L305
+    admin_request_timeout_ms = 25000
+    create_kafka_conf(bootstrap_servers, common_client_config, admin_client_config)
+    admin_conf = create_kafka_conf(bootstrap_servers, common_client_config, admin_client_config);
+    admin_conf["socket.timeout.ms"] = admin_request_timeout_ms
+    return admin_conf
+
+def create_producer_conn(bootstrap_servers, common_client_config, producer_config):
+    producer_conf = create_kafka_conf(bootstrap_servers, common_client_config, producer_config)
+    return Producer(**producer_conf)
+
+def record_on_delivery(err, msg):
+    if err is not None:
+        trogdor_log("ProduceSpecRunner: delivery failed: {} [{}]: {}".format(msg.topic(), msg.partition(), err))
+    else:
+        trogdor_log("ProduceSpecRunner: delivery successed: {}".format(str(msg)))
+def create_admin_conn(bootstrap_servers, common_client_config, admin_client_config):
+    admin_conf = create_admin_conf(bootstrap_servers, common_client_config, admin_client_config)
+    admin_conn = AdminClient(admin_conf)
+    return admin_conn
+
+
+def create_topics(admin_conn, topics):
+    for topic_name in topics:
+        topic = topics[topic_name]
+        create_topic(admin_conn, topic_name, topic)
+
+
+def create_topic(admin_conn, topic_name, topic):
+    num_partitions = topic["numPartitions"]
+    replication_factor = topic["replicationFactor"]
+    fs = admin_conn.create_topics([NewTopic(topic_name, num_partitions, replication_factor)])
+    fs = fs[topic_name]
+    try:
+        res = fs.result()
+    except KafkaException as ex:
+        if ex.args[0].code() == KafkaError.TOPIC_ALREADY_EXISTS:
+            trogdor_log("Topic %s already exists" % (topic_name))
+        else:
+            raise ex
+
+
+# msg is a JSON string {"status":status, "error":error, "log":log}
+def output_trogdor_message(msg):
+    print(msg)
+    sys.stdout.flush()
+
+
+def update_trogdor_status(status):
+    msg = json.dumps({"status": status})
+    output_trogdor_message(msg)
+
+
+def update_trogdor_error(error):
+    msg = json.dumps({"error": error})
+    output_trogdor_message(msg)
+
+
+def trogdor_log(log):
+    msg = json.dumps({"log": log})
+    output_trogdor_message(msg)
+
+class SeqGenerator:
+    def __init__(self, size, start_offset):
+        self.size = size
+        self.start_offset = start_offset
+
+    def generate(self, position):
+        return (self.start_offset + position).to_bytes(self.size, byteorder='little')
+
+class ConstGenerator:
+    def __init__(self, size, val):
+        self.size = size
+        self.const_bytes = val.to_bytes(self.size, byteorder='little')
+
+    def generate(self, position):
+        return self.const_bytes
+
+class PayloadGenerator:
+    def __init__(self, pyload_generator):
+        self.generator = pyload_generator
+        self.position = 0
+        self.last = None
+
+    def nextVal(self):
+        load = self.generator.generate(self.position)
+        self.position += 1
+        self.last = load
+        return self.last
+
+    def fetch_last(self):
+        return self.last


### PR DESCRIPTION
The Trogdor Runner executes Trogdor ExternalCommandSpec tasks. It can be invoked directly with `./tests/trogdor_runner --spec ExternalCommandSpecFile`, or started by Trogdor agents. When directly invoking, the Trogdor Runner parse the spec file and execute the workload. When started by Trogdor agents, it wants on stdin for command, then execute the workload.

* Add Trogdor Runner (./tests/trogdor/trogdor_runner.py) to execute Trogdor tasks.
* Add Trogdor Produce Runner (./tests/trogdor/produce_spec_runner.py) to execute Trogdor Produce task.
* Add Trogdor Produce Test to ./tests/run.sh. 