### PR TITLE
implement environment markers to fix poetry

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,16 +3,13 @@
 import os
 from setuptools import setup, find_packages
 from distutils.core import Extension
-import sys
 import platform
 
-INSTALL_REQUIRES = list()
-
-if sys.version_info[0] < 3:
-    avro = 'avro'
-    INSTALL_REQUIRES.extend(['futures', 'enum34', 'requests'])
-else:
-    avro = 'avro-python3'
+INSTALL_REQUIRES = [
+    'futures;python_version<"3.2"',
+    'enum34;python_version<"3.4"',
+    'requests;python_version<"3.2"'
+]
 
 # On Un*x the library is linked as -lrdkafka,
 # while on windows we need the full librdkafka name.
@@ -51,6 +48,11 @@ setup(name='confluent-kafka',
       data_files=[('', ['LICENSE.txt'])],
       install_requires=INSTALL_REQUIRES,
       extras_require={
-          'avro': ['fastavro', 'requests', avro],
+          'avro': [
+              'fastavro',
+              'requests',
+              'avro;python_version<"3.0"',
+              'avro-python3;python_version>"3.0"'
+          ],
           'dev': get_install_requirements("test-requirements.txt")
       })


### PR DESCRIPTION
pep 508 recommends the usage of environment markers rather than version_info
https://www.python.org/dev/peps/pep-0508/#environment-markers

currently installing using poetry resolves the wrong libraries