### PR TITLE
Fixed fastavro not being used if schemas aren't manually specified…

### DIFF
--- a/confluent_kafka/avro/load.py
+++ b/confluent_kafka/avro/load.py
@@ -52,3 +52,21 @@ try:
 
 except ImportError:
     schema = None
+
+
+HAS_FAST = False
+try:
+    import fastavro
+    import json
+    HAS_FAST = True
+except ImportError:
+    pass
+
+
+def loads_fast(schema_str):
+    if HAS_FAST:
+        try:
+            return fastavro.parse_schema(json.loads(schema_str))
+        except Exception:
+            pass
+    return None

--- a/confluent_kafka/avro/serializer/message_serializer.py
+++ b/confluent_kafka/avro/serializer/message_serializer.py
@@ -169,9 +169,13 @@ class MessageSerializer(object):
         if HAS_FAST:
             # try to use fast avro
             try:
-                writer_schema = writer_schema_obj.to_json()
-                reader_schema = reader_schema_obj.to_json()
-                schemaless_reader(payload, writer_schema)
+                writer_schema = self.registry_client.get_by_id_fast(schema_id)
+                if writer_schema is None:
+                    writer_schema = writer_schema_obj.to_json()
+                reader_schema = None
+                if reader_schema_obj is not None:
+                    reader_schema = reader_schema_obj.to_json()
+                schemaless_reader(payload, writer_schema, reader_schema)
 
                 # If we reach this point, this means we have fastavro and it can
                 # do this deserialization. Rewind since this method just determines


### PR DESCRIPTION
… Don't force fastavro to re-parse from JSON every time; cache the result. Added a flag to disable message key decoding.

As the commit message summarises, this improves a few things. I'll elaborate:
1) Addresses #616, where `fastavro` would no longer be used by default.
2) I also addressed #518 while I was working on the above, so that `fastavro` will no longer be forced to reparse the schema dict for every message.
3) Finally, I made the key decoding in `AvroConsumer` optional (but on by default). The main reason for this is that it is not, as far as I can tell, a requirement to encode both for a given topic. One very good reason for only Avro-encoding message values and not keys is that KSQL actually requires this! See confluentinc/ksql#824, for example.

Potentially point 3 at least would be superseded by #502, if that's still planned. However, we needed a way of disabling this more immediately. Let me know if you would therefore like me to minimise this PR at all.