### PR TITLE
Have fastavro log on deserialization failures

### DIFF
--- a/confluent_kafka/avro/serializer/message_serializer.py
+++ b/confluent_kafka/avro/serializer/message_serializer.py
@@ -183,8 +183,7 @@ class MessageSerializer(object):
                     p, writer_schema, reader_schema)
                 return self.id_to_decoder_func[schema_id]
             except Exception:
-                # Fast avro failed, fall thru to standard avro below.
-                pass
+                log.warning("Fast avro failed for schema with id %d, falling thru to standard avro" % (schema_id))
 
         # here means we should just delegate to slow avro
         # rewind


### PR DESCRIPTION
I was troubleshooting an issue similar to the one found in https://github.com/confluentinc/schema-registry/issues/426 and felt it would be easier to spot these types of issues if fastavro deserialization failures logged a warning message, instead of silently falling back to standard avro.