### PR TITLE
Avro consumer: don't require the key to have a schema

### DIFF
--- a/confluent_kafka/avro/serializer/message_serializer.py
+++ b/confluent_kafka/avro/serializer/message_serializer.py
@@ -216,12 +216,18 @@ class MessageSerializer(object):
         if message is None:
             return None
 
-        if len(message) <= 5:
+        if len(message) <= 5 and not is_key:
             raise SerializerError("message is too small to decode")
 
         with ContextStringIO(message) as payload:
             magic, schema_id = struct.unpack('>bI', payload.read(5))
             if magic != MAGIC_BYTE:
-                raise SerializerError("message does not start with magic byte")
+                if not is_key:
+                    raise SerializerError("message does not start with magic byte")
+                key_str = payload.getvalue().decode('utf-8')
+                print('Warning: decoding key as string', key_str)
+                return key_str
             decoder_func = self._get_decoder_func(schema_id, payload, is_key)
             return decoder_func(payload)
+
+


### PR DESCRIPTION
I am working through this [ksql udemy course](https://www.udemy.com/kafka-ksql) and got interested in manually reading underlying topic from this KSQL stream:

```sql
create stream requested_journey as
select rr.latitude as from_latitude
, rr.longitude as from_longitude
, rr.user
, rr.city_name as city_name
, w.city_country
, w.latitude as to_latitude
, w.longitude as to_longitude
, w.description as weather_description
, w.rain
from rr_world rr
left join weathernow w on rr.city_name = w.city_name;
```
With this script:

```python
from confluent_kafka import KafkaError
from confluent_kafka.avro import AvroConsumer
from confluent_kafka.avro.serializer import SerializerError

c = AvroConsumer({
    'bootstrap.servers': 'localhost:9092',
    'group.id': 'groupid3',
    'schema.registry.url': 'http://localhost:8081',
    'auto.offset.reset': 'earliest'
    })

c.subscribe(['REQUESTED_JOURNEY'])

while True:
    try:
        msg = c.poll(10)
    except SerializerError as e:
        print("Message deserialization failed {}".format(e))
        continue
    if msg is None:
        continue
    if msg.error():
        print("AvroConsumer error: {}".format(msg.error()))
        continue
    print('\n\nMsg key = ', msg.key(), '\nMsg Value = ', msg.value())
    print(msg.value())
c.close()
```

It seems that this topic has a schema for the value:

![image](https://user-images.githubusercontent.com/463534/62420171-84ea5000-b653-11e9-8318-f7332b4849cc.png)

but **NOT** for the key

![image](https://user-images.githubusercontent.com/463534/62420186-b9f6a280-b653-11e9-9c92-c6b795b6e2ba.png)

So my script fails with the error:

``message does not start with magic byte``

I'm aware my changes in this merge request are a dirty hack, but I'd like to start a discussion on a proper fix.

Btw, the output of my script with these changes is:

```
Msg key =  Liverpool
Msg Value =  {'FROM_LATITUDE': 50.770315988486665, 'FROM_LONGITUDE': 1.1781419675310865, 'USER': 'Heidi', 'CITY_NAME': 'Liverpool', 'CITY_COUNTRY': 'GB', 'TO_LATITUDE': 53.4084, 'TO_LONGITUDE': -2.9916, 'WEATHER_DESCRIPTION': 'haze', 'RAIN': 3.0}
{'FROM_LATITUDE': 50.770315988486665, 'FROM_LONGITUDE': 1.1781419675310865, 'USER': 'Heidi', 'CITY_NAME': 'Liverpool', 'CITY_COUNTRY': 'GB', 'TO_LATITUDE': 53.4084, 'TO_LONGITUDE': -2.9916, 'WEATHER_DESCRIPTION': 'haze', 'RAIN': 3.0}
Warning: decoding key as string London


Msg key =  London
Msg Value =  {'FROM_LATITUDE': 50.11712903564495, 'FROM_LONGITUDE': -0.36741093798582325, 'USER': 'Bob', 'CITY_NAME': 'London', 'CITY_COUNTRY': 'GB', 'TO_LATITUDE': 51.5074, 'TO_LONGITUDE': -0.1278, 'WEATHER_DESCRIPTION': 'heavy rain', 'RAIN': 8.0}
{'FROM_LATITUDE': 50.11712903564495, 'FROM_LONGITUDE': -0.36741093798582325, 'USER': 'Bob', 'CITY_NAME': 'London', 'CITY_COUNTRY': 'GB', 'TO_LATITUDE': 51.5074, 'TO_LONGITUDE': -0.1278, 'WEATHER_DESCRIPTION': 'heavy rain', 'RAIN': 8.0}

...
```