### PR TITLE
Fix doc avro 495

### DIFF
--- a/confluent_kafka/avro/cached_schema_registry_client.py
+++ b/confluent_kafka/avro/cached_schema_registry_client.py
@@ -50,7 +50,8 @@ class CachedSchemaRegistryClient(object):
 
     See http://confluent.io/docs/current/schema-registry/docs/intro.html for more information.
 
-    .. deprecated::
+    .. deprecated:: 1.1.0
+
     Use CachedSchemaRegistryClient(dict: config) instead.
     Existing params ca_location, cert_location and key_location will be replaced with their librdkafka equivalents:
     `ssl.ca.location`, `ssl.certificate.location` and `ssl.key.location` respectively.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -44,8 +44,8 @@ Avro
 .. automodule:: confluent_kafka.avro
    :members:
 
-   .. autoclass:: confluent_kafka.avro.CachedSchemaRegistryClient
-      :members:
+.. autoclass:: confluent_kafka.avro.CachedSchemaRegistryClient
+   :members:
 
 *******
 Message

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -44,6 +44,8 @@ Avro
 .. automodule:: confluent_kafka.avro
    :members:
 
+   .. autoclass:: confluent_kafka.avro.CachedSchemaRegistryClient
+      :members:
 
 *******
 Message
@@ -147,4 +149,3 @@ The Python bindings also provide some additional configuration properties:
     mylogger = logging.getLogger()
     mylogger.addHandler(logging.StreamHandler())
     producer = confluent_kafka.Producer({'bootstrap.servers': 'mybroker.com'}, logger=mylogger)
-


### PR DESCRIPTION
This is a fix for 495.  This includes the cached schema registry in the doc generation.