### PR TITLE
Fix for 644 signature mismatch

### DIFF
--- a/confluent_kafka/src/AdminTypes.c
+++ b/confluent_kafka/src/AdminTypes.c
@@ -437,7 +437,7 @@ PyTypeObject NewPartitionsType = {
         "NewPartitions specifies per-topic settings for passing to "
         "passed to AdminClient.create_partitions().\n"
         "\n"
-        ".. py:function:: NewPartitions(topic, new_total_count, [replication_factor], [replica_assignment])\n"
+        ".. py:function:: NewPartitions(topic, new_total_count, [replica_assignment])\n"
         "\n"
         "  Instantiate a NewPartitions object.\n"
         "\n"


### PR DESCRIPTION
An extra argument was specified in the doc signature.  This fixes the discrepancy.  This resolves bug 644