### PR TITLE
Add wheel metadata for additional libs

### DIFF
--- a/tools/fixup-wheels.sh
+++ b/tools/fixup-wheels.sh
@@ -12,6 +12,7 @@ set -e
 wheelhouse=$1
 fixed_wheelhouse=$2
 platform=$(uname -s)
+gen_record_row=$(dirname $(readlink -f $0))/generate-record-row.py
 
 stagedir=$PWD/staging
 
@@ -26,7 +27,13 @@ fi
 
 mkdir -p $fixed_wheelhouse
 
+find_record_file () {
+  find . -name RECORD -type f | head -1
+}
+
 fixup_wheel_linux () {
+
+    local record_path=$(find_record_file)
 
     pushd confluent_kafka/.libs
 
@@ -62,6 +69,8 @@ fixup_wheel_linux () {
         fi
         echo "$lib dependencies:"
         ldd $lib
+
+        $gen_record_row $lib confluent_kafka/.libs/ >> ../../$record_path
     done
 
     popd # confluent_kafka/.libs
@@ -69,6 +78,8 @@ fixup_wheel_linux () {
 
 
 fixup_wheel_macosx () {
+
+    local record_path=$(find_record_file)
 
     pushd confluent_kafka/.dylibs
 
@@ -93,6 +104,8 @@ fixup_wheel_macosx () {
             echo "WARNING: couldn't find librdkafka reference in $lib"
             otool -L $lib
         fi
+
+        $gen_record_row $lib confluent_kafka/.dylibs/ >> ../../$record_path
 
     done
 
@@ -164,6 +177,3 @@ fi
 for wheel in $wheelhouse/*${wheelmatch}*.whl ; do
     fixup_wheel "$wheel"
 done
-
-
-

--- a/tools/generate-record-row.py
+++ b/tools/generate-record-row.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python
+"""
+Generate wheel metadata RECORD file row for given file.
+
+Usefull in cases where you want to postprocess the wheel archive e.g. include
+additional libraries after the wheel has been build.
+"""
+import argparse
+import base64
+import csv
+import hashlib
+import os
+import sys
+
+if sys.version_info[0] < 3:
+
+    def native(s, encoding="utf-8"):
+        if isinstance(s, unicode):  # noqa: F821
+            return s.encode(encoding)
+        return s
+
+
+else:
+
+    def native(s, encoding="utf-8"):
+        if isinstance(s, bytes):
+            return s.decode(encoding)
+        return s
+
+
+def urlsafe_b64encode(data):
+    """urlsafe_b64encode without padding"""
+    return base64.urlsafe_b64encode(data).rstrip(b"=")
+
+
+def gen_record_row(fname, prefix=""):
+    writer = csv.writer(sys.stdout, delimiter=",", quotechar='"', lineterminator="\n")
+    with open(fname, "rb") as f:
+        writer.writerow(
+            (
+                prefix + fname,
+                "sha256="
+                + native(urlsafe_b64encode(hashlib.sha256(f.read()).digest())),
+                os.stat(fname).st_size,
+            )
+        )
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("fname", help="Path to the library.")
+    parser.add_argument("prefix", help="Used to prefix path in the RECORD file.")
+    args = parser.parse_args()
+    gen_record_row(args.fname, args.prefix)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This PR adds correct metadata to the wheel RECORD file for additional libraries.

Since some libraries are added to the wheels without also adding their correct metadata to the wheel RECORD file wheel verification process is failing.

That means that for example creating a [pex](https://github.com/pantsbuild/pex) distribution will fail with:

```
$ pex confluent_kafka -o test.pex
...
pex.vendor._vendored.wheel.wheel.install.BadWheelFile: No expected hash for file 'confluent_kafka/.libs/monitoring-interceptor.so'
```