### PR TITLE
Calling consumer.close() multiple times should not raise an Exception

### DIFF
--- a/confluent_kafka/src/Consumer.c
+++ b/confluent_kafka/src/Consumer.c
@@ -981,11 +981,8 @@ static PyObject *Consumer_consume (Handle *self, PyObject *args,
 static PyObject *Consumer_close (Handle *self, PyObject *ignore) {
         CallState cs;
 
-        if (!self->rk) {
-                PyErr_SetString(PyExc_RuntimeError,
-                                "Consumer already closed");
-                return NULL;
-        }
+        if (!self->rk)
+                Py_RETURN_NONE;
 
         CallState_begin(self, &cs);
 
@@ -1275,7 +1272,6 @@ static PyMethodDef Consumer_methods[] = {
 	  "see :py:func::`poll()` for more info.\n"
 	  "\n"
 	  "  :rtype: None\n"
-      "  :raises: RuntimeError if called on a closed consumer\n"
 	  "\n"
 	},
         { "list_topics", (PyCFunction)list_topics, METH_VARARGS|METH_KEYWORDS,


### PR DESCRIPTION
Currently, calling `consumer.close` more than once will raise a `RuntimeError: Consumer already closed`.

The proposed changes will just return NULL if the user calls `close` on a consumer that has already been closed.

This will make it rerunnable and allow the developer to not have to trap this exception.