### PR TITLE
Closing consumer multiple times should not raise RunTimeError

### DIFF
--- a/confluent_kafka/src/Consumer.c
+++ b/confluent_kafka/src/Consumer.c
@@ -981,11 +981,8 @@ static PyObject *Consumer_consume (Handle *self, PyObject *args,
 static PyObject *Consumer_close (Handle *self, PyObject *ignore) {
         CallState cs;
 
-        if (!self->rk) {
-                PyErr_SetString(PyExc_RuntimeError,
-                                "Consumer already closed");
-                return NULL;
-        }
+        if (!self->rk)
+                Py_RETURN_NONE;
 
         CallState_begin(self, &cs);
 
@@ -1275,7 +1272,6 @@ static PyMethodDef Consumer_methods[] = {
 	  "see :py:func::`poll()` for more info.\n"
 	  "\n"
 	  "  :rtype: None\n"
-      "  :raises: RuntimeError if called on a closed consumer\n"
 	  "\n"
 	},
         { "list_topics", (PyCFunction)list_topics, METH_VARARGS|METH_KEYWORDS,

--- a/tests/test_Consumer.py
+++ b/tests/test_Consumer.py
@@ -209,8 +209,8 @@ def test_offsets_for_times():
     c.close()
 
 
-def test_multiple_close_throw_exception():
-    """ Calling Consumer.close() multiple times should throw Runtime Exception
+def test_multiple_close_does_not_throw_exception():
+    """ Calling Consumer.close() multiple times should not throw Runtime Exception
     """
     c = Consumer({'group.id': 'test',
                   'enable.auto.commit': True,
@@ -222,10 +222,7 @@ def test_multiple_close_throw_exception():
 
     c.unsubscribe()
     c.close()
-
-    with pytest.raises(RuntimeError) as ex:
-        c.close()
-    assert ex.match('Consumer already closed')
+    c.close()
 
 
 def test_any_method_after_close_throws_exception():


### PR DESCRIPTION
The current behavior is to raise a `RunTimeError` if `consumer.close` is called more than once.

This proposed change makes `close` rerunnable by not raising `RunTimeError` if it is called more than once.

This will make it convenient for developers to safely call consumer.close in a `finally` or a context manager without having to trap this exception.

The use case is to make `close` rerunnable, for example if you wanted to make a context manager, or if you had a large function wrapped in a try/except/finally. Another programmer who calls your context manager can close inside if he wants; otherwise the context manager will close for him.

    import contextlib
    from confluent_kafka import Consumer
    
    @contextlib.contextmanager
    def kafka():
        consumer = Consumer({...})
        try:
            yield consumer
        finally:
            # currently, would need to wrap this in a try/except
            consumer.close()

    # ...
    # Some programmers may want to call close explicitly
    with kafka() as consumer:
            # do something
            consumer.close()

    # Other programmers would prefer the context manager to take care
    with kafka() as consumer:
        # do something


I'm also under the impression that the majority of the other python libraries that close resources also make close rerunnable. I think it would be a good idea to have confluent_kafka follow this pattern.

    from requests import Session
    s = Session()
    s.close()
    s.close()  # does not raise an exception

    import sqlite3
    conn = sqlite3.connect(':memory:')
    conn.close()
    conn.close()  # does not raise an exception