### PR TITLE
Let GitHub identify repo as Python

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# "Hide" .c files from github's language detection so the repository shows up as Python, not C 
+ *.c linguist-vendored=true


### PR DESCRIPTION
Not sure if we can even try this out without merging, so might as well just merge and wait for search caches to get updated.

More info:
https://github.com/github/linguist/blob/master/README.md#overrides
https://github.com/github/markup/issues/892#issuecomment-222289077