### PR TITLE
Significant performance boost: only write to the writer schema cache once.

### DIFF
--- a/confluent_kafka/avro/serializer/message_serializer.py
+++ b/confluent_kafka/avro/serializer/message_serializer.py
@@ -110,7 +110,8 @@ class MessageSerializer(object):
             raise serialize_err(message)
 
         # cache writer
-        self.id_to_writers[schema_id] = self._get_encoder_func(schema)
+        if schema_id not in self.id_to_writers:
+            self.id_to_writers[schema_id] = self._get_encoder_func(schema)
 
         return self.encode_record_with_schema_id(schema_id, record, is_key=is_key)
 

--- a/tests/avro/data_gen.py
+++ b/tests/avro/data_gen.py
@@ -54,7 +54,7 @@ def create_basic_item(i):
     }
 
 
-BASIC_ITEMS = map(create_basic_item, range(1, 20))
+BASIC_ITEMS = list(map(create_basic_item, range(1, 20)))
 
 ADVANCED_SCHEMA = load_schema_file(os.path.join(avsc_dir, 'adv_schema.avsc'))
 
@@ -68,7 +68,7 @@ def create_adv_item(i):
     return basic
 
 
-ADVANCED_ITEMS = map(create_adv_item, range(1, 20))
+ADVANCED_ITEMS = list(map(create_adv_item, range(1, 20)))
 
 
 def _write_items(base_name, schema_str, items):


### PR DESCRIPTION
We noticed a performance problem with confluent-kafka-python while profiling our app: `_get_decoder_func` was being called a small number of times and took up a tiny amount of time, but `_get_encoder_func` seemed as if it was being called once per message and was taking up about 10% of our total runtime. This one-line patch gave us a 9% speed boost.

What's happening is that we have a cache for the encoder functions, but we're not actually using it in the `encode_record_with_schema` method: https://github.com/confluentinc/confluent-kafka-python/blob/50e09cf35445a7c2709c3e97683c17f171d4a9eb/confluent_kafka/avro/serializer/message_serializer.py#L113 Every time that method is called, it will set a new entry in the `id_to_writers` cache, even if an identical one already exists. The fix is trivial: we should actually use the cache and not set new entries if there's already one in there.