### PR TITLE
Fix crash when new topic is not created.

### DIFF
--- a/confluent_kafka/src/Admin.c
+++ b/confluent_kafka/src/Admin.c
@@ -394,7 +394,6 @@ static PyObject *Admin_create_topics (Handle *self, PyObject *args,
                         PyErr_Format(PyExc_ValueError,
                                      "Invalid NewTopic(%s): %s",
                                      newt->topic, errstr);
-                        i++;
                         goto err;
                 }
 


### PR DESCRIPTION
I found that the following code caused a crash:

```

from confluent_kafka.admin import AdminClient
from confluent_kafka.cimpl import NewTopic

client = AdminClient({})
topics = [NewTopic(topic='foo', num_partitions=0)]
client.create_topics(topics)
```

This pull request, fixes the issue. The problem was that when a topic failed to be created, like in this case where the number of partitions is zero, we would still try to free the topic, causing a null pointer to be de-referenced in rdkafka.

While, this is also a bug in rdkafka, since a null pointer should not be de-referenced either way, we should not pass such a pointer to a library either.