### PR TITLE
Correct the SchemaRegistry authentication for SASL_INHERIT

### DIFF
--- a/confluent_kafka/avro/__init__.py
+++ b/confluent_kafka/avro/__init__.py
@@ -33,7 +33,7 @@ class AvroProducer(Producer):
                    for key, value in config.items() if key.startswith("schema.registry")}
 
         if sr_conf.get("basic.auth.credentials.source") == 'SASL_INHERIT':
-            sr_conf['sasl.mechanisms'] = config.get('sasl.mechanisms', '')
+            sr_conf['sasl.mechanism'] = config.get('sasl.mechanism', '')
             sr_conf['sasl.username'] = config.get('sasl.username', '')
             sr_conf['sasl.password'] = config.get('sasl.password', '')
 
@@ -110,7 +110,7 @@ class AvroConsumer(Consumer):
                    for key, value in config.items() if key.startswith("schema.registry")}
 
         if sr_conf.get("basic.auth.credentials.source") == 'SASL_INHERIT':
-            sr_conf['sasl.mechanisms'] = config.get('sasl.mechanisms', '')
+            sr_conf['sasl.mechanism'] = config.get('sasl.mechanism', '')
             sr_conf['sasl.username'] = config.get('sasl.username', '')
             sr_conf['sasl.password'] = config.get('sasl.password', '')
 

--- a/confluent_kafka/avro/__init__.py
+++ b/confluent_kafka/avro/__init__.py
@@ -33,7 +33,8 @@ class AvroProducer(Producer):
                    for key, value in config.items() if key.startswith("schema.registry")}
 
         if sr_conf.get("basic.auth.credentials.source") == 'SASL_INHERIT':
-            sr_conf['sasl.mechanism'] = config.get('sasl.mechanism', '')
+            # Fallback to plural 'mechanisms' for backward compatibility
+            sr_conf['sasl.mechanism'] = config.get('sasl.mechanism', config.get('sasl.mechanisms', ''))
             sr_conf['sasl.username'] = config.get('sasl.username', '')
             sr_conf['sasl.password'] = config.get('sasl.password', '')
 
@@ -110,7 +111,8 @@ class AvroConsumer(Consumer):
                    for key, value in config.items() if key.startswith("schema.registry")}
 
         if sr_conf.get("basic.auth.credentials.source") == 'SASL_INHERIT':
-            sr_conf['sasl.mechanism'] = config.get('sasl.mechanism', '')
+            # Fallback to plural 'mechanisms' for backward compatibility
+            sr_conf['sasl.mechanism'] = config.get('sasl.mechanism', config.get('sasl.mechanisms', ''))
             sr_conf['sasl.username'] = config.get('sasl.username', '')
             sr_conf['sasl.password'] = config.get('sasl.password', '')
 

--- a/confluent_kafka/avro/cached_schema_registry_client.py
+++ b/confluent_kafka/avro/cached_schema_registry_client.py
@@ -135,8 +135,8 @@ class CachedSchemaRegistryClient(object):
             raise ValueError("schema.registry.basic.auth.credentials.source must be one of {}"
                              .format(VALID_AUTH_PROVIDERS))
         if auth_provider == 'SASL_INHERIT':
-            if conf.pop('sasl.mechanism', '').upper() is ['GSSAPI']:
-                raise ValueError("SASL_INHERIT does not support SASL mechanisms GSSAPI")
+            if conf.pop('sasl.mechanism', '').upper() == 'GSSAPI':
+                raise ValueError("SASL_INHERIT does not support SASL mechanism GSSAPI")
             auth = (conf.pop('sasl.username', ''), conf.pop('sasl.password', ''))
         elif auth_provider == 'USER_INFO':
             auth = tuple(conf.pop('basic.auth.user.info', '').split(':'))

--- a/examples/confluent_cloud.py
+++ b/examples/confluent_cloud.py
@@ -53,7 +53,7 @@ from confluent_kafka import Producer, Consumer
 
 p = Producer({
     'bootstrap.servers': '<ccloud bootstrap servers>',
-    'sasl.mechanisms': 'PLAIN',
+    'sasl.mechanism': 'PLAIN',
     'security.protocol': 'SASL_SSL',
     'sasl.username': '<ccloud key>',
     'sasl.password': '<ccloud secret>'
@@ -78,7 +78,7 @@ p.flush(10)
 
 c = Consumer({
     'bootstrap.servers': '<ccloud bootstrap servers>',
-    'sasl.mechanisms': 'PLAIN',
+    'sasl.mechanism': 'PLAIN',
     'security.protocol': 'SASL_SSL',
     'sasl.username': '<ccloud key>',
     'sasl.password': '<ccloud secret>',

--- a/examples/confluent_cloud.py
+++ b/examples/confluent_cloud.py
@@ -53,10 +53,15 @@ from confluent_kafka import Producer, Consumer
 
 p = Producer({
     'bootstrap.servers': '<ccloud bootstrap servers>',
-    'sasl.mechanisms': 'PLAIN',
+    'sasl.mechanism': 'PLAIN',
     'security.protocol': 'SASL_SSL',
     'sasl.username': '<ccloud key>',
-    'sasl.password': '<ccloud secret>'
+    'sasl.password': '<ccloud secret>',
+    # (Optional) Schema Registry
+    # Note: SchemaRegistry has separate credentials.
+    'schema.registry.url': '<ccloud schema registry endpoint>',
+    'schema.registry.basic.auth.credentials.source': 'USER_INFO',
+    'schema.registry.basic.auth.user.info': '<ccloud registry key>:<ccloud registry secret>'
 })
 
 
@@ -78,12 +83,16 @@ p.flush(10)
 
 c = Consumer({
     'bootstrap.servers': '<ccloud bootstrap servers>',
-    'sasl.mechanisms': 'PLAIN',
+    'sasl.mechanism': 'PLAIN',
     'security.protocol': 'SASL_SSL',
     'sasl.username': '<ccloud key>',
     'sasl.password': '<ccloud secret>',
     'group.id': str(uuid.uuid1()),  # this will create a new consumer group on each invocation.
-    'auto.offset.reset': 'earliest'
+    'auto.offset.reset': 'earliest',
+    # (Optional) Schema Registry (separate credentials).
+    'schema.registry.url': '<ccloud schema registry endpoint>',
+    'schema.registry.basic.auth.credentials.source': 'USER_INFO',
+    'schema.registry.basic.auth.user.info': '<ccloud registry key>:<ccloud registry secret>',
 })
 
 c.subscribe(['python-test-topic'])

--- a/examples/confluent_cloud.py
+++ b/examples/confluent_cloud.py
@@ -53,15 +53,10 @@ from confluent_kafka import Producer, Consumer
 
 p = Producer({
     'bootstrap.servers': '<ccloud bootstrap servers>',
-    'sasl.mechanism': 'PLAIN',
+    'sasl.mechanisms': 'PLAIN',
     'security.protocol': 'SASL_SSL',
     'sasl.username': '<ccloud key>',
-    'sasl.password': '<ccloud secret>',
-    # (Optional) Schema Registry
-    # Note: SchemaRegistry has separate credentials.
-    'schema.registry.url': '<ccloud schema registry endpoint>',
-    'schema.registry.basic.auth.credentials.source': 'USER_INFO',
-    'schema.registry.basic.auth.user.info': '<ccloud registry key>:<ccloud registry secret>'
+    'sasl.password': '<ccloud secret>'
 })
 
 
@@ -83,16 +78,12 @@ p.flush(10)
 
 c = Consumer({
     'bootstrap.servers': '<ccloud bootstrap servers>',
-    'sasl.mechanism': 'PLAIN',
+    'sasl.mechanisms': 'PLAIN',
     'security.protocol': 'SASL_SSL',
     'sasl.username': '<ccloud key>',
     'sasl.password': '<ccloud secret>',
     'group.id': str(uuid.uuid1()),  # this will create a new consumer group on each invocation.
-    'auto.offset.reset': 'earliest',
-    # (Optional) Schema Registry (separate credentials).
-    'schema.registry.url': '<ccloud schema registry endpoint>',
-    'schema.registry.basic.auth.credentials.source': 'USER_INFO',
-    'schema.registry.basic.auth.user.info': '<ccloud registry key>:<ccloud registry secret>',
+    'auto.offset.reset': 'earliest'
 })
 
 c.subscribe(['python-test-topic'])

--- a/tests/avro/test_cached_client.py
+++ b/tests/avro/test_cached_client.py
@@ -204,6 +204,15 @@ class TestCacheSchemaRegistryClient(unittest.TestCase):
         })
         self.assertTupleEqual(('user_sasl', 'secret_sasl'), self.client._session.auth)
 
+    def test_basic_auth_sasl_inherit_invalid(self):
+        with self.assertRaises(ValueError) as e:
+            self.client = CachedSchemaRegistryClient({
+                'url': 'https://user_url:secret_url@127.0.0.1:65534',
+                'basic.auth.credentials.source': 'SASL_INHERIT',
+                'sasl.mechanism': 'gssapi'  # also test the .upper()
+            })
+        self.assertEqual(str(e.exception), "SASL_INHERIT does not support SASL mechanism GSSAPI")
+
     def test_basic_auth_invalid(self):
         with self.assertRaises(ValueError):
             self.client = CachedSchemaRegistryClient({


### PR DESCRIPTION
We ran into an issue connecting the SchemaRegistry inside the Producer.

I looked into the problem, it turns out the Server(broker) can use multiple `sasl.mechanisms` (plural) and the clients (producer / consumer) `sasl.mechanism` (singular). There was an issue passing through this config, when the setting `schema.registry.basic.auth.credentials.source` is set to `SASL_INHERIT`.

I think there is no point in inheriting the credentials, since the SchemaRegistry has separate key/secret, but maybe there is a way to use the same credentials for both (SR + Cluster).

This PR will fix the SASL_INHERIT in SchemaRegistry.

I did add an example for `confluent_cloud.py`, but looks like the `avro-cli.py` has a working solution already, so I reverted this commit.