### PR TITLE
README: Add delivery report to Avro example

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Confluent's Python Client for Apache Kafka<sup>TM</sup>
 [Apache Kafka<sup>TM<sup>](http://kafka.apache.org/) brokers >= v0.8, [Confluent Cloud](https://www.confluent.io/confluent-cloud/)
 and the [Confluent Platform](https://www.confluent.io/product/compare/). The client is:
 
-- **Reliable** - It's a wrapper around [librdkafka](https://github.com/edenhill/librdkafka) (provided automatically via binary wheels) which is widely deployed in a diverse set of production scenarios. It's tested using [the same set of system tests](https://github.com/confluentinc/confluent-kafka-python/tree/master/confluent_kafka/kafkatest) as the Java client [and more](https://github.com/confluentinc/confluent-kafka-python/tree/master/tests). It's supported by [Confluent](https://confluent.io). 
+- **Reliable** - It's a wrapper around [librdkafka](https://github.com/edenhill/librdkafka) (provided automatically via binary wheels) which is widely deployed in a diverse set of production scenarios. It's tested using [the same set of system tests](https://github.com/confluentinc/confluent-kafka-python/tree/master/confluent_kafka/kafkatest) as the Java client [and more](https://github.com/confluentinc/confluent-kafka-python/tree/master/tests). It's supported by [Confluent](https://confluent.io).
 
 - **Performant** - Performance is a key design consideration. Maximum throughput is on par with the Java client for larger message sizes (where the overhead of the Python interpreter has less impact). Latency is on par with the Java client.
 
@@ -125,8 +125,19 @@ key_schema = avro.loads(key_schema_str)
 value = {"name": "Value"}
 key = {"name": "Key"}
 
+
+def delivery_report(err, msg):
+    """ Called once for each message produced to indicate delivery result.
+        Triggered by poll() or flush(). """
+    if err is not None:
+        print('Message delivery failed: {}'.format(err))
+    else:
+        print('Message delivered to {} [{}]'.format(msg.topic(), msg.partition()))
+
+
 avroProducer = AvroProducer({
     'bootstrap.servers': 'mybroker,mybroker2',
+    'on_delivery': delivery_report,
     'schema.registry.url': 'http://schema_registry_host:port'
     }, default_key_schema=key_schema, default_value_schema=value_schema)
 


### PR DESCRIPTION
The AvroProducer.produce() call should also take an on_delivery|callback argument.

See discussion in https://github.com/confluentinc/confluent-kafka-python/issues/741#issuecomment-565042361