### PR TITLE
fix error with trailing slash at the end

### DIFF
--- a/tests/avro/test_cached_client.py
+++ b/tests/avro/test_cached_client.py
@@ -180,6 +180,12 @@ class TestCacheSchemaRegistryClient(unittest.TestCase):
                 'url': 'example.com:65534'
             })
 
+    def test_trailing_slash_removal(self):
+        self.client = CachedSchemaRegistryClient({
+            'url': 'http://127.0.0.1:65534/'
+        })
+        self.assertEqual(self.client.url, "http://127.0.0.1:65534")
+
     def test_basic_auth_url(self):
         self.client = CachedSchemaRegistryClient({
             'url': 'https://user_url:secret_url@127.0.0.1:65534',


### PR DESCRIPTION
To whom it may concern:

if you define the url for schema registry with `/` in the end, the lib will construct the wrong one.

Example:
`schema_registy_host=http://localhost:1234/`
will lead to `http://localhost:1234//schemas/whatever_next`

The lib does strip the `/` at the end of the string [here](https://github.com/confluentinc/confluent-kafka-python/blob/master/confluent_kafka/avro/cached_schema_registry_client.py#L95)

but [several lines below](https://github.com/confluentinc/confluent-kafka-python/blob/master/confluent_kafka/avro/cached_schema_registry_client.py#L111) get the deleted url from config with '/'.

So, with this fix there will be no error if the path of the schema registry will be defined like so:
`http://localhost:1234/`