### PR TITLE
Configure cibuildwheel to use manylinux1 with wide-unicode support(#751)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,11 @@ matrix:
   - os: linux
     dist: trusty
     sudo: required
-    env: CIBW_BEFORE_BUILD="tools/prepare-cibuildwheel-linux.sh ${LIBRDKAFKA_VERSION}"
+    env:
+      - CIBW_BEFORE_BUILD="tools/prepare-cibuildwheel-linux.sh ${LIBRDKAFKA_VERSION}"
+      - PYTHON_CONFIGURE_OPTS="--enable-unicode=ucs4 --with-wide-unicode"
+      - CIBW_MANYLINUX_X86_64_IMAGE="manylinux1"
+      - CIBW_MANYLINUX_I686_IMAGE="manylinux1
     language: python
     python: "2.7"
     services: docker


### PR DESCRIPTION
cibuildwheel no longer builds `manylinux1` builds by default which means we are no longer providing wheels compatible with older installations of pip. Setting the build image to manylinux1 alone is not enough as it will only build wheels with narrow-width unicode abi support ootb. The addition of the ucs4 flag ensures both variants are built restoring the previous behaviour of the build. 

Pip selects wheel eligibility based on the flags described in pep 425. 
https://www.python.org/dev/peps/pep-0425/

Python versions 3.4+ no longer have to concern themselves with unicode width abi compatibility.
https://www.python.org/dev/peps/pep-0393/ 