### PR TITLE
Add support for fastavro when reader schema isn't provided.

### DIFF
--- a/confluent_kafka/avro/serializer/message_serializer.py
+++ b/confluent_kafka/avro/serializer/message_serializer.py
@@ -175,7 +175,8 @@ class MessageSerializer(object):
             # try to use fast avro
             try:
                 fast_avro_writer_schema = parse_schema(writer_schema_obj.to_json())
-                fast_avro_reader_schema = parse_schema(reader_schema_obj.to_json())
+                fast_avro_reader_schema = None if reader_schema_obj is None \
+                    else parse_schema(reader_schema_obj.to_json())
                 schemaless_reader(payload, fast_avro_writer_schema)
 
                 # If we reach this point, this means we have fastavro and it can


### PR DESCRIPTION
Related issue: https://github.com/confluentinc/confluent-kafka-python/issues/616

This is causing issues for people who want to use fastavro but don't want to provide a reader schema. 

It's not just a performance issue, as records are different when using fastavro (for example logical date time are represented as python `datetime` in fastavro, instead of `int`).

I've tested it on my local environment but it'd be better if we can write unit test for this. 

Also it'd be good to get rid of this try catch block that surrounds this statement and swallows important errors. When fastavro isn't installed but doens't work, it should be explicit.