### PR TITLE
Bump Apache Avro to 1.9.2[.1]

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,8 +14,8 @@ INSTALL_REQUIRES = [
 AVRO_REQUIRES = [
     'fastavro',
     'requests',
-    'avro;python_version<"3.0"',
-    'avro-python3==1.9.1;python_version>"3.0"'
+    'avro==1.9.2;python_version<"3.0"',
+    'avro-python3==1.9.2.1;python_version>"3.0"'
 ]
 
 TEST_REQUIRES = [


### PR DESCRIPTION
Follow-up to  #778: currently master is using avro (1.9.2) for python2 and avro-python3 (1.9.1) for python3. 

This PR explicitly pins to released version 1.9.2 and 1.9.2.1 respectively.  The latter includes the fix to the faulty module described in https://issues.apache.org/jira/browse/AVRO-2737