### PR TITLE
Raise import error on module import failure to avoid segfault

### DIFF
--- a/confluent_kafka/src/confluent_kafka.c
+++ b/confluent_kafka/src/confluent_kafka.c
@@ -1952,10 +1952,10 @@ PyObject *cfl_PyObject_lookup (const char *modulename, const char *typename) {
         PyObject *module = PyImport_ImportModule(modulename);
         PyObject *obj;
 
-        if (!modulename) {
-                PyErr_Format(PyExc_TypeError,
-                             "Module %s not found when looking up %s.%s",
-                             modulename, modulename, typename);
+        if (!module) {
+                PyErr_Format(PyExc_ImportError,
+                             "Module not found when looking up %s.%s",
+                             modulename, typename);
                 return NULL;
         }
 


### PR DESCRIPTION
A dependency of confluent-kafka, `enum34`, published a broken version 1.1.8 that caused a segfault in `confluent-kafka` python library when accessing the module `confluent_kafka.admin`.  For example, the list_topics call will try to import this module in function `cfl_PyObject_lookup`.

This results in `module` pointer being nil in the return of this call:
```        PyObject *module = PyImport_ImportModule(modulename);```

and then it gets accessed here
```        obj = PyObject_GetAttrString(module, typename);```
which results in a segfault:
```

Thread 28 "python" received signal SIGSEGV, Segmentation fault.
--
[Switching to Thread 0x7fff96ffd700 (LWP 8778)]
0x00000000004efa6b in PyObject_GetAttrString ()
(gdb) backtrace
#0  0x00000000004efa6b in PyObject_GetAttrString ()
#1  0x00007ffff433dae2 in cfl_PyObject_lookup (modulename=modulename@entry=0x7ffff434a067 "confluent_kafka.admin",
typename=typename@entry=0x7ffff434a057 "ClusterMetadata") at confluent_kafka/src/confluent_kafka.c:1962
#2  0x00007ffff43418a0 in c_metadata_to_py (self=0x7ffff0127440, metadata=0x7fff84002570) at confluent_kafka/src/Metadata.c:267
#3  list_topics (self=0x7ffff0127440, args=<optimized out>, kwargs=<optimized out>) at confluent_kafka/src/Metadata.c:382

```

This pull request is to check the value of module to ensure that it's not null otherwise return a runtime exception.  This will make debugging this issue in the future.

Without patch
```
$ python ~/list.py
Segmentation fault
```

with patch:
```
$ python ~/list.py
Traceback (most recent call last):
  File "/home/brian/list.py", line 5, in <module>
    print producer.list_topics(topic=topic).topics.values()
RuntimeError: Module confluent_kafka.admin import failed.
```
