### PR TITLE
BUG: sasl.mechanism -> sasl.mechanisms 

### DIFF
--- a/confluent_kafka/avro/cached_schema_registry_client.py
+++ b/confluent_kafka/avro/cached_schema_registry_client.py
@@ -135,7 +135,7 @@ class CachedSchemaRegistryClient(object):
             raise ValueError("schema.registry.basic.auth.credentials.source must be one of {}"
                              .format(VALID_AUTH_PROVIDERS))
         if auth_provider == 'SASL_INHERIT':
-            if conf.pop('sasl.mechanism', '').upper() is ['GSSAPI']:
+            if conf.pop('sasl.mechanisms', '').upper() is ['GSSAPI']:
                 raise ValueError("SASL_INHERIT does not support SASL mechanisms GSSAPI")
             auth = (conf.pop('sasl.username', ''), conf.pop('sasl.password', ''))
         elif auth_provider == 'USER_INFO':

--- a/tests/avro/test_cached_client.py
+++ b/tests/avro/test_cached_client.py
@@ -210,7 +210,7 @@ class TestCacheSchemaRegistryClient(unittest.TestCase):
         self.client = CachedSchemaRegistryClient({
             'url': 'https://user_url:secret_url@127.0.0.1:65534',
             'basic.auth.credentials.source': 'SASL_INHERIT',
-            'sasl.mechanism': 'PLAIN',
+            'sasl.mechanisms': 'PLAIN',
             'sasl.username': 'user_sasl',
             'sasl.password': 'secret_sasl'
         })


### PR DESCRIPTION
... when configuring basic auth using SASL_INHERIT. 

Per: https://github.com/confluentinc/confluent-kafka-python/issues/803