### PR TITLE
Fix failure to use fastavro when no Avro reader schema is given

### DIFF
--- a/confluent_kafka/avro/serializer/message_serializer.py
+++ b/confluent_kafka/avro/serializer/message_serializer.py
@@ -175,7 +175,7 @@ class MessageSerializer(object):
             # try to use fast avro
             try:
                 fast_avro_writer_schema = parse_schema(writer_schema_obj.to_json())
-                fast_avro_reader_schema = parse_schema(reader_schema_obj.to_json())
+                fast_avro_reader_schema = parse_schema(reader_schema_obj.to_json()) if reader_schema_obj else None
                 schemaless_reader(payload, fast_avro_writer_schema)
 
                 # If we reach this point, this means we have fastavro and it can


### PR DESCRIPTION
When `MessageSerializer` is initialized without a `reader_schema`, the `to_json` method call on the None value at L178 results in an exception. Since this happens in a broad try/except block that captures all exceptions, it was leading to a silent failure to use the fastavro library in such cases. This is a quick fix for that.