### PR TITLE
typo in function "test_consumer_withot_groupid"

### DIFF
--- a/tests/test_Consumer.py
+++ b/tests/test_Consumer.py
@@ -314,7 +314,7 @@ def test_calling_store_offsets_after_close_throws_erro():
     assert ex.match('Consumer closed')
 
 
-def test_consumer_withot_groupid():
+def test_consumer_without_groupid():
     """ Consumer should raise exception if group.id is not set """
 
     with pytest.raises(ValueError) as ex:


### PR DESCRIPTION
Fixed a typo in the function name.