### PR TITLE
requests auth property takes a tuple and not a list.

### DIFF
--- a/confluent_kafka/schema_registry/schema_registry_client.py
+++ b/confluent_kafka/schema_registry/schema_registry_client.py
@@ -104,7 +104,7 @@ class _RestClient(object):
                                  " remove basic.auth.user.info from the"
                                  " configuration")
 
-            userinfo = conf_copy.pop('basic.auth.user.info', '').split(':')
+            userinfo = tuple(conf_copy.pop('basic.auth.user.info', '').split(':'))
 
             if len(userinfo) != 2:
                 raise ValueError("basic.auth.user.info must be in the form"


### PR DESCRIPTION
Ran into the same issue as https://github.com/confluentinc/confluent-kafka-python/issues/848

Seems like it would be this simple to fix.

Not sure the protocol here for PRs on this repo so I'll open and let you comment.

Thanks!