### PR TITLE
Fix Consume/ProduceError to handle KafkaError constants and instances

### DIFF
--- a/confluent_kafka/deserializing_consumer.py
+++ b/confluent_kafka/deserializing_consumer.py
@@ -128,7 +128,7 @@ class DeserializingConsumer(_ConsumerImpl):
             return None
 
         if msg.error() is not None:
-            raise ConsumeError(msg.error(), message=msg)
+            raise ConsumeError(msg.error(), kafka_message=msg)
 
         ctx = SerializationContext(msg.topic(), MessageField.VALUE)
         value = msg.value()
@@ -136,7 +136,7 @@ class DeserializingConsumer(_ConsumerImpl):
             try:
                 value = self._value_deserializer(value, ctx)
             except Exception as se:
-                raise ValueDeserializationError(exception=se, message=msg)
+                raise ValueDeserializationError(exception=se, kafka_message=msg)
 
         key = msg.key()
         ctx.field = MessageField.KEY
@@ -144,7 +144,7 @@ class DeserializingConsumer(_ConsumerImpl):
             try:
                 key = self._key_deserializer(key, ctx)
             except Exception as se:
-                raise KeyDeserializationError(exception=se, message=msg)
+                raise KeyDeserializationError(exception=se, kafka_message=msg)
 
         msg.set_key(key)
         msg.set_value(value)

--- a/confluent_kafka/error.py
+++ b/confluent_kafka/error.py
@@ -28,8 +28,8 @@ class _KafkaClientError(KafkaException):
 
         exception(Exception, optional): The original exception
 
-        kafka_message (Message, optional): Alternative error message.
-
+        kafka_message (Message, optional): The Kafka Message returned
+        by the broker.
     """
 
     def __init__(self, kafka_error, exception=None, kafka_message=None):
@@ -52,15 +52,15 @@ class ConsumeError(_KafkaClientError):
 
     Note:
         In the event of a serialization error the original message
-        contents may be retrieved from the ``message`` attribute.
+        contents may be retrieved from the ``kafka_message`` attribute.
 
     Args:
         kafka_error (KafkaError): KafkaError instance.
 
         exception(Exception, optional): The original exception
 
-        kafka_message (Message, optional): The Kafka Message returned
-        by the broker.
+        kafka_message (Message, optional): The Kafka Message
+        returned by the broker.
 
     """
 
@@ -76,8 +76,8 @@ class KeyDeserializationError(ConsumeError, SerializationError):
     Args:
         exception(Exception, optional): The original exception
 
-        kafka_message (Message, optional): The Kafka Message returned by
-        the broker.
+        kafka_message (Message, optional): The Kafka Message returned
+        by the broker.
 
     """
 
@@ -95,7 +95,8 @@ class ValueDeserializationError(ConsumeError, SerializationError):
     Args:
         exception(Exception, optional): The original exception
 
-        kafka_message (Message, optional): The Kafka Message returned from the broker.
+        kafka_message (Message, optional): The Kafka Message returned
+        by the broker.
 
     """
 

--- a/confluent_kafka/error.py
+++ b/confluent_kafka/error.py
@@ -28,7 +28,7 @@ class _KafkaClientError(KafkaException):
 
         exception(Exception, optional): The original exception
 
-        message (Message, optional): Alternative error message.
+        message (str, optional): Alternative error message.
 
     """
 
@@ -59,7 +59,7 @@ class ConsumeError(_KafkaClientError):
 
         exception(Exception, optional): The original exception
 
-        message (Message, optional): The Kafka Message returned from the broker.
+        message (str, optional): Alternative error message.
 
     """
 
@@ -75,7 +75,7 @@ class KeyDeserializationError(ConsumeError, SerializationError):
     Args:
         exception(Exception, optional): The original exception
 
-        message (Message, optional): The Kafka Message returned from the broker.
+        message (str, optional): Alternative error message.
 
     """
 
@@ -93,7 +93,7 @@ class ValueDeserializationError(ConsumeError, SerializationError):
     Args:
         exception(Exception, optional): The original exception
 
-        message (Message, optional): The Kafka Message returned from the broker.
+        message (str, optional): Alternative error message.
 
     """
 
@@ -112,7 +112,7 @@ class ProduceError(_KafkaClientError):
 
         exception(Exception, optional): The original exception.
 
-        message (Message, optional): The Kafka Message returned from the broker.
+        message (str, optional): Alternative error message.
 
     """
 

--- a/confluent_kafka/error.py
+++ b/confluent_kafka/error.py
@@ -28,14 +28,14 @@ class _KafkaClientError(KafkaException):
 
         exception(Exception, optional): The original exception
 
-        message (str, optional): Alternative error message.
+        kafka_message (Message, optional): Alternative error message.
 
     """
 
-    def __init__(self, kafka_error, exception=None, message=None):
+    def __init__(self, kafka_error, exception=None, kafka_message=None):
         super(_KafkaClientError, self).__init__(kafka_error)
         self.exception = exception
-        self.message = str(KafkaError) if message is None else message
+        self.kafka_message = kafka_message
 
     @property
     def code(self):
@@ -51,20 +51,21 @@ class ConsumeError(_KafkaClientError):
     Wraps all errors encountered during the consumption of a message.
 
     Note:
-        In the event of a serialization error the original message contents
-        may be retrieved from the ``message`` attribute.
+        In the event of a serialization error the original message
+        contents may be retrieved from the ``message`` attribute.
 
     Args:
         kafka_error (KafkaError): KafkaError instance.
 
         exception(Exception, optional): The original exception
 
-        message (str, optional): Alternative error message.
+        kafka_message (Message, optional): The Kafka Message returned
+        by the broker.
 
     """
 
-    def __init__(self, kafka_error, exception=None, message=None):
-        super(ConsumeError, self).__init__(kafka_error, exception, message)
+    def __init__(self, kafka_error, exception=None, kafka_message=None):
+        super(ConsumeError, self).__init__(kafka_error, exception, kafka_message)
 
 
 class KeyDeserializationError(ConsumeError, SerializationError):
@@ -75,14 +76,15 @@ class KeyDeserializationError(ConsumeError, SerializationError):
     Args:
         exception(Exception, optional): The original exception
 
-        message (str, optional): Alternative error message.
+        kafka_message (Message, optional): The Kafka Message returned by
+        the broker.
 
     """
 
-    def __init__(self, exception=None, message=None):
+    def __init__(self, exception=None, kafka_message=None):
         super(KeyDeserializationError, self).__init__(
             KafkaError(KafkaError._KEY_DESERIALIZATION, str(exception)),
-            exception=exception, message=message)
+            exception=exception, kafka_message=kafka_message)
 
 
 class ValueDeserializationError(ConsumeError, SerializationError):
@@ -93,14 +95,14 @@ class ValueDeserializationError(ConsumeError, SerializationError):
     Args:
         exception(Exception, optional): The original exception
 
-        message (str, optional): Alternative error message.
+        kafka_message (Message, optional): The Kafka Message returned from the broker.
 
     """
 
-    def __init__(self, exception=None, message=None):
+    def __init__(self, exception=None, kafka_message=None):
         super(ValueDeserializationError, self).__init__(
             KafkaError(KafkaError._VALUE_DESERIALIZATION, str(exception)),
-            exception=exception, message=message)
+            exception=exception, kafka_message=kafka_message)
 
 
 class ProduceError(_KafkaClientError):
@@ -111,13 +113,10 @@ class ProduceError(_KafkaClientError):
         kafka_error (KafkaError): KafkaError instance.
 
         exception(Exception, optional): The original exception.
-
-        message (str, optional): Alternative error message.
-
     """
 
-    def __init__(self, kafka_error, exception=None, message=None):
-        super(ProduceError, self).__init__(kafka_error, exception, message)
+    def __init__(self, kafka_error, exception=None):
+        super(ProduceError, self).__init__(kafka_error, exception, None)
 
 
 class KeySerializationError(ProduceError, SerializationError):

--- a/tests/integration/consumer/.gitignore
+++ b/tests/integration/consumer/.gitignore
@@ -1,0 +1,1 @@
+tmp-KafkaCluster

--- a/tests/integration/consumer/.gitignore
+++ b/tests/integration/consumer/.gitignore
@@ -1,1 +1,0 @@
-tmp-KafkaCluster

--- a/tests/integration/consumer/test_consumer_error.py
+++ b/tests/integration/consumer/test_consumer_error.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Copyright 2020 Confluent Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limit
+#
+
+import pytest
+
+from confluent_kafka.error import ConsumeError
+from confluent_kafka.serialization import StringSerializer
+
+
+def test_commit_transaction(kafka_cluster):
+    topic = kafka_cluster.create_topic("test_commit_transaction")
+    consumer_conf = {'enable.partition.eof': True}
+
+    producer = kafka_cluster.producer()
+    producer.produce(topic=topic, value="a")
+    producer.flush()
+
+    consumer = kafka_cluster.consumer(consumer_conf,
+                                      value_deserializer=StringSerializer())
+    consumer.subscribe([topic])
+
+    # read only valid offset
+    consumer.poll()
+
+    with pytest.raises(ConsumeError, match="No more messages"):
+        # Trigger EOF error
+        consumer.poll()

--- a/tests/integration/consumer/test_consumer_error.py
+++ b/tests/integration/consumer/test_consumer_error.py
@@ -17,6 +17,7 @@
 #
 
 import pytest
+from confluent_kafka.cimpl import TopicPartition, OFFSET_END
 
 from confluent_kafka.error import ConsumeError
 from confluent_kafka.serialization import StringSerializer
@@ -36,10 +37,7 @@ def test_consume_error(kafka_cluster):
 
     consumer = kafka_cluster.consumer(consumer_conf,
                                       value_deserializer=StringSerializer())
-    consumer.subscribe([topic])
-
-    # read only valid offset
-    consumer.poll()
+    consumer.assign([TopicPartition(topic, 0, OFFSET_END)])
 
     with pytest.raises(ConsumeError, match="No more messages"):
         # Trigger EOF error

--- a/tests/integration/consumer/test_consumer_error.py
+++ b/tests/integration/consumer/test_consumer_error.py
@@ -22,7 +22,11 @@ from confluent_kafka.error import ConsumeError
 from confluent_kafka.serialization import StringSerializer
 
 
-def test_commit_transaction(kafka_cluster):
+def test_consume_error(kafka_cluster):
+    """
+    Tests to ensure librdkafka errors are propagated as
+    an instance of ConsumeError.
+    """
     topic = kafka_cluster.create_topic("test_commit_transaction")
     consumer_conf = {'enable.partition.eof': True}
 

--- a/tests/test_error.py
+++ b/tests/test_error.py
@@ -43,7 +43,7 @@ def test_new_consume_error_custom_message():
 
     assert ce.code == KafkaError._KEY_SERIALIZATION
     assert ce.name == u'_KEY_SERIALIZATION'
-    assert ce[0].str() == "Unable to serialize key"
+    assert ce.args[0].str() == "Unable to serialize key"
 
 
 def test_new_produce_error_constant():
@@ -68,4 +68,4 @@ def test_new_produce_error_custom_message():
 
     assert pe.code == KafkaError._KEY_SERIALIZATION
     assert pe.name == u'_KEY_SERIALIZATION'
-    assert pe[0].str() == "Unable to serialize key"
+    assert pe.args[0].str() == "Unable to serialize key"

--- a/tests/test_error.py
+++ b/tests/test_error.py
@@ -17,7 +17,8 @@
 #
 
 from confluent_kafka.cimpl import KafkaError
-from confluent_kafka.error import ConsumeError, ProduceError
+from confluent_kafka.error import ConsumeError, \
+    ProduceError
 
 
 def test_new_consume_error_constant():
@@ -37,12 +38,12 @@ def test_new_consume_error_caused_by():
 
 
 def test_new_consume_error_custom_message():
-    ce = ConsumeError(KafkaError(KafkaError._KEY_SERIALIZATION),
-                      message="Unable to serialize key")
+    ce = ConsumeError(KafkaError(KafkaError._KEY_SERIALIZATION,
+                                 "Unable to serialize key"))
 
     assert ce.code == KafkaError._KEY_SERIALIZATION
     assert ce.name == u'_KEY_SERIALIZATION'
-    assert ce.message == "Unable to serialize key"
+    assert ce[0].str() == "Unable to serialize key"
 
 
 def test_new_produce_error_constant():
@@ -62,9 +63,9 @@ def test_new_produce_error_caused_by():
 
 
 def test_new_produce_error_custom_message():
-    pe = ProduceError(KafkaError(KafkaError._KEY_SERIALIZATION),
-                      message="Unable to serialize key")
+    pe = ProduceError(KafkaError(KafkaError._KEY_SERIALIZATION,
+                                 "Unable to serialize key"))
 
     assert pe.code == KafkaError._KEY_SERIALIZATION
     assert pe.name == u'_KEY_SERIALIZATION'
-    assert pe.message == "Unable to serialize key"
+    assert pe[0].str() == "Unable to serialize key"

--- a/tests/test_error.py
+++ b/tests/test_error.py
@@ -15,31 +15,20 @@
 # See the License for the specific language governing permissions and
 # limit
 #
-from __future__ import print_function
 
 from confluent_kafka.cimpl import KafkaError
-
 from confluent_kafka.error import ConsumeError, ProduceError
 
 
 def test_new_consume_error_constant():
-    ce = ConsumeError(KafkaError._PARTITION_EOF)
+    ce = ConsumeError(KafkaError(KafkaError._PARTITION_EOF))
 
     assert ce.code == KafkaError._PARTITION_EOF
     assert ce.name == u'_PARTITION_EOF'
 
 
-# message.error() returns a KafkaError instance
-def test_new_consume_error_kafkaerror():
-    ke = KafkaError(KafkaError._PARTITION_EOF)
-    ce = ConsumeError(ke)
-
-    assert ce.code == ke.code()
-    assert ce.name == ke.name()
-
-
 def test_new_consume_error_caused_by():
-    ce = ConsumeError(KafkaError.INVALID_CONFIG,
+    ce = ConsumeError(KafkaError(KafkaError.INVALID_CONFIG),
                       exception=ValueError())
 
     assert ce.code == KafkaError.INVALID_CONFIG
@@ -48,7 +37,7 @@ def test_new_consume_error_caused_by():
 
 
 def test_new_consume_error_custom_message():
-    ce = ConsumeError(KafkaError._KEY_SERIALIZATION,
+    ce = ConsumeError(KafkaError(KafkaError._KEY_SERIALIZATION),
                       message="Unable to serialize key")
 
     assert ce.code == KafkaError._KEY_SERIALIZATION
@@ -57,22 +46,14 @@ def test_new_consume_error_custom_message():
 
 
 def test_new_produce_error_constant():
-    pe = ProduceError(KafkaError._PARTITION_EOF)
+    pe = ProduceError(KafkaError(KafkaError._PARTITION_EOF))
 
     assert pe.code == KafkaError._PARTITION_EOF
     assert pe.name == u'_PARTITION_EOF'
 
 
-def test_new_produce_error_kafkaerror():
-    pe = KafkaError(KafkaError._PARTITION_EOF)
-    ce = ProduceError(pe)
-
-    assert ce.code == pe.code()
-    assert ce.name == pe.name()
-
-
 def test_new_produce_error_caused_by():
-    pe = ProduceError(KafkaError.INVALID_CONFIG,
+    pe = ProduceError(KafkaError(KafkaError.INVALID_CONFIG),
                       exception=ValueError())
 
     assert pe.code == KafkaError.INVALID_CONFIG
@@ -81,7 +62,7 @@ def test_new_produce_error_caused_by():
 
 
 def test_new_produce_error_custom_message():
-    pe = ProduceError(KafkaError._KEY_SERIALIZATION,
+    pe = ProduceError(KafkaError(KafkaError._KEY_SERIALIZATION),
                       message="Unable to serialize key")
 
     assert pe.code == KafkaError._KEY_SERIALIZATION

--- a/tests/test_error.py
+++ b/tests/test_error.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Copyright 2020 Confluent Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limit
+#
+from __future__ import print_function
+
+from confluent_kafka.cimpl import KafkaError
+
+from confluent_kafka.error import ConsumeError, ProduceError
+
+
+def test_new_consume_error_constant():
+    ce = ConsumeError(KafkaError._PARTITION_EOF)
+
+    assert ce.code == KafkaError._PARTITION_EOF
+    assert ce.name == u'_PARTITION_EOF'
+
+
+# message.error() returns a KafkaError instance
+def test_new_consume_error_kafkaerror():
+    ke = KafkaError(KafkaError._PARTITION_EOF)
+    ce = ConsumeError(ke)
+
+    assert ce.code == ke.code()
+    assert ce.name == ke.name()
+
+
+def test_new_consume_error_caused_by():
+    ce = ConsumeError(KafkaError.INVALID_CONFIG,
+                      exception=ValueError())
+
+    assert ce.code == KafkaError.INVALID_CONFIG
+    assert ce.name == u'INVALID_CONFIG'
+    assert isinstance(ce.exception, ValueError)
+
+
+def test_new_consume_error_custom_message():
+    ce = ConsumeError(KafkaError._KEY_SERIALIZATION,
+                      message="Unable to serialize key")
+
+    assert ce.code == KafkaError._KEY_SERIALIZATION
+    assert ce.name == u'_KEY_SERIALIZATION'
+    assert ce.message == "Unable to serialize key"
+
+
+def test_new_produce_error_constant():
+    pe = ProduceError(KafkaError._PARTITION_EOF)
+
+    assert pe.code == KafkaError._PARTITION_EOF
+    assert pe.name == u'_PARTITION_EOF'
+
+
+def test_new_produce_error_kafkaerror():
+    pe = KafkaError(KafkaError._PARTITION_EOF)
+    ce = ProduceError(pe)
+
+    assert ce.code == pe.code()
+    assert ce.name == pe.name()
+
+
+def test_new_produce_error_caused_by():
+    pe = ProduceError(KafkaError.INVALID_CONFIG,
+                      exception=ValueError())
+
+    assert pe.code == KafkaError.INVALID_CONFIG
+    assert pe.name == u'INVALID_CONFIG'
+    assert isinstance(pe.exception, ValueError)
+
+
+def test_new_produce_error_custom_message():
+    pe = ProduceError(KafkaError._KEY_SERIALIZATION,
+                      message="Unable to serialize key")
+
+    assert pe.code == KafkaError._KEY_SERIALIZATION
+    assert pe.name == u'_KEY_SERIALIZATION'
+    assert pe.message == "Unable to serialize key"


### PR DESCRIPTION
Message.error() returns a KafkaError instance while KafkaError.* constants are ints. This PR handles both in the Consume/ProduceError constructor rather than relying on one or the other. 

fixes #871 