### PR TITLE
Add AvroSerializer ability to pre load schema ID + Fix bug when the same serializer is used for multiple topics

### DIFF
--- a/tests/schema_registry/conftest.py
+++ b/tests/schema_registry/conftest.py
@@ -36,6 +36,14 @@ def mock_schema_registry():
     return MockSchemaRegistryClient
 
 
+@pytest.fixture(autouse=True)
+def clear_registry_counters():
+    MockSchemaRegistryClient.counter["DELETE"].clear()
+    MockSchemaRegistryClient.counter["GET"].clear()
+    MockSchemaRegistryClient.counter["POST"].clear()
+    MockSchemaRegistryClient.counter["PUT"].clear()
+
+
 def find_schema_id(x, max_value=50):
     """Build schema ID based on subject name"""
     # We cannot use the builtin 'hash' function. It is not

--- a/tests/schema_registry/test_api_client.py
+++ b/tests/schema_registry/test_api_client.py
@@ -22,6 +22,8 @@ from concurrent.futures import ThreadPoolExecutor, wait
 from confluent_kafka.schema_registry.error import SchemaRegistryError
 from confluent_kafka.schema_registry.schema_registry_client import Schema
 
+from .conftest import find_schema_id
+
 """
     Basic SchemaRegistryClient API functionality tests.
 
@@ -80,7 +82,7 @@ def test_register_schema(mock_schema_registry, load_avsc):
     schema = Schema(load_avsc('basic_schema.avsc'), schema_type='AVRO')
 
     result = sr.register_schema('test-key', schema)
-    assert result == mock_schema_registry.SCHEMA_ID
+    assert result == find_schema_id('test-key')
 
 
 def test_register_schema_incompatible(mock_schema_registry, load_avsc):
@@ -188,7 +190,7 @@ def test_get_registration(mock_schema_registry, load_avsc):
 
     assert response.subject == subject
     assert response.version == mock_schema_registry.VERSION
-    assert response.schema_id == mock_schema_registry.SCHEMA_ID
+    assert response.schema_id == find_schema_id(subject)
     assert cmp_schema(response.schema, schema)
 
 
@@ -257,7 +259,7 @@ def test_get_version(mock_schema_registry, load_avsc):
     assert result.subject == subject
     assert result.version == version
     assert cmp_schema(result.schema, schema)
-    assert result.schema_id == mock_schema_registry.SCHEMA_ID
+    assert result.schema_id == find_schema_id(subject)
 
 
 def test_get_version_no_version(mock_schema_registry):


### PR DESCRIPTION
See issue #913 

# Changes to MockSchemaRegistryClient

1) ID changes

Do not use constant `SCHEMA_ID` but generate constant IDs based on subject name.

Before this change, it was impossible to check if cache is correctly used per topic.
Moreover, in real registry, IDs are different per subject.

2) Tests reset changes

Reset `MockSchemaRegistryClient.counter` before each tests.

# Changes to AvroSerializer

1) Fix bug when the same serializer is used for multiple topics
2) Add ability to force pre loading of registry schema ID