### PR TITLE
Use str instead of to_json when converting a schema to json

### DIFF
--- a/confluent_kafka/avro/cached_schema_registry_client.py
+++ b/confluent_kafka/avro/cached_schema_registry_client.py
@@ -253,7 +253,7 @@ class CachedSchemaRegistryClient(object):
         url = '/'.join([self.url, 'subjects', subject])
         # body is { schema : json_string }
 
-        body = {'schema': json.dumps(avro_schema.to_json())}
+        body = {'schema': json.dumps(str(avro_schema))}
         result, code = self._send_request(url, method='POST', body=body)
         if code == 401 or code == 403:
             raise ClientError("Unauthorized access. Error code:" + str(code))
@@ -374,7 +374,7 @@ class CachedSchemaRegistryClient(object):
             return version
 
         url = '/'.join([self.url, 'subjects', subject])
-        body = {'schema': json.dumps(avro_schema.to_json())}
+        body = {'schema': json.dumps(str(avro_schema))}
 
         result, code = self._send_request(url, method='POST', body=body)
         if code == 404:
@@ -402,7 +402,7 @@ class CachedSchemaRegistryClient(object):
         """
         url = '/'.join([self.url, 'compatibility', 'subjects', subject,
                         'versions', str(version)])
-        body = {'schema': json.dumps(avro_schema.to_json())}
+        body = {'schema': json.dumps(str(avro_schema))}
         try:
             result, code = self._send_request(url, method='POST', body=body)
             if code == 404:

--- a/confluent_kafka/avro/cached_schema_registry_client.py
+++ b/confluent_kafka/avro/cached_schema_registry_client.py
@@ -213,7 +213,7 @@ class CachedSchemaRegistryClient(object):
         url = '/'.join([self.url, 'subjects', subject, 'versions'])
         # body is { schema : json_string }
 
-        body = {'schema': json.dumps(avro_schema.to_json())}
+        body = {'schema': json.dumps(str(avro_schema))}
         result, code = self._send_request(url, method='POST', body=body)
         if (code == 401 or code == 403):
             raise ClientError("Unauthorized access. Error code:" + str(code))

--- a/confluent_kafka/avro/cached_schema_registry_client.py
+++ b/confluent_kafka/avro/cached_schema_registry_client.py
@@ -213,7 +213,7 @@ class CachedSchemaRegistryClient(object):
         url = '/'.join([self.url, 'subjects', subject, 'versions'])
         # body is { schema : json_string }
 
-        body = {'schema': json.dumps(str(avro_schema))}
+        body = {'schema': str(avro_schema)}
         result, code = self._send_request(url, method='POST', body=body)
         if (code == 401 or code == 403):
             raise ClientError("Unauthorized access. Error code:" + str(code))
@@ -253,7 +253,7 @@ class CachedSchemaRegistryClient(object):
         url = '/'.join([self.url, 'subjects', subject])
         # body is { schema : json_string }
 
-        body = {'schema': json.dumps(str(avro_schema))}
+        body = {'schema': str(avro_schema)}
         result, code = self._send_request(url, method='POST', body=body)
         if code == 401 or code == 403:
             raise ClientError("Unauthorized access. Error code:" + str(code))
@@ -374,7 +374,7 @@ class CachedSchemaRegistryClient(object):
             return version
 
         url = '/'.join([self.url, 'subjects', subject])
-        body = {'schema': json.dumps(str(avro_schema))}
+        body = {'schema': str(avro_schema)}
 
         result, code = self._send_request(url, method='POST', body=body)
         if code == 404:
@@ -402,7 +402,7 @@ class CachedSchemaRegistryClient(object):
         """
         url = '/'.join([self.url, 'compatibility', 'subjects', subject,
                         'versions', str(version)])
-        body = {'schema': json.dumps(str(avro_schema))}
+        body = {'schema': str(avro_schema)}
         try:
             result, code = self._send_request(url, method='POST', body=body)
             if code == 404:

--- a/confluent_kafka/avro/serializer/message_serializer.py
+++ b/confluent_kafka/avro/serializer/message_serializer.py
@@ -79,7 +79,7 @@ class MessageSerializer(object):
     # Encoder support
     def _get_encoder_func(self, writer_schema):
         if HAS_FAST:
-            schema = str(writer_schema)
+            schema = writer_schema.to_json()
             parsed_schema = parse_schema(schema)
             return lambda record, fp: schemaless_writer(fp, parsed_schema, record)
         writer = avro.io.DatumWriter(writer_schema)
@@ -174,8 +174,8 @@ class MessageSerializer(object):
         if HAS_FAST:
             # try to use fast avro
             try:
-                fast_avro_writer_schema = parse_schema(str(writer_schema_obj))
-                fast_avro_reader_schema = parse_schema(str(reader_schema_obj))
+                fast_avro_writer_schema = parse_schema(writer_schema_obj.to_json())
+                fast_avro_reader_schema = parse_schema(reader_schema_obj.to_json())
                 schemaless_reader(payload, fast_avro_writer_schema)
 
                 # If we reach this point, this means we have fastavro and it can

--- a/confluent_kafka/avro/serializer/message_serializer.py
+++ b/confluent_kafka/avro/serializer/message_serializer.py
@@ -79,7 +79,7 @@ class MessageSerializer(object):
     # Encoder support
     def _get_encoder_func(self, writer_schema):
         if HAS_FAST:
-            schema = writer_schema.to_json()
+            schema = str(writer_schema)
             parsed_schema = parse_schema(schema)
             return lambda record, fp: schemaless_writer(fp, parsed_schema, record)
         writer = avro.io.DatumWriter(writer_schema)
@@ -174,8 +174,8 @@ class MessageSerializer(object):
         if HAS_FAST:
             # try to use fast avro
             try:
-                fast_avro_writer_schema = parse_schema(writer_schema_obj.to_json())
-                fast_avro_reader_schema = parse_schema(reader_schema_obj.to_json())
+                fast_avro_writer_schema = parse_schema(str(writer_schema_obj))
+                fast_avro_reader_schema = parse_schema(str(reader_schema_obj))
                 schemaless_reader(payload, fast_avro_writer_schema)
 
                 # If we reach this point, this means we have fastavro and it can

--- a/tests/avro/mock_registry.py
+++ b/tests/avro/mock_registry.py
@@ -100,13 +100,13 @@ class MockServer(HTTPSERVER.HTTPServer, object):
         if not schema:
             return self._create_error("schema not found", 404)
         result = {
-            "schema": json.dumps(str(schema))
+            "schema": str(schema)
         }
         return (200, result)
 
     def _get_identity_schema(self, avro_schema):
         # normalized
-        schema_str = json.dumps(str(avro_schema))
+        schema_str = str(avro_schema)
         if schema_str in self.schema_cache:
             return self.schema_cache[schema_str]
         self.schema_cache[schema_str] = avro_schema
@@ -150,7 +150,7 @@ class MockServer(HTTPSERVER.HTTPServer, object):
         schema_id = self.registry.get_id_for_schema(subject, avro_schema)
 
         result = {
-            "schema": json.dumps(str(avro_schema)),
+            "schema": str(avro_schema),
             "subject": subject,
             "id": schema_id,
             "version": version
@@ -163,7 +163,7 @@ class MockServer(HTTPSERVER.HTTPServer, object):
         if schema_id is None:
             return self._create_error("Not found", 404)
         result = {
-            "schema": json.dumps(str(avro_schema)),
+            "schema": str(avro_schema),
             "subject": subject,
             "id": schema_id,
             "version": version

--- a/tests/avro/mock_registry.py
+++ b/tests/avro/mock_registry.py
@@ -100,13 +100,13 @@ class MockServer(HTTPSERVER.HTTPServer, object):
         if not schema:
             return self._create_error("schema not found", 404)
         result = {
-            "schema": json.dumps(schema.to_json())
+            "schema": json.dumps(str(schema))
         }
         return (200, result)
 
     def _get_identity_schema(self, avro_schema):
         # normalized
-        schema_str = json.dumps(avro_schema.to_json())
+        schema_str = json.dumps(str(avro_schema))
         if schema_str in self.schema_cache:
             return self.schema_cache[schema_str]
         self.schema_cache[schema_str] = avro_schema
@@ -150,7 +150,7 @@ class MockServer(HTTPSERVER.HTTPServer, object):
         schema_id = self.registry.get_id_for_schema(subject, avro_schema)
 
         result = {
-            "schema": json.dumps(avro_schema.to_json()),
+            "schema": json.dumps(str(avro_schema)),
             "subject": subject,
             "id": schema_id,
             "version": version
@@ -163,7 +163,7 @@ class MockServer(HTTPSERVER.HTTPServer, object):
         if schema_id is None:
             return self._create_error("Not found", 404)
         result = {
-            "schema": json.dumps(avro_schema.to_json()),
+            "schema": json.dumps(str(avro_schema)),
             "subject": subject,
             "id": schema_id,
             "version": version


### PR DESCRIPTION
fixes #610 

In version 1.9 of the avro library, they now use a `MappingProxy` that breaks the `to_json` method (it can't be serialized to JSON properly). Unfortunately it's still broken in 1.10. A simple workaround is to just use the `__str__` method of the schema object.