### PR TITLE
Change schema registry to work without avro

### DIFF
--- a/confluent_kafka/schema_registry/error.py
+++ b/confluent_kafka/schema_registry/error.py
@@ -15,7 +15,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-from fastavro.schema import SchemaParseException, UnknownType
+try:
+    from fastavro.schema import SchemaParseException, UnknownType
+except ImportError:
+    pass
 
 __all__ = ['SchemaRegistryError', 'SchemaParseException', 'UnknownType']
 


### PR DESCRIPTION
These errors are being used just to export avro's exceptions but this means that you can never use schema-registry if you installed confluent kafka with `confluent-kafka[schema-registry]`