### PR TITLE
Add callback for oauth

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -459,6 +459,9 @@ The Python bindings also provide some additional configuration properties:
   This callback is served upon calling ``client.poll()`` or ``producer.flush()``. See
   https://github.com/edenhill/librdkafka/wiki/Statistics" for more information.
 
+* ``oauth_cb(oauthbearer_config_str)``: Callback for retrieving Oauth token.
+  Return value of this callback is expected to be ``(token_str, expiry_time)`` tuple.
+
 * ``on_delivery(kafka.KafkaError, kafka.Message)`` (**Producer**): value is a Python function reference
   that is called once for each produced message to indicate the final
   delivery result (success or failure).

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -459,8 +459,13 @@ The Python bindings also provide some additional configuration properties:
   This callback is served upon calling ``client.poll()`` or ``producer.flush()``. See
   https://github.com/edenhill/librdkafka/wiki/Statistics" for more information.
 
-* ``oauth_cb(oauthbearer_config_str)``: Callback for retrieving Oauth token.
-  Return value of this callback is expected to be ``(token_str, expiry_time)`` tuple.
+* ``oauth_cb(config_str)``: Callback for retrieving OAuth Bearer token.
+  Function argument ``config_str`` is a str from config: ``sasl.oauthbearer.config``.
+  Return value of this callback is expected to be ``(token_str, expiry_time)`` tuple
+  where ``expiry_time`` is the time in seconds since the epoch as a floating point number.
+  This callback is useful only when ``sasl.mechanisms=OAUTHBEARER`` is set and
+  is served to get the initial token before a successful broker connection can be made.
+  The callback can be triggered by calling ``client.poll()`` or ``producer.flush()``.
 
 * ``on_delivery(kafka.KafkaError, kafka.Message)`` (**Producer**): value is a Python function reference
   that is called once for each produced message to indicate the final

--- a/examples/README.md
+++ b/examples/README.md
@@ -14,6 +14,7 @@ The scripts in this directory provide code examples using Confluent's Python cli
 * [protobuf_consumer.py](protobuf_consumer.py): DeserializingConsumer with ProtobufDeserializer
 * [sasl_producer.py](sasl_producer.py): SerializingProducer with SASL Authentication
 * [list_offsets.py](list_offsets.py): List committed offsets and consumer lag for group and topics
+* [oauth_producer.py](oauth_producer.py): SerializingProducer with OAuth Authentication (client credentials)
 
 Additional examples for [Confluent Cloud](https://www.confluent.io/confluent-cloud/):
 

--- a/examples/oauth_producer.py
+++ b/examples/oauth_producer.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Copyright 2020 Confluent Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+#
+# This uses OAuth client credentials grant:
+# https://www.oauth.com/oauth2-servers/access-tokens/client-credentials/
+# where client_id and client_secret are passed as HTTP Authorization header
+#
+
+import logging
+import functools
+import argparse
+import time
+from confluent_kafka import SerializingProducer
+from confluent_kafka.serialization import StringSerializer
+import requests
+
+
+def _get_token(args, config):
+    """Note here value of config comes from sasl.oauthbearer.config below.
+    It is not used in this example but you can put arbitrary values to
+    configure how you can get the token (e.g. which token URL to use)
+    """
+    payload = {
+        'grant_type': 'client_credentials',
+        'scope': ' '.join(args.scopes)
+    }
+    resp = requests.post(args.token_url,
+                         auth=(args.client_id, args.client_secret), data=payload)
+    token = resp.json()
+    return token['access_token'], time.time() + token['expires_in']
+
+
+def producer_config(args):
+    logger = logging.getLogger(__name__)
+    return {
+        'bootstrap.servers': args.bootstrap_servers,
+        'key.serializer': StringSerializer('utf_8'),
+        'value.serializer': StringSerializer('utf_8'),
+        'security.protocol': 'sasl_plaintext',
+        'sasl.mechanisms': 'OAUTHBEARER',
+        'sasl.oauthbearer.config': "not-important",
+        'oauth_cb': functools.partial(_get_token, args),
+        'logger': logger,
+    }
+
+
+def delivery_report(err, msg):
+    """
+    Reports the failure or success of a message delivery.
+
+    Args:
+        err (KafkaError): The error that occurred on None on success.
+
+        msg (Message): The message that was produced or failed.
+
+    Note:
+        In the delivery report callback the Message.key() and Message.value()
+        will be the binary format as encoded by any configured Serializers and
+        not the same object that was passed to produce().
+        If you wish to pass the original object(s) for key and value to delivery
+        report callback we recommend a bound callback or lambda where you pass
+        the objects along.
+
+    """
+    if err is not None:
+        print("Delivery failed for User record {}: {}".format(msg.key(), err))
+        return
+    print('User record {} successfully produced to {} [{}] at offset {}'.format(
+        msg.key(), msg.topic(), msg.partition(), msg.offset()))
+
+
+def main(args):
+    topic = args.topic
+    delimiter = args.delimiter
+
+    producer_conf = producer_config(args)
+
+    producer = SerializingProducer(producer_conf)
+
+    print("Producing records to topic {}. ^C to exit.".format(topic))
+    while True:
+        # Serve on_delivery callbacks from previous calls to produce()
+        producer.poll(0.0)
+        try:
+            msg_data = input(">")
+            msg = msg_data.split(delimiter)
+            if len(msg) == 2:
+                producer.produce(topic=topic, key=msg[0], value=msg[1],
+                                 on_delivery=delivery_report)
+            else:
+                producer.produce(topic=topic, value=msg[0],
+                                 on_delivery=delivery_report)
+        except KeyboardInterrupt:
+            break
+
+    print("\nFlushing {} records...".format(len(producer)))
+    producer.flush()
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description="SerializingProducer OAUTH Example"
+                                                 " with client credentials grant")
+    parser.add_argument('-b', dest="bootstrap_servers", required=True,
+                        help="Bootstrap broker(s) (host[:port])")
+    parser.add_argument('-t', dest="topic", default="example_producer_oauth",
+                        help="Topic name")
+    parser.add_argument('-d', dest="delimiter", default="|",
+                        help="Key-Value delimiter. Defaults to '|'"),
+    parser.add_argument('--client', dest="client_id", required=True,
+                        help="Client ID for client credentials flow")
+    parser.add_argument('--secret', dest="client_secret", required=True,
+                        help="Client secret for client credentials flow.")
+    parser.add_argument('--token-url', dest="token_url", required=True,
+                        help="Token URL.")
+    parser.add_argument('--scopes', dest="scopes", required=True, nargs='+',
+                        help="Scopes requested from OAuth server.")
+
+    main(parser.parse_args())

--- a/examples/oauth_producer.py
+++ b/examples/oauth_producer.py
@@ -55,7 +55,10 @@ def producer_config(args):
         'value.serializer': StringSerializer('utf_8'),
         'security.protocol': 'sasl_plaintext',
         'sasl.mechanisms': 'OAUTHBEARER',
-        'sasl.oauthbearer.config': 'not-important',
+        # sasl.oauthbearer.config can be used to pass argument to your oauth_cb
+        # It is not used in this example since we are passing all the arguments
+        # from command line
+        # 'sasl.oauthbearer.config': 'not-used',
         'oauth_cb': functools.partial(_get_token, args),
         'logger': logger,
     }

--- a/examples/oauth_producer.py
+++ b/examples/oauth_producer.py
@@ -41,9 +41,10 @@ def _get_token(args, config):
         'scope': ' '.join(args.scopes)
     }
     resp = requests.post(args.token_url,
-                         auth=(args.client_id, args.client_secret), data=payload)
+                         auth=(args.client_id, args.client_secret),
+                         data=payload)
     token = resp.json()
-    return token['access_token'], time.time() + token['expires_in']
+    return token['access_token'], time.time() + float(token['expires_in'])
 
 
 def producer_config(args):
@@ -54,7 +55,7 @@ def producer_config(args):
         'value.serializer': StringSerializer('utf_8'),
         'security.protocol': 'sasl_plaintext',
         'sasl.mechanisms': 'OAUTHBEARER',
-        'sasl.oauthbearer.config': "not-important",
+        'sasl.oauthbearer.config': 'not-important',
         'oauth_cb': functools.partial(_get_token, args),
         'logger': logger,
     }
@@ -79,7 +80,7 @@ def delivery_report(err, msg):
 
     """
     if err is not None:
-        print("Delivery failed for User record {}: {}".format(msg.key(), err))
+        print('Delivery failed for User record {}: {}'.format(msg.key(), err))
         return
     print('User record {} successfully produced to {} [{}] at offset {}'.format(
         msg.key(), msg.topic(), msg.partition(), msg.offset()))
@@ -93,7 +94,7 @@ def main(args):
 
     producer = SerializingProducer(producer_conf)
 
-    print("Producing records to topic {}. ^C to exit.".format(topic))
+    print('Producing records to topic {}. ^C to exit.'.format(topic))
     while True:
         # Serve on_delivery callbacks from previous calls to produce()
         producer.poll(0.0)
@@ -109,7 +110,7 @@ def main(args):
         except KeyboardInterrupt:
             break
 
-    print("\nFlushing {} records...".format(len(producer)))
+    print('\nFlushing {} records...'.format(len(producer)))
     producer.flush()
 
 

--- a/examples/requirements.txt
+++ b/examples/requirements.txt
@@ -7,3 +7,4 @@ pyrsistent==0.16.1;python_version<"3.0"
 pyrsistent;python_version>"3.0"
 jsonschema
 protobuf
+requests

--- a/src/confluent_kafka/src/confluent_kafka.c
+++ b/src/confluent_kafka/src/confluent_kafka.c
@@ -1521,14 +1521,15 @@ static void log_cb (const rd_kafka_t *rk, int level,
         CallState_resume(cs);
 }
 
-static void oauth_cb (rd_kafka_t *rk, const char *oauthbearer_config, void *opaque) {
+static void oauth_cb (rd_kafka_t *rk, const char *oauthbearer_config,
+                      void *opaque) {
         Handle *h = opaque;
         PyObject *eo, *result;
         CallState *cs;
         const char *token;
         double expiry;
         char err_msg[2048];
-        rd_kafka_resp_err_t err_code = RD_KAFKA_RESP_ERR_NO_ERROR;
+        rd_kafka_resp_err_t err_code;
 
         cs = CallState_get(h);
 
@@ -1546,8 +1547,10 @@ static void oauth_cb (rd_kafka_t *rk, const char *oauthbearer_config, void *opaq
                              "to be (token_str, expiry_time) tuple");
                 goto err;
         }
-        err_code = rd_kafka_oauthbearer_set_token(h->rk, token, (int64_t)(expiry * 1000), "",
-                                                  NULL, 0, err_msg, sizeof(err_msg));
+        err_code = rd_kafka_oauthbearer_set_token(h->rk, token,
+                                                  (int64_t)(expiry * 1000),
+                                                  "", NULL, 0, err_msg,
+                                                  sizeof(err_msg));
         Py_DECREF(result);
         if (err_code) {
                 PyErr_Format(PyExc_ValueError, "%s", err_msg);

--- a/src/confluent_kafka/src/confluent_kafka.h
+++ b/src/confluent_kafka/src/confluent_kafka.h
@@ -236,6 +236,7 @@ typedef struct {
         rd_kafka_type_t type; /* Producer or consumer */
 
         PyObject *logger;
+        PyObject *oauth_cb;
 
 	union {
 		/**


### PR DESCRIPTION
We have requirements to make use of the OAuth server in our company for Kafka. Our Kafka server-side implementation is based on: https://github.com/kafka-security/oauth

This change expose the necessary callback for Python client

This closes https://github.com/confluentinc/confluent-kafka-python/issues/839
