### PR TITLE
Upgrade fastavro to a minimum of 1.0.0.post1

### DIFF
--- a/confluent_kafka/schema_registry/requirements.txt
+++ b/confluent_kafka/schema_registry/requirements.txt
@@ -1,4 +1,4 @@
-fastavro>=0.23.0
+fastavro>=1.0.0.post1
 jsonschema
 protobuf
 requests


### PR DESCRIPTION
We're using confluent-kafka-python and running into an issue in fastavro [#459](https://github.com/fastavro/fastavro/pull/459). This is fixed in 0.24.1.

I've updated fastavro to depend on at least the latest version (1.0.0.post1). Since the requirements.txt was already depending on at least version 0.23.0 it would've pulled in the latest version anyway for the next release. Do note that version 1.0.0 drops support for Python 2. If this is undesirable for confluent-kafka-python, I can change the fastavro dependency to be fixed to 0.24.2.