### PR TITLE
Note that Python 3.9 is broken

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,7 +284,7 @@ client's CA location with `'ssl.ca.location': certifi.where()`.
 Prerequisites
 =============
 
- * Python >= 2.7 or Python 3.x
+ * Python >= 2.7, >=3.9
  * [librdkafka](https://github.com/edenhill/librdkafka) >= 1.4.0 (latest release is embedded in wheels)
 
 librdkafka is embedded in the macosx manylinux wheels, for other platforms, SASL Kerberos/GSSAPI support or


### PR DESCRIPTION
Python 3.9 is busted for wheel installs

See issue: https://github.com/confluentinc/confluent-kafka-python/issues/968