### PR TITLE
Leave a note about python 3.9 being broken.

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,7 +284,7 @@ client's CA location with `'ssl.ca.location': certifi.where()`.
 Prerequisites
 =============
 
- * Python >= 2.7 or Python < 3.9*
+ * Python >= 2.7 or Python < 3.9 - Please note that we intend to support all persions of python, but the latest version broke things for us. We intend to fix this as soon as possible.
 
  * [librdkafka](https://github.com/edenhill/librdkafka) >= 1.4.0 (latest release is embedded in wheels)
 
@@ -300,7 +300,6 @@ http://docs.confluent.io/current/installation.html#rpm-packages-via-yum
  * On **OSX**, use **homebrew** and do `brew install librdkafka`
 
 
-Note: We intend to support all persions of python, but the latest version broke things for us. We intend to fix this as soon as possible.
 
 Developer Notes
 ===============

--- a/README.md
+++ b/README.md
@@ -284,7 +284,8 @@ client's CA location with `'ssl.ca.location': certifi.where()`.
 Prerequisites
 =============
 
- * Python >= 2.7 or Python 3.x
+ * Python >= 2.7 or Python < 3.9*
+
  * [librdkafka](https://github.com/edenhill/librdkafka) >= 1.4.0 (latest release is embedded in wheels)
 
 librdkafka is embedded in the macosx manylinux wheels, for other platforms, SASL Kerberos/GSSAPI support or
@@ -298,6 +299,8 @@ http://docs.confluent.io/current/installation.html#rpm-packages-via-yum
 
  * On **OSX**, use **homebrew** and do `brew install librdkafka`
 
+
+Note: We intend to support all persions of python, but the latest version broke things for us. We intend to fix this as soon as possible.
 
 Developer Notes
 ===============


### PR DESCRIPTION
Python 3.9 is currently broken.

While we should of course fix this, in the meantime I believe it is important to let users know about this as the error message they receive will not make this clear.

Issue https://github.com/confluentinc/confluent-kafka-python/issues/968