### PR TITLE
Change schema.Parse to all lower case

### DIFF
--- a/src/confluent_kafka/avro/load.py
+++ b/src/confluent_kafka/avro/load.py
@@ -23,10 +23,7 @@ from confluent_kafka.avro.error import ClientError
 def loads(schema_str):
     """ Parse a schema given a schema string """
     try:
-        if sys.version_info[0] < 3:
-            return schema.parse(schema_str)
-        else:
-            return schema.Parse(schema_str)
+        return schema.parse(schema_str)
     except schema.SchemaParseException as e:
         raise ClientError("Schema parse failed: %s" % (str(e)))
 


### PR DESCRIPTION
Method call schema.Parse has been deprecated. This changes the call to schema.parse instead.

This fixes #1005.