### PR TITLE
Added ASF notice to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,14 +297,16 @@ http://docs.confluent.io/current/installation.html#rpm-packages-via-yum
  * On **OSX**, use **homebrew** and do `brew install librdkafka`
 
 
-Developer Notes
-===============
+License
+=======
 
-Instructions on building and testing confluent-kafka-python can be found [here](DEVELOPER.md).
-
-
-**License:** [Apache License v2.0](http://www.apache.org/licenses/LICENSE-2.0)
+[Apache License v2.0](http://www.apache.org/licenses/LICENSE-2.0)
 
 KAFKA is a registered trademark of The Apache Software Foundation and has been licensed for use
 by confluent-kafka-python. confluent-kafka-python has no affiliation with and is not endorsed by
 The Apache Software Foundation.
+
+Developer Notes
+===============
+
+Instructions on building and testing confluent-kafka-python can be found [here](DEVELOPER.md).

--- a/README.md
+++ b/README.md
@@ -17,8 +17,6 @@ pace with core Apache Kafka and components of the [Confluent Platform](https://w
 
 See the [API documentation](http://docs.confluent.io/current/clients/confluent-kafka-python/index.html) for more info.
 
-**License**: [Apache License v2.0](http://www.apache.org/licenses/LICENSE-2.0)
-
 
 Usage
 =====
@@ -303,3 +301,10 @@ Developer Notes
 ===============
 
 Instructions on building and testing confluent-kafka-python can be found [here](DEVELOPER.md).
+
+
+**License:** [Apache License v2.0](http://www.apache.org/licenses/LICENSE-2.0)
+
+KAFKA is a registered trademark of The Apache Software Foundation and has been licensed for use
+by confluent-kafka-python. confluent-kafka-python has no affiliation with and is not endorsed by
+The Apache Software Foundation.


### PR DESCRIPTION
i think it makes sense to put this text after the license.
i think it's a bit too heavy though and low impact to be putting near the top, so i moved the license, and this down the bottom.
although i like the license up the top (it's something to advertise), i don't see any issue in not doing this - people are used to seeking out license, and we don't make it hard to find (there's a LICENSE.txt file).
