### PR TITLE
update docs for poll to describe default timeout behaviour for Consumer.poll.

### DIFF
--- a/src/confluent_kafka/src/Consumer.c
+++ b/src/confluent_kafka/src/Consumer.c
@@ -1072,7 +1072,7 @@ static PyMethodDef Consumer_methods[] = {
 	  "  .. note: Callbacks may be called from this method, "
 	  "such as ``on_assign``, ``on_revoke``, et.al.\n"
 	  "\n"
-	  "  :param float timeout: Maximum time to block waiting for message, event or callback. (Seconds)\n"
+	  "  :param float timeout: Maximum time to block waiting for message, event or callback (default: infinite (None translated into -1 in the library)). (Seconds)\n"
 	  "  :returns: A Message object or None on timeout\n"
 	  "  :rtype: :py:class:`Message` or None\n"
       "  :raises: RuntimeError if called on a closed consumer\n"


### PR DESCRIPTION
Docs for Consumer poll:
https://docs.confluent.io/platform/current/clients/confluent-kafka-python/index.html#confluent_kafka.Consumer.poll

Was unclear about what timeout=None meant, this PR adds further description that None basically means -1, which means blocks infinitely.