### PR TITLE
Update Prerequisite in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,7 +283,7 @@ Prerequisites
 =============
 
  * Python >= 2.7 or Python 3.x
- * [librdkafka](https://github.com/edenhill/librdkafka) >= 1.4.0 (latest release is embedded in wheels)
+ * [librdkafka](https://github.com/edenhill/librdkafka) >= 1.6.0 (latest release is embedded in wheels)
 
 librdkafka is embedded in the macosx manylinux wheels, for other platforms, SASL Kerberos/GSSAPI support or
 when a specific version of librdkafka is desired, following these guidelines:


### PR DESCRIPTION
confluent-kafka requires librdkafka >= 1.6.0

Logs building wheel with librdkafka = 1.4.0

```
  gcc -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -DTHREAD_STACK_SIZE=0x100000 -fPIC -I/usr/local/include/python3.6m -c /tmp/pip-install-k9sj2mmo/confluent-kafka/src/confluent_kafka/src/confluent_kafka.c -o build/temp.linux-x86_64-3.6/tmp/pip-install-k9sj2mmo/confluent-kafka/src/confluent_kafka/src/confluent_kafka.o
  In file included from /tmp/pip-install-k9sj2mmo/confluent-kafka/src/confluent_kafka/src/confluent_kafka.c:17:
  /tmp/pip-install-k9sj2mmo/confluent-kafka/src/confluent_kafka/src/confluent_kafka.h:66:2: error: #error "confluent-kafka-python requires librdkafka v1.6.0 or later. Install the latest version of librdkafka from the Confluent repositories, see http://docs.confluent.io/current/installation.html"
   #error "confluent-kafka-python requires librdkafka v1.6.0 or later. Install the latest version of librdkafka from the Confluent repositories, see http://docs.confluent.io/current/installation.html"
    ^~~~~
  error: command 'gcc' failed with exit status 1
  ----------------------------------------
  ERROR: Failed building wheel for confluent-kafka
```
Signed-off-by: Martin Chacon Piza <martin@chaconpiza.com>