### PR TITLE
Make cibuildwheel work at windows platform

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,6 +46,8 @@ else:
 
 module = Extension('confluent_kafka.cimpl',
                    libraries=[librdkafka_libname],
+                   include_dirs=[os.getenv('include')],
+                   library_dirs=[os.getenv('lib')],
                    sources=[os.path.join(ext_dir, 'confluent_kafka.c'),
                             os.path.join(ext_dir, 'Producer.c'),
                             os.path.join(ext_dir, 'Consumer.c'),

--- a/tools/wheels/build-wheels.bat
+++ b/tools/wheels/build-wheels.bat
@@ -13,8 +13,8 @@ set WHEELHOUSE=%4
 if [%WHEELHOUSE%]==[] goto usage
 echo on
 
-set CIBW_BUILD=cp27-%BW_ARCH% cp36-%BW_ARCH% cp37-%BW_ARCH% cp38-%BW_ARCH% cp39-%BW_ARCH%
-set CIBW_BEFORE_BUILD=python -m pip install delvewheel==0.0.6
+set CIBW_BUILD=cp36-%BW_ARCH% cp37-%BW_ARCH% cp38-%BW_ARCH% cp39-%BW_ARCH%
+set CIBW_BEFORE_BUILD=python -m pip install delvewheel
 set CIBW_TEST_REQUIRES=-r tests/requirements.txt
 set CIBW_TEST_COMMAND=pytest {project}\tests\test_Producer.py
 rem set CIBW_BUILD_VERBOSITY=3
@@ -23,7 +23,7 @@ set lib=%cd%\%DEST%\build\native\lib\win\%ARCH%\win-%ARCH%-Release\v120
 set DLL_DIR=%cd%\%DEST%\runtimes\win-%ARCH%\native
 set CIBW_REPAIR_WHEEL_COMMAND=python -m delvewheel repair --add-path %DLL_DIR% -w {dest_dir} {wheel}
 
-set PATH=%PATH%;c:\Program Files\Git\bin\
+rem set PATH=%PATH%;c:\Program Files\Git\bin\
 
 python -m pip install cibuildwheel==1.7.4 || goto :error
 
@@ -34,7 +34,7 @@ dir %WHEELHOUSE%
 goto :eof
 
 :usage
-@echo "Usage: %0 x86|x64 win32|win_amd64 wheelhouse-dir"
+@echo Usage: %0 x86|x64 win32|win_amd64 librdkafka-dir wheelhouse-dir
 exit /B 1
 
 :error

--- a/tools/windows-build-wheel.bat
+++ b/tools/windows-build-wheel.bat
@@ -1,0 +1,41 @@
+@echo off
+rem Build wheels (using cibuildwheel) on Windows
+set LIB_VER=%1
+if [%LIB_VER%]==[] (
+    set LIB_VER=%LIBRDKAFKA_NUGET_VERSION%
+    if [%LIB_VER%]==[] (
+        goto usage
+    )
+)
+
+set LIB_DIR=%2
+if [%LIB_DIR%]==[] (
+    set LIB_DIR=dest
+)
+
+set OUT_DIR=%3
+if [%OUT_DIR%]==[] (
+    set OUT_DIR=wheelhouse
+)
+
+echo on
+rem Download and install librdkafka from NuGet.
+nuget install librdkafka.redist -version %LIB_VER% -OutputDirectory %LIB_DIR%
+
+rem Build wheels (with tests)
+call tools\wheels\build-wheels.bat x64 win_amd64 %LIB_DIR%/librdkafka.redist.%LIB_VER% %OUT_DIR% || goto :error
+call tools\wheels\build-wheels.bat x86 win32     %LIB_DIR%/librdkafka.redist.%LIB_VER% %OUT_DIR% || goto :error
+
+goto :eof
+
+:usage
+@echo Usage: %0 librdkafka-ver [librdkafka-dir [wheelhouse-dir]]
+@echo   default librdkafka-ver: environment variable LIBRDKAFKA_NUGET_VERSION, if ommitted.
+@echo   default librdkafka-dir: dest
+@echo   default wheelhouse-dir: wheelhouse
+exit /B 1
+
+:error
+echo Failed with error #%errorlevel%.
+exit /b %errorlevel%
+


### PR DESCRIPTION
1. Add 'include_dirs', and 'library_dirs' to compile setting of module.
2. Remove python 2.7 from cibuildwheel's build list
3. Add batch file to download librdkafka from nuget then call
   tools/wheels/build-wheels.bat

Note:
1. current values of 'indlude_dirs' and 'library_dirs' in setup.py are workaround for someone to build wheels locally.  Their values should be modified after the required .h file and library are included in source packages.
2. The batch file 'tools/windows-build-wheel.bat' should be run in git for window's 'git-bash' shell due to some scripts need command 'which' which is not support in native windows environment.