### PR TITLE
Change schema registry to work without avro

### DIFF
--- a/src/confluent_kafka/schema_registry/error.py
+++ b/src/confluent_kafka/schema_registry/error.py
@@ -15,7 +15,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-from fastavro.schema import SchemaParseException, UnknownType
+try:
+    from fastavro.schema import SchemaParseException, UnknownType
+except ImportError:
+    pass
 
 __all__ = ['SchemaRegistryError', 'SchemaParseException', 'UnknownType']
 


### PR DESCRIPTION
this is exactly https://github.com/confluentinc/confluent-kafka-python/pull/950 