### PR TITLE
Show the error details when failing to register a schema

### DIFF
--- a/src/confluent_kafka/avro/cached_schema_registry_client.py
+++ b/src/confluent_kafka/avro/cached_schema_registry_client.py
@@ -215,13 +215,17 @@ class CachedSchemaRegistryClient(object):
         body = {'schema': str(avro_schema)}
         result, code = self._send_request(url, method='POST', body=body)
         if (code == 401 or code == 403):
-            raise ClientError("Unauthorized access. Error code:" + str(code))
+            raise ClientError("Unauthorized access. Error code:" + str(code)
+                              + " message:" + str(result))
         elif code == 409:
-            raise ClientError("Incompatible Avro schema:" + str(code))
+            raise ClientError("Incompatible Avro schema:" + str(code)
+                              + " message:" + str(result))
         elif code == 422:
-            raise ClientError("Invalid Avro schema:" + str(code))
+            raise ClientError("Invalid Avro schema:" + str(code)
+                              + " message:" + str(result))
         elif not (code >= 200 and code <= 299):
-            raise ClientError("Unable to register schema. Error code:" + str(code))
+            raise ClientError("Unable to register schema. Error code:" + str(code)
+                              + " message:" + str(result))
         # result is a dict
         schema_id = result['id']
         # cache it


### PR DESCRIPTION
this is exactly https://github.com/confluentinc/confluent-kafka-python/pull/673 which for some reason is showing a merge conflict.