### PR TITLE
Correct SerializingProducer callable parameters description

### DIFF
--- a/src/confluent_kafka/serializing_producer.py
+++ b/src/confluent_kafka/serializing_producer.py
@@ -62,11 +62,11 @@ class SerializingProducer(_ProducerImpl):
     +=========================+=====================+=====================================================+
     | ``bootstrap.servers`` * | str                 | Comma-separated list of brokers.                    |
     +-------------------------+---------------------+-----------------------------------------------------+
-    |                         |                     | Callable(SerializationContext, obj) -> bytes        |
+    |                         |                     | Callable(obj, SerializationContext) -> bytes        |
     | ``key.serializer``      | callable            |                                                     |
     |                         |                     | Serializer used for message keys.                   |
     +-------------------------+---------------------+-----------------------------------------------------+
-    |                         |                     | Callable(SerializationContext, obj) -> bytes        |
+    |                         |                     | Callable(obj, SerializationContext) -> bytes        |
     | ``value.serializer``    | callable            |                                                     |
     |                         |                     | Serializer used for message values.                 |
     +-------------------------+---------------------+-----------------------------------------------------+


### PR DESCRIPTION
this is exactly: https://github.com/confluentinc/confluent-kafka-python/pull/942 , opening again to work around github merge conflict issue.