### PR TITLE
fix test_message_serializer.py

### DIFF
--- a/tests/avro/test_message_serializer.py
+++ b/tests/avro/test_message_serializer.py
@@ -34,6 +34,7 @@ from tests.avro.mock_schema_registry_client import MockSchemaRegistryClient
 from confluent_kafka import avro
 from pyflakes.test.harness import skipIf
 
+
 class TestMessageSerializer(unittest.TestCase):
     def setUp(self):
         # need to set up the serializer

--- a/tests/avro/test_message_serializer.py
+++ b/tests/avro/test_message_serializer.py
@@ -23,7 +23,9 @@
 import struct
 
 import unittest
-from unittest.mock import patch
+
+if sys.version >= 3.0
+    from unittest.mock import patch
 
 from tests.avro import data_gen
 from confluent_kafka.avro.serializer.message_serializer import MessageSerializer
@@ -76,7 +78,10 @@ class TestMessageSerializer(unittest.TestCase):
             message = self.ms.encode_record_with_schema(topic, basic, record)
             self.assertMessageIsSame(message, record, schema_id)
 
-    def test_encode_record_with_schema_sets_writers_cache_once(self):
+    def test_encode_r   ecord_with_schema_sets_writers_cache_once(self):
+        if sys.version < 3.0
+            # unittest.mock.patch not available
+            return
         topic = 'test'
         basic = avro.loads(data_gen.BASIC_SCHEMA)
         subject = 'test-value'

--- a/tests/avro/test_message_serializer.py
+++ b/tests/avro/test_message_serializer.py
@@ -23,15 +23,16 @@
 import struct
 
 import unittest
+from sys import version_info
 
-if sys.version >= 3.0
+if version_info >= (3,):
     from unittest.mock import patch
 
 from tests.avro import data_gen
 from confluent_kafka.avro.serializer.message_serializer import MessageSerializer
 from tests.avro.mock_schema_registry_client import MockSchemaRegistryClient
 from confluent_kafka import avro
-
+from pyflakes.test.harness import skipIf
 
 class TestMessageSerializer(unittest.TestCase):
     def setUp(self):
@@ -78,10 +79,9 @@ class TestMessageSerializer(unittest.TestCase):
             message = self.ms.encode_record_with_schema(topic, basic, record)
             self.assertMessageIsSame(message, record, schema_id)
 
-    def test_encode_r   ecord_with_schema_sets_writers_cache_once(self):
-        if sys.version < 3.0
-            # unittest.mock.patch not available
-            return
+    @skipIf(version_info < (3,),
+            'unittest.mock.patch not available in Python 2')
+    def test_encode_record_with_schema_sets_writers_cache_once(self):
         topic = 'test'
         basic = avro.loads(data_gen.BASIC_SCHEMA)
         subject = 'test-value'


### PR DESCRIPTION
this should fix the travis failure on linux/2.7. given this is the old avro client which is going to be depreciated, i think this hack solution is good enough.

review this only after travis is green. if travis is not green, i will fix