### PR TITLE
Minor bugfix: Fix format string parameters for ClientError

### DIFF
--- a/src/confluent_kafka/avro/cached_schema_registry_client.py
+++ b/src/confluent_kafka/avro/cached_schema_registry_client.py
@@ -461,7 +461,7 @@ class CachedSchemaRegistryClient(object):
         if code >= 200 and code <= 299:
             return result['compatibility']
         else:
-            raise ClientError("Unable to update level: %s. Error code: %d" % (str(level)), code)
+            raise ClientError("Unable to update level: %s. Error code: %d" % (str(level), code))
 
     def get_compatibility(self, subject=None):
         """


### PR DESCRIPTION
Fixes an error encountered when a ClientError is being raised due to failure to update schema compatibility levels:

```
<...snip...>
  File "/usr/local/lib/python3.8/site-packages/confluent_kafka/avro/cached_schema_registry_client.py", line 406, in update_compatibility
    raise ClientError("Unable to update level: %s. Error code: %d" % (str(level)), code)    
TypeError: not enough arguments for format string
```
