### PR TITLE
Add missing update to _known_subjects in ProtobufSerializer

### DIFF
--- a/src/confluent_kafka/schema_registry/protobuf.py
+++ b/src/confluent_kafka/schema_registry/protobuf.py
@@ -323,6 +323,8 @@ class ProtobufSerializer(object):
                 self._schema_id = self._registry.lookup_schema(
                     subject, self._schema).schema_id
 
+            self._known_subjects.add(subject)
+
         with _ContextStringIO() as fo:
             # Write the magic byte and schema ID in network byte order
             # (big endian)


### PR DESCRIPTION
Fixes https://github.com/confluentinc/confluent-kafka-python/issues/935 https://github.com/confluentinc/confluent-kafka-python/issues/1053

Without this update, a schema lookup is performed for every `ProtobufSerializer` call.

