### PR TITLE
Encode message indexes with varints to match java impl

### DIFF
--- a/tests/schema_registry/test_proto.py
+++ b/tests/schema_registry/test_proto.py
@@ -51,7 +51,7 @@ def test_create_index(pb2, coordinates):
 def test_index_serialization(pb2):
     msg_idx = _create_msg_index(pb2.DESCRIPTOR)
     buf = BytesIO()
-    ProtobufSerializer._encode_uvarints(buf, msg_idx)
+    ProtobufSerializer._encode_varints(buf, msg_idx)
     buf.flush()
 
     # reset buffer cursor
@@ -64,14 +64,14 @@ def test_index_serialization(pb2):
 
 @pytest.mark.parametrize("msg_idx, expected_hex", [
     ([1, 0], b'00'),   # b2a_hex always returns hex pairs
-    ([1, 1], b'01'),
-    ([1, 127], b'7f'),
-    ([1, 128], b'8001'),
-    ([1, 9223372036854775807], b'ffffffffffffffff7f')
+    ([1, 1], b'02'),
+    ([1, 127], b'fe01'),
+    ([1, 128], b'8002'),
+    ([1, 9223372036854775807], b'feffffffffffffffff01')
 ])
 def test_index_encoder(msg_idx, expected_hex):
     buf = BytesIO()
-    ProtobufSerializer._encode_uvarints(buf, msg_idx)
+    ProtobufSerializer._encode_varints(buf, msg_idx)
     buf.flush()
     # ignore array length prefix
     buf.seek(1)

--- a/tests/schema_registry/test_proto.py
+++ b/tests/schema_registry/test_proto.py
@@ -62,16 +62,21 @@ def test_index_serialization(pb2):
     assert decoded_msg_idx == msg_idx
 
 
-@pytest.mark.parametrize("msg_idx, expected_hex", [
-    ([1, 0], b'00'),   # b2a_hex always returns hex pairs
-    ([1, 1], b'02'),
-    ([1, 127], b'fe01'),
-    ([1, 128], b'8002'),
-    ([1, 9223372036854775807], b'feffffffffffffffff01')
+@pytest.mark.parametrize("msg_idx, expected_hex, deprecated_format", [
+    ([1, 0], b'00', False),   # b2a_hex always returns hex pirs
+    ([1, 1], b'02', False),
+    ([1, 127], b'fe01', False),
+    ([1, 128], b'8002', False),
+    ([1, 9223372036854775807], b'feffffffffffffffff01', False),
+    ([1, 0], b'00', True),
+    ([1, 1], b'01', True),
+    ([1, 127], b'7f', True),
+    ([1, 128], b'8001', True),
+    ([1, 9223372036854775807], b'ffffffffffffffff7f', True)
 ])
-def test_index_encoder(msg_idx, expected_hex):
+def test_index_encoder(msg_idx, expected_hex, deprecated_format):
     buf = BytesIO()
-    ProtobufSerializer._encode_varints(buf, msg_idx)
+    ProtobufSerializer._encode_index(buf, msg_idx, deprecated_format)
     buf.flush()
     # ignore array length prefix
     buf.seek(1)
@@ -79,4 +84,4 @@ def test_index_encoder(msg_idx, expected_hex):
 
     # reset reader and test decoder
     buf.seek(0)
-    assert msg_idx == ProtobufDeserializer._decode_index(buf)
+    assert msg_idx == ProtobufDeserializer._decode_index(buf, deprecated_format)


### PR DESCRIPTION
Fixes #926

Otherwise the python and java implementations are mutually
incompatible.

Is there anything else that needs to be done about this w.r.t. backwards compatibility?
This version will be incompatible with previous versions (w.r.t. reading/writing data) in the
same way that the previous versions are already incompatible with the java library.

That seems like a poor user experience (it's a "breaking change", in a sense), but I'm not
sure what a reasonable mitigation is, and doing nothing (retaining incompatibility with java)
is worse.

I should also mention that I was unable to run tests locally, so I'll be relying on the build
to tell me if I overlooked something.