### PR TITLE
Docs say Schema when they mean SchemaReference

### DIFF
--- a/src/confluent_kafka/schema_registry/schema_registry_client.py
+++ b/src/confluent_kafka/schema_registry/schema_registry_client.py
@@ -671,7 +671,7 @@ class Schema(object):
     Args:
         schema_str (str): String representation of the schema.
 
-        references ([Schema]): Schemas referenced by this schema.
+        references ([SchemaReference]): SchemaReferences used in this schema.
 
         schema_type (str): The schema type: AVRO, PROTOBUF or JSON.
 


### PR DESCRIPTION
Fixes https://github.com/confluentinc/confluent-kafka-python/issues/864