### PR TITLE
Document Fastavro tuple notation for unions

### DIFF
--- a/src/confluent_kafka/schema_registry/avro.py
+++ b/src/confluent_kafka/schema_registry/avro.py
@@ -123,7 +123,7 @@ class AvroSerializer(Serializer):
 
     Note:
        Tuple notation can be used to determine which branch of an ambiguous union to take.
-       
+
        See `fastavro notation <https://fastavro.readthedocs.io/en/latest/writer.html#using-the-tuple-notation-to-specify-which-branch-of-a-union-to-take>`_
 
     Args:

--- a/src/confluent_kafka/schema_registry/avro.py
+++ b/src/confluent_kafka/schema_registry/avro.py
@@ -121,6 +121,11 @@ class AvroSerializer(Serializer):
 
         See ``avro_producer.py`` in the examples directory for example usage.
 
+    Note:
+       Tuple notation can be used to determine which branch of an ambiguous union to take.
+       
+       See `fastavro notation <https://fastavro.readthedocs.io/en/latest/writer.html#using-the-tuple-notation-to-specify-which-branch-of-a-union-to-take>`_
+
     Args:
         schema_registry_client (SchemaRegistryClient): Schema Registry client instance.
 


### PR DESCRIPTION
Fixes: https://github.com/confluentinc/confluent-kafka-python/issues/656