### PR TITLE
Add list_topics and list_groups to Admin.py

### DIFF
--- a/src/confluent_kafka/admin/__init__.py
+++ b/src/confluent_kafka/admin/__init__.py
@@ -363,6 +363,14 @@ class AdminClient (_AdminClientImpl):
 
         return futmap
 
+    def list_topics(self, **kwargs):
+
+        return super(AdminClient, self).list_topics(**kwargs)
+
+    def list_groups(self, **kwargs):
+
+        return super(AdminClient, self).list_groups(**kwargs)
+
     def create_partitions(self, new_partitions, **kwargs):
         """
         Create additional partitions for the given topics.


### PR DESCRIPTION
_AdminClientImpl supports list_topics and list_groups, which are helpful functions to have available on the Py equivalent AdminClient. While you can access it, it's be great if the Py class had these functions included, so that the documentation could be more consistent and other tools (such as IDE's) could auto-complete these Py functions.