### PR TITLE
Add support for connect_cb

### DIFF
--- a/src/confluent_kafka/src/Consumer.c
+++ b/src/confluent_kafka/src/Consumer.c
@@ -271,7 +271,9 @@ static PyObject *Consumer_assign (Handle *self, PyObject *tlist) {
 
 	self->u.Consumer.rebalance_assigned++;
 
+        Py_BEGIN_ALLOW_THREADS
 	err = rd_kafka_assign(self->rk, c_parts);
+        Py_END_ALLOW_THREADS
 
 	rd_kafka_topic_partition_list_destroy(c_parts);
 
@@ -298,7 +300,10 @@ static PyObject *Consumer_unassign (Handle *self, PyObject *ignore) {
 
 	self->u.Consumer.rebalance_assigned++;
 
+        Py_BEGIN_ALLOW_THREADS
 	err = rd_kafka_assign(self->rk, NULL);
+        Py_END_ALLOW_THREADS
+
 	if (err) {
 		cfl_PyErr_Format(err,
 				 "Failed to remove assignment: %s",

--- a/src/confluent_kafka/src/Metadata.c
+++ b/src/confluent_kafka/src/Metadata.c
@@ -370,8 +370,15 @@ list_topics (Handle *self, PyObject *args, PyObject *kwargs) {
                 return NULL;
 
         if (topic != NULL) {
-                if (!(only_rkt = rd_kafka_topic_new(self->rk,
-                                                    topic, NULL))) {
+                CallState_begin(self, &cs);
+
+                only_rkt = rd_kafka_topic_new(self->rk, topic, NULL);
+
+                if (!CallState_end(self, &cs)) {
+                        goto end;
+                }
+
+                if (!only_rkt) {
                         return PyErr_Format(
                                 PyExc_RuntimeError,
                                 "Unable to create topic object "

--- a/src/confluent_kafka/src/confluent_kafka.c
+++ b/src/confluent_kafka/src/confluent_kafka.c
@@ -16,6 +16,7 @@
 
 #include "confluent_kafka.h"
 
+#include <arpa/inet.h>
 #include <stdarg.h>
 
 
@@ -1488,6 +1489,38 @@ static int stats_cb(rd_kafka_t *rk, char *json, size_t json_len, void *opaque) {
 	return 0;
 }
 
+static int connect_cb(int sockfd, const struct sockaddr *addr, int addrlen, const char *id, void *opaque) {
+        Handle *h = opaque;
+        PyObject *so = NULL, *ao = NULL, *io = NULL, *result = NULL;
+        const struct sockaddr_in *addr_in = NULL;
+        PyGILState_STATE gil;
+
+        gil = PyGILState_Ensure();
+
+        assert(addr->sa_family == AF_INET);
+        addr_in = (const struct sockaddr_in *)addr;
+
+        so = Py_BuildValue("i", sockfd);
+        ao = Py_BuildValue("(si)",
+                           inet_ntoa(addr_in->sin_addr),
+                           ntohs(addr_in->sin_port));
+        io = Py_BuildValue("s", id);
+        result = PyObject_CallFunctionObjArgs(h->connect_cb, so, ao, io, NULL);
+        Py_DECREF(io);
+        Py_DECREF(ao);
+        Py_DECREF(so);
+
+        if (result)
+                Py_DECREF(result);
+        else {
+                rd_kafka_yield(h->rk);
+        }
+
+/* done: */
+        PyGILState_Release(gil);
+        return 0;
+}
+
 static void log_cb (const rd_kafka_t *rk, int level,
                     const char *fac, const char *buf) {
         Handle *h = rd_kafka_opaque(rk);
@@ -2011,6 +2044,24 @@ rd_kafka_conf_t *common_conf_setup (rd_kafka_type_t ktype,
                         }
                         Py_XDECREF(ks8);
                         Py_DECREF(ks);
+                } else if (!strcmp(k, "connect_cb")) {
+                        if (!PyCallable_Check(vo)) {
+                                PyErr_SetString(PyExc_ValueError,
+                                        "expected connect_cb property "
+                                        "as a callable function");
+                                goto inner_err;
+                        }
+                        if (h->connect_cb) {
+                                Py_DECREF(h->connect_cb);
+                                h->connect_cb = NULL;
+                        }
+                        if (vo != Py_None) {
+                                h->connect_cb = vo;
+                                Py_INCREF(h->connect_cb);
+                        }
+                        Py_XDECREF(ks8);
+                        Py_DECREF(ks);
+                        rd_kafka_conf_set_connect_cb(conf, connect_cb);
                         continue;
                 }
 

--- a/src/confluent_kafka/src/confluent_kafka.h
+++ b/src/confluent_kafka/src/confluent_kafka.h
@@ -224,6 +224,7 @@ typedef struct {
 	PyObject *error_cb;
 	PyObject *throttle_cb;
 	PyObject *stats_cb;
+        PyObject *connect_cb;
         int initiated;
 
         /* Thread-Local-Storage key */


### PR DESCRIPTION
This PR adds the ability to set the `connect_cb` function to a Python function object. Through many iterations it has caused us to run into a few deadlocking situations because of the GIL, which is why several `rdkafka` calls now release it. We are looking for some feedback, but in particular this PR is still missing

- [ ] Windows support
- [ ] Docs
- [ ] Tests

Notably as discussed in #1097 this patch also releases/acquires the GIL in potentially hot paths, so the overall performance impact here is worth some attention.