### PR TITLE
Unset and reset error state to avoid triggering SystemErrors

### DIFF
--- a/src/confluent_kafka/src/confluent_kafka.c
+++ b/src/confluent_kafka/src/confluent_kafka.c
@@ -2120,6 +2120,9 @@ void CallState_begin (Handle *h, CallState *cs) {
 	cs->thread_state = PyEval_SaveThread();
 	assert(cs->thread_state != NULL);
 	cs->crashed = 0;
+	cs->err_type = NULL;
+	cs->err_value = NULL;
+	cs->err_traceback = NULL;
 #ifdef WITH_PY_TSS
         PyThread_tss_set(&h->tlskey, cs);
 #else
@@ -2140,8 +2143,15 @@ int CallState_end (Handle *h, CallState *cs) {
 
 	PyEval_RestoreThread(cs->thread_state);
 
-	if (PyErr_CheckSignals() == -1 || cs->crashed)
+	if (PyErr_CheckSignals() == -1 || cs->crashed) {
+		if (cs->err_type) { /* Restore any stored error */
+			PyErr_Restore(cs->err_type, cs->err_value, cs->err_traceback);
+			cs->err_type = NULL;
+			cs->err_value = NULL;
+			cs->err_traceback = NULL;
+		}
 		return 0;
+	}
 
 	return 1;
 }
@@ -2177,6 +2187,22 @@ void CallState_resume (CallState *cs) {
  */
 void CallState_crash (CallState *cs) {
 	cs->crashed++;
+	/* Obtain and clear the current error state */
+	PyObject *err_type, *err_value, *err_traceback;
+	PyErr_Fetch(&err_type, &err_value, &err_traceback);
+	if (err_type) {
+		/* If there was a previously stored error, discard it */
+		if (cs->err_type)
+			Py_DECREF(cs->err_type);
+		if (cs->err_value)
+			Py_DECREF(cs->err_value);
+		if (cs->err_traceback)
+			Py_DECREF(cs->err_traceback);
+		/* Save the new error */
+		cs->err_type = err_type;
+		cs->err_value = err_value;
+		cs->err_traceback = err_traceback;
+	}
 }
 
 

--- a/src/confluent_kafka/src/confluent_kafka.h
+++ b/src/confluent_kafka/src/confluent_kafka.h
@@ -275,6 +275,9 @@ int  Handle_traverse (Handle *h, visitproc visit, void *arg);
 typedef struct {
 	PyThreadState *thread_state;
 	int crashed;   /* Callback crashed */
+	PyObject *err_type; /* Error type emitted from the callback */
+	PyObject *err_value; /* Error object emitted from the callback */
+	PyObject *err_traceback; /* Error traceback emitted from the callback */
 } CallState;
 
 /**


### PR DESCRIPTION
Currently `error_cb` attempts to handle the case of the callback raising a python error, but this handling breaks down when the callback is invoked multiple times. The problem is that since raising an error simply consists of setting the error state in the interpreter, if this is not cleared the interpreter will treat every subsequent return from C code back to python as having raised an error, which is itself an error if that code (not having actually raised an error) attempts to return a value (including `None` to indicate successful completion). 

The error callback may be invoked multiple times by functions like `Consumer_consume` when retries are performed due to network issues. Given a callback of the form:

	def handle_error(kafka_error: confluent_kafka.KafkaError):
		logger.warning(f"internal kafka error: {kafka_error}")
		if some_condition:
			raise SomeError

Once `some_condition` has caused `SomeError` to be raised, subsequent invocations of the callback will fail in ways likely surprising to the user: A `SystemError` complaining that logger.warning "returned a result with an error set". (`logger.warning` could be any code which ends up calling into a C implmentation, including `print`.) Although this error will chain back to the original `SomeError` as the cause, it alters the control flow of the subsequent callback invocations, potentially bypasing logic that was important to the user. Additionally, the `SystemError`s obscure the original error type, so that attempting to handle it in the obvious way (`try. . . except SomeError`) will not work. 

The proposed solution is that confluent-kafka, instead of leaving the error state set after the callback to propagate when `Consumer_consume`, et al. return, should record any error directly after the callback completes, unset the error state, and then restore any error state before returning to python. `CallState_crash` and `CallState_end` seem to be well-positioned to do this. One possible source of complexity is that repeated invocations of the callback may raise multiple errors. The approach taken in this patch is simply to preserve and propagate the last error raised. It would certainly be possile to preserve all errors, but it does not seem obvious how to usefully communicate multiple errors back to the user. 