### PR TITLE
Support rd_kafka_memberid() from python clients

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Confluent's Python client for Apache Kafka
 
+## v1.8.0
+
+v1.8.0 is a maintenance release with the following fixes and enhancements:
+
+### Enhancements
+
+- Support rd_kafka_memberid() from python clients (#1154).
+
+confluent-kafka-python is based on librdkafka v1.8.0, see the
+[librdkafka release notes](https://github.com/edenhill/librdkafka/releases/tag/v1.8.0)
+for a complete list of changes, enhancements, fixes and upgrade considerations.
+
+
 ## v1.7.0
 
 v1.7.0 is a maintenance release with the following fixes and enhancements:

--- a/src/confluent_kafka/src/Consumer.c
+++ b/src/confluent_kafka/src/Consumer.c
@@ -993,10 +993,10 @@ static PyObject *Consumer_memberid (Handle *self, PyObject *args,
         memberid = rd_kafka_memberid(self->rk);
 
         if (!memberid)
-                return NULL;
+                Py_RETURN_NONE;
 
         memberidobj = Py_BuildValue("s", memberid);
-        rd_kafka_mem_free(NULL, memberid);
+        rd_kafka_mem_free(self->rk, memberid);
 
         return memberidobj;
 }

--- a/src/confluent_kafka/src/Consumer.c
+++ b/src/confluent_kafka/src/Consumer.c
@@ -96,9 +96,6 @@ static int Consumer_traverse (Handle *self,
 
 
 
-
-
-
 static PyObject *Consumer_subscribe (Handle *self, PyObject *args,
 					 PyObject *kwargs) {
 
@@ -980,6 +977,35 @@ static PyObject *Consumer_poll (Handle *self, PyObject *args,
 }
 
 
+static PyObject *Consumer_memberid (Handle *self, PyObject *args,
+                                    PyObject *kwargs) {
+        char *memberid = NULL;
+        PyObject *memberidobj;
+        CallState cs;
+        if (!self->rk) {
+                PyErr_SetString(PyExc_RuntimeError,
+                                "Consumer closed");
+                return NULL;
+        }
+
+        CallState_begin(self, &cs);
+
+        memberid = rd_kafka_memberid(self->rk);
+
+        fprintf(stderr, "Jing Liu memberid %s\n", memberid);
+
+        if (!CallState_end(self, &cs)) {
+                return NULL;
+        }
+
+        if (!memberid)
+                Py_RETURN_NONE;
+
+        memberidobj = PyBytes_FromString(memberid);
+        return memberidobj;
+}
+
+
 static PyObject *Consumer_consume (Handle *self, PyObject *args,
                                         PyObject *kwargs) {
         unsigned int num_messages = 1;
@@ -1409,6 +1435,22 @@ static PyMethodDef Consumer_methods[] = {
           "  :raises: RuntimeError if called on a closed consumer\n"
           "\n"
         },
+
+        { "memberid", (PyCFunction)Consumer_memberid,
+	  METH_VARARGS|METH_KEYWORDS,
+	  ".. py:function:: memberid()\n"
+	  "\n"
+	  " Look up this client's broker-assigned group member id.\n"
+	  "\n"
+	  " The member id is assigned by the group coordinator and "
+          " is propagated to the consumer during rebalance.\n"
+	  "\n"
+	  "  :returns: A string member id PyObject or None\n"
+	  "  :rtype: :py:class:`PyObject` or None\n"
+          "  :raises: RuntimeError if called on a closed consumer\n"
+	  "\n"
+	},
+
 	{ "close", (PyCFunction)Consumer_close, METH_NOARGS,
 	  "\n"
 	  "  Close down and terminate the Kafka Consumer.\n"

--- a/src/confluent_kafka/src/Consumer.c
+++ b/src/confluent_kafka/src/Consumer.c
@@ -982,27 +982,22 @@ static PyObject *Consumer_poll (Handle *self, PyObject *args,
 
 static PyObject *Consumer_memberid (Handle *self, PyObject *args,
                                     PyObject *kwargs) {
-        char *memberid = NULL;
+        char *memberid;
         PyObject *memberidobj;
-        CallState cs;
         if (!self->rk) {
                 PyErr_SetString(PyExc_RuntimeError,
                                 "Consumer closed");
                 return NULL;
         }
 
-        CallState_begin(self, &cs);
-
         memberid = rd_kafka_memberid(self->rk);
 
-        if (!CallState_end(self, &cs)) {
-                return NULL;
-        }
-
         if (!memberid)
-                Py_RETURN_NONE;
+                return NULL;
 
-        memberidobj = PyBytes_FromString(memberid);
+        memberidobj = Py_BuildValue("s", memberid);
+        rd_kafka_mem_free(NULL, memberid);
+
         return memberidobj;
 }
 
@@ -1436,17 +1431,16 @@ static PyMethodDef Consumer_methods[] = {
           "  :raises: RuntimeError if called on a closed consumer\n"
           "\n"
         },
-        { "memberid", (PyCFunction)Consumer_memberid,
-          METH_VARARGS|METH_KEYWORDS,
+        { "memberid", (PyCFunction)Consumer_memberid, METH_NOARGS,
           ".. py:function:: memberid()\n"
           "\n"
-          " Look up this client's broker-assigned group member id.\n"
+          " Return this client's broker-assigned group member id.\n"
           "\n"
-          " The member id is assigned by the group coordinator and "
+          " The member id is assigned by the group coordinator and"
           " is propagated to the consumer during rebalance.\n"
           "\n"
-          "  :returns: A PyObject with member id or None\n"
-          "  :rtype: :py:class:`PyObject` or None\n"
+          "  :returns: Member id string or None\n"
+          "  :rtype: string\n"
           "  :raises: RuntimeError if called on a closed consumer\n"
           "\n"
         },

--- a/src/confluent_kafka/src/Consumer.c
+++ b/src/confluent_kafka/src/Consumer.c
@@ -96,6 +96,9 @@ static int Consumer_traverse (Handle *self,
 
 
 
+
+
+
 static PyObject *Consumer_subscribe (Handle *self, PyObject *args,
 					 PyObject *kwargs) {
 
@@ -992,8 +995,6 @@ static PyObject *Consumer_memberid (Handle *self, PyObject *args,
 
         memberid = rd_kafka_memberid(self->rk);
 
-        fprintf(stderr, "Jing Liu memberid %s\n", memberid);
-
         if (!CallState_end(self, &cs)) {
                 return NULL;
         }
@@ -1435,22 +1436,20 @@ static PyMethodDef Consumer_methods[] = {
           "  :raises: RuntimeError if called on a closed consumer\n"
           "\n"
         },
-
         { "memberid", (PyCFunction)Consumer_memberid,
-	  METH_VARARGS|METH_KEYWORDS,
-	  ".. py:function:: memberid()\n"
-	  "\n"
-	  " Look up this client's broker-assigned group member id.\n"
-	  "\n"
-	  " The member id is assigned by the group coordinator and "
+          METH_VARARGS|METH_KEYWORDS,
+          ".. py:function:: memberid()\n"
+          "\n"
+          " Look up this client's broker-assigned group member id.\n"
+          "\n"
+          " The member id is assigned by the group coordinator and "
           " is propagated to the consumer during rebalance.\n"
-	  "\n"
-	  "  :returns: A string member id PyObject or None\n"
-	  "  :rtype: :py:class:`PyObject` or None\n"
+          "\n"
+          "  :returns: A PyObject with member id or None\n"
+          "  :rtype: :py:class:`PyObject` or None\n"
           "  :raises: RuntimeError if called on a closed consumer\n"
-	  "\n"
-	},
-
+          "\n"
+        },
 	{ "close", (PyCFunction)Consumer_close, METH_NOARGS,
 	  "\n"
 	  "  Close down and terminate the Kafka Consumer.\n"

--- a/tests/integration/consumer/test_consumer_memberid.py
+++ b/tests/integration/consumer/test_consumer_memberid.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Copyright 2020 Confluent Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limit
+
+import pytest
+import time
+from uuid import uuid1
+
+def test_consumer_memberid(kafka_cluster):
+    """
+    Test cooperative-sticky assignor and various aspects
+    of the incremental rebalancing API.
+    """
+
+    consumer_conf = {
+            'group.id': 'test'
+           }
+
+    topic = "testmemberid"
+
+    kafka_cluster.create_topic(topic)
+    
+
+    consumer = kafka_cluster.consumer(consumer_conf)
+
+    kafka_cluster.seed_topic(topic, value_source=[b'memberid'])
+
+    consumer.subscribe([topic])
+    msg = consumer.poll(10)
+    assert msg is not None
+    assert msg.value() == b'memberid'
+
+    assert consumer.kafka_memberid() is not None 
+    print("jing liu after poll memberid", consumer.kafka_memberid())
+
+    consumer.close()

--- a/tests/integration/consumer/test_consumer_memberid.py
+++ b/tests/integration/consumer/test_consumer_memberid.py
@@ -30,6 +30,7 @@ def test_consumer_memberid(kafka_cluster):
     consumer = kafka_cluster.consumer(consumer_conf)
 
     assert consumer is not None
+    assert len(consumer.memberid()) == 0
     kafka_cluster.seed_topic(topic, value_source=[b'memberid'])
 
     consumer.subscribe([topic])
@@ -37,4 +38,5 @@ def test_consumer_memberid(kafka_cluster):
     assert msg is not None
     assert msg.value() == b'memberid'
     assert len(consumer.memberid()) > 0
+    assert isinstance(consumer.memberid(), str) is True
     consumer.close()

--- a/tests/integration/consumer/test_consumer_memberid.py
+++ b/tests/integration/consumer/test_consumer_memberid.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
-# Copyright 2020 Confluent Inc.
+# Copyright 2021 Confluent Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,24 +15,17 @@
 # See the License for the specific language governing permissions and
 # limit
 
-import pytest
-import time
-from uuid import uuid1
 
 def test_consumer_memberid(kafka_cluster):
     """
-    Test cooperative-sticky assignor and various aspects
-    of the incremental rebalancing API.
+    Test consumer memberid.
     """
 
-    consumer_conf = {
-            'group.id': 'test'
-           }
+    consumer_conf = {'group.id': 'test'}
 
     topic = "testmemberid"
 
     kafka_cluster.create_topic(topic)
-    
 
     consumer = kafka_cluster.consumer(consumer_conf)
 
@@ -42,8 +35,5 @@ def test_consumer_memberid(kafka_cluster):
     msg = consumer.poll(10)
     assert msg is not None
     assert msg.value() == b'memberid'
-
-    assert consumer.kafka_memberid() is not None 
-    print("jing liu after poll memberid", consumer.kafka_memberid())
-
+    assert consumer.memberid() is not None
     consumer.close()

--- a/tests/integration/consumer/test_consumer_memberid.py
+++ b/tests/integration/consumer/test_consumer_memberid.py
@@ -29,11 +29,12 @@ def test_consumer_memberid(kafka_cluster):
 
     consumer = kafka_cluster.consumer(consumer_conf)
 
+    assert consumer is not None
     kafka_cluster.seed_topic(topic, value_source=[b'memberid'])
 
     consumer.subscribe([topic])
     msg = consumer.poll(10)
     assert msg is not None
     assert msg.value() == b'memberid'
-    assert consumer.memberid() is not None
+    assert len(consumer.memberid()) > 0
     consumer.close()

--- a/tests/integration/consumer/test_consumer_memberid.py
+++ b/tests/integration/consumer/test_consumer_memberid.py
@@ -37,6 +37,6 @@ def test_consumer_memberid(kafka_cluster):
     msg = consumer.poll(10)
     assert msg is not None
     assert msg.value() == b'memberid'
-    assert len(consumer.memberid()) > 0
     assert isinstance(consumer.memberid(), str) is True
+    assert len(consumer.memberid()) > 0
     consumer.close()


### PR DESCRIPTION
librdkafka has a rd_kafka_memberid() function, but it is not exposed in the Python client yet.

Local test:
```
tests/test_Consumer.py::test_consumer_without_groupid PASSED
tests/test_Consumer.py::test_consumer_memberid Jing Liu before partitioner
Jing Liu no partitioner
msg after consumer b'Hello Go!'
Jing Liu memberid start librdkafkaJing Liu memberid librdkafka rdkafka-29c884cd-cca3-4a18-a62f-e6ddd8bcd8ea
jing liu after poll memberid rdkafka-29c884cd-cca3-4a18-a62f-e6ddd8bcd8ea
PASSED
```