### PR TITLE
avro: fix primitive and union schema parsing bugs

### DIFF
--- a/src/confluent_kafka/schema_registry/avro.py
+++ b/src/confluent_kafka/schema_registry/avro.py
@@ -62,8 +62,8 @@ def _schema_loads(schema_str):
     schema_str = schema_str.strip()
 
     # canonical form primitive declarations are not supported
-    if schema_str[0] != "{":
-        schema_str = '{"type":"' + schema_str + '"}'
+    if schema_str[0] != "{" and schema_str[0] != "[":
+        schema_str = '{"type":' + schema_str + '}'
 
     return Schema(schema_str, schema_type='AVRO')
 
@@ -187,11 +187,20 @@ class AvroSerializer(Serializer):
         schema = _schema_loads(schema_str)
         schema_dict = loads(schema.schema_str)
         parsed_schema = parse_schema(schema_dict)
-        # The Avro spec states primitives have a name equal to their type
-        # i.e. {"type": "string"} has a name of string.
-        # This function does not comply.
-        # https://github.com/fastavro/fastavro/issues/415
-        schema_name = parsed_schema.get('name', schema_dict['type'])
+
+        if isinstance(parsed_schema, list):
+            # if parsed_schema is a list, we have an Avro union and there
+            # is no valid schema name. This is fine because the only use of
+            # schema_name is for supplying the subject name to the registry
+            # and union types should use topic_subject_name_strategy, which
+            # just discards the schema name anyway
+            schema_name = None
+        else:
+            # The Avro spec states primitives have a name equal to their type
+            # i.e. {"type": "string"} has a name of string.
+            # This function does not comply.
+            # https://github.com/fastavro/fastavro/issues/415
+            schema_name = parsed_schema.get("name", schema_dict["type"])
 
         self._schema = schema
         self._schema_name = schema_name

--- a/tests/integration/schema_registry/data/union_schema.avsc
+++ b/tests/integration/schema_registry/data/union_schema.avsc
@@ -1,0 +1,22 @@
+[
+    {
+        "name": "RecordOne",
+        "type": "record",
+        "fields": [
+            {
+                "name": "field_one",
+                "type": "string"
+            }
+        ]
+    },
+    {
+        "name": "RecordTwo",
+        "type": "record",
+        "fields": [
+            {
+                "name": "field_two",
+                "type": "int"
+            }
+        ]
+    }
+]


### PR DESCRIPTION
Fixes #989 

This commit cleans up a few bugs in the _schema_loads function:

We use primitive types retrieved from the Confluent Registry and encountered an issue where _schema_loads would cause json deserialization errors by double quoting valid primitive declarations. Previous tests included incorrectly specified primitive declarations, according to the Avro spec primitive declarations are valid JSON documents, but they had been specified as strings of their type name with no quoting. I fixed the tests as well as the issue in _schema_loads

Somewhat separately, there was also an issue with Avro union types. _schema_loads was incorrectly causing json serialization errors for unions because it included them on accident with its special-casing of primitive declarations. I added a check for json arrays to exclude them from the special casing. I also had to add a check later to ensure the _schema_name property was special-cased to None for unions. This should have no impact on names in the registry because _schema_name isn't used at all for the recommended subject name strategy with unions.