### PR TITLE
Add a missing incref to c_headers_to_py

### DIFF
--- a/src/confluent_kafka/src/confluent_kafka.c
+++ b/src/confluent_kafka/src/confluent_kafka.c
@@ -1299,6 +1299,7 @@ PyObject *c_headers_to_py (rd_kafka_headers_t *headers) {
                         cfl_PyBin(_FromStringAndSize(header_value, header_value_size))
                     );
             } else {
+                Py_INCREF(Py_None);
                 PyTuple_SetItem(header_tuple, 1, Py_None);
             }
         PyList_SET_ITEM(header_list, idx-1, header_tuple);


### PR DESCRIPTION
Before the `c_headers_to_py` function had a branch where a refcount was
not correctly incremented.  This can cause the `Py_None` object to
eventually deallocate which will crash the interpreter.