### PR TITLE
Support default parameters for AdminClient#createTopic

### DIFF
--- a/src/confluent_kafka/src/AdminTypes.c
+++ b/src/confluent_kafka/src/AdminTypes.c
@@ -78,7 +78,7 @@ static int NewTopic_init (PyObject *self0, PyObject *args,
         self->replica_assignment = NULL;
         self->config = NULL;
 
-        if (!PyArg_ParseTupleAndKeywords(args, kwargs, "si|iOO", kws,
+        if (!PyArg_ParseTupleAndKeywords(args, kwargs, "s|iiOO", kws,
                                          &topic, &self->num_partitions,
                                          &self->replication_factor,
                                          &self->replica_assignment,

--- a/tests/test_Admin.py
+++ b/tests/test_Admin.py
@@ -115,6 +115,8 @@ def test_create_topics_api():
         a.create_topics([NewTopic("mytopic", 3, 2,
                                   config=["fails", "because not a dict"])])
 
+    fs = a.create_topics([NewTopic("mytopicDefault")])
+
 
 @pytest.mark.skipif(libversion()[1] < 0x000b0500,
                     reason="AdminAPI requires librdkafka >= v0.11.5")


### PR DESCRIPTION
librdkafka supports creating topics with default
partitions and replication factor, expose this
feature to python client.