### PR TITLE
Update Jenkinsfile Nodelabel

### DIFF
--- a/tests/system/Jenkinsfile
+++ b/tests/system/Jenkinsfile
@@ -1,6 +1,6 @@
 def config = jobConfig {
     cron = '@midnight'
-    nodeLabel = 'docker-oraclejdk8'
+    nodeLabel = 'docker-debian-10-system-test-jdk8'
     realJobPrefixes = ['system-test-python-client']
     owner = 'client'
     slackChannel = 'clients-eng'


### PR DESCRIPTION
Update Jenkinsfile Nodelabel to use new build image.

Job is still active but doesn't seem to run correctly anymore: https://jenkins.confluent.io/job/system-test-python-client/job/master/. -> still making change in case we want to fix, if not we should deprecate/remove job.