### PR TITLE
Use `str(Schema)` rather than `Schema.to_json`

### DIFF
--- a/src/confluent_kafka/avro/serializer/message_serializer.py
+++ b/src/confluent_kafka/avro/serializer/message_serializer.py
@@ -20,6 +20,7 @@
 # derived from https://github.com/verisign/python-confluent-schemaregistry.git
 #
 import io
+import json
 import logging
 import struct
 import sys
@@ -79,7 +80,7 @@ class MessageSerializer(object):
     # Encoder support
     def _get_encoder_func(self, writer_schema):
         if HAS_FAST:
-            schema = writer_schema.to_json()
+            schema = json.loads(str(writer_schema))
             parsed_schema = parse_schema(schema)
             return lambda record, fp: schemaless_writer(fp, parsed_schema, record)
         writer = avro.io.DatumWriter(writer_schema)
@@ -175,8 +176,8 @@ class MessageSerializer(object):
         if HAS_FAST:
             # try to use fast avro
             try:
-                fast_avro_writer_schema = parse_schema(writer_schema_obj.to_json())
-                fast_avro_reader_schema = parse_schema(reader_schema_obj.to_json())
+                fast_avro_writer_schema = parse_schema(json.loads(str(writer_schema_obj)))
+                fast_avro_reader_schema = parse_schema(json.loads(str(reader_schema_obj)))
                 schemaless_reader(payload, fast_avro_writer_schema)
 
                 # If we reach this point, this means we have fastavro and it can

--- a/src/confluent_kafka/avro/serializer/message_serializer.py
+++ b/src/confluent_kafka/avro/serializer/message_serializer.py
@@ -177,7 +177,10 @@ class MessageSerializer(object):
             # try to use fast avro
             try:
                 fast_avro_writer_schema = parse_schema(json.loads(str(writer_schema_obj)))
-                fast_avro_reader_schema = parse_schema(json.loads(str(reader_schema_obj)))
+                if reader_schema_obj is not None:
+                    fast_avro_reader_schema = parse_schema(json.loads(str(reader_schema_obj)))
+                else:
+                    fast_avro_reader_schema = None
                 schemaless_reader(payload, fast_avro_writer_schema)
 
                 # If we reach this point, this means we have fastavro and it can

--- a/tests/avro/adv_schema.avsc
+++ b/tests/avro/adv_schema.avsc
@@ -56,6 +56,17 @@
                 "type" : "map",
                 "values" : "basicPerson"
             }
+        },
+        {
+            "name": "timestamp",
+            "type": [
+                "null",
+                {
+                    "type": "long",
+                    "logicalType": "timestamp-millis"
+                }
+            ],
+            "default": null
         }
     ]
 }

--- a/tests/avro/data_gen.py
+++ b/tests/avro/data_gen.py
@@ -22,6 +22,7 @@
 import os
 import os.path
 import random
+from datetime import datetime, timezone
 
 from avro import schema
 from avro.datafile import DataFileWriter
@@ -65,6 +66,7 @@ def create_adv_item(i):
     basic = create_basic_item(i)
     basic['family'] = dict(map(lambda bi: (bi['name'], bi), family))
     basic['friends'] = dict(map(lambda bi: (bi['name'], bi), friends))
+    basic['timestamp'] = datetime(1970, 1, 1, 0, 0, tzinfo=timezone.utc)
     return basic
 
 


### PR DESCRIPTION
Use `str(Schema)` rather than `Schema.to_json` to prevent `fastavro` from raising exception `TypeError: unhashable type: 'mappingproxy'`

Fixes #1156

When you try to produce a message with a schema such as
```json
{
    "name": "ComplexValue",
    "type": "record",
    "fields": [
        {
            "name": "primitive_field",
            "type": "string"
        },
        {
            "name": "optional_recursive_field",
            "type": [
                "null",
                "ComplexValue"
            ],
            "default": null
        },
        {
            "name": "logical_type_field",
            "type": [
                "null",
                {
                    "type": "long",
                    "logicalType": "timestamp-millis"
                }
            ],
            "default": 1
        }
    ]
}
```
`fastavro` raises `E   TypeError: unhashable type: 'mappingproxy'`

This is caused by the wrong json produced by `Schema.to_json`. Since `avro-python3` version 1.9.0 ([according to this JIRA](https://issues.apache.org/jira/browse/AVRO-2411)), the recommended way of serialising a schema to json is to use `str(schema)` rather than `schema.to_json()`

The code in this PR calls `str` and `json.loads` to have a proper `dict` instance that `fastavro` will be able to handle.