### PR TITLE
Update avro dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ SCHEMA_REGISTRY_REQUIRES = ['requests']
 
 AVRO_REQUIRES = ['fastavro>=0.23.0,<1.0;python_version<"3.0"',
                  'fastavro>=1.0;python_version>"3.0"',
-                 'avro==1.10.0'
+                 'avro>=1.11.1,<2',
                  ] + SCHEMA_REGISTRY_REQUIRES
 
 JSON_REQUIRES = ['pyrsistent==0.16.1;python_version<"3.0"',

--- a/src/confluent_kafka/avro/requirements.txt
+++ b/src/confluent_kafka/avro/requirements.txt
@@ -1,3 +1,3 @@
 fastavro>=0.23.0
 requests
-avro==1.10.0
+avro>=1.11.1,<2

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -5,6 +5,6 @@ pytest-timeout
 requests-mock
 trivup>=0.8.3
 fastavro
-avro==1.10.0
+avro>=1.11.1,<2
 jsonschema
 protobuf


### PR DESCRIPTION
https://avro.apache.org/docs/1.10.2/gettingstartedpython.html

> Notice for Python 3 users
> A package called "avro-python3" had been provided to support Python 3 previously, but the codebase was consolidated into the "avro" package and that supports both Python 2 and 3 now. The avro-python3 package will be removed in the near future, so users should use the "avro" package instead. They are mostly API compatible, but there's a few minor difference (e.g., function name capitalization, such as avro.schema.Parse vs avro.schema.parse).
