### PR TITLE
single schema object for to be returned for all method

### DIFF
--- a/src/confluent_kafka/schema_registry/schema_registry_client.py
+++ b/src/confluent_kafka/schema_registry/schema_registry_client.py
@@ -677,7 +677,7 @@ class Schema(object):
 
         self.schema_str = schema_str
         self.schema_type = schema_type
-        self.references = self.schema_references(references)
+        self.references = [SchemaReference(name=ref['name'], subject=ref['subject'], version=ref['version']) for ref in references]
         self._hash = hash(schema_str)
 
     def __eq__(self, other):
@@ -686,15 +686,6 @@ class Schema(object):
 
     def __hash__(self):
         return self._hash
-
-    def schema_references(self, references):
-        refs = []
-        for ref in references:
-            refs.append(SchemaReference(name=ref['name'],
-                                        subject=ref['subject'],
-                                        version=ref['version']))
-        return refs
-
 
 
 class RegisteredSchema(object):

--- a/src/confluent_kafka/schema_registry/schema_registry_client.py
+++ b/src/confluent_kafka/schema_registry/schema_registry_client.py
@@ -367,14 +367,8 @@ class SchemaRegistryClient(object):
 
         response = self._rest_client.get('schemas/ids/{}'.format(schema_id))
         schema = Schema(schema_str=response['schema'],
-                        schema_type=response.get('schemaType', 'AVRO'))
-
-        refs = []
-        for ref in response.get('references', []):
-            refs.append(SchemaReference(name=ref['name'],
-                                        subject=ref['subject'],
-                                        version=ref['version']))
-        schema.references = refs
+                        schema_type=response.get('schemaType', 'AVRO'),
+                        references=response.get('references', []))
 
         self._cache.set(schema_id, schema)
 
@@ -683,7 +677,7 @@ class Schema(object):
 
         self.schema_str = schema_str
         self.schema_type = schema_type
-        self.references = references
+        self.references = self.schema_references(references)
         self._hash = hash(schema_str)
 
     def __eq__(self, other):
@@ -692,6 +686,15 @@ class Schema(object):
 
     def __hash__(self):
         return self._hash
+
+    def schema_references(self, references):
+        refs = []
+        for ref in references:
+            refs.append(SchemaReference(name=ref['name'],
+                                        subject=ref['subject'],
+                                        version=ref['version']))
+        return refs
+
 
 
 class RegisteredSchema(object):


### PR DESCRIPTION
Currently `SchemaRegistryClient` method have different schema object for different method for example:  `get_latest_version` return you schema with references as array of json as below
```
[{'name': 'com.test.common.event.Eventdata', 'subject': 'com.test.common.event.Eventdata', 'version': 5}, {'name': 'com.test.schema.user.Details', 'subject': 'com.test.schema.user.Details', 'version': 2}]
```
While `get_schema` method return you schema with references as array of `SchemaReference` object as below
```
[<confluent_kafka.schema_registry.schema_registry_client.SchemaReference object at 0x1037a9790>, <confluent_kafka.schema_registry.schema_registry_client.SchemaReference object at 0x1037a97f0>]
```

Which get it difficult to use like need to make different function one for to get schema id and other to get schema object with id that has `SchemaReference` object.

As it is more like to fetch schema with subject name rather than `schema_id` because we can map our schema with topic and reuse topic name to fetch the schema.

So this PR will make a single universal schema object that will be returned by any method call.