### PR TITLE
Added aarch64 build steps to Developer guide 

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -13,6 +13,28 @@ If librdkafka is installed in a non-standard location provide the include and li
 
 **Note**: On Windows the variables for Visual Studio are named INCLUDE and LIB 
 
+### aarch64 Build
+
+Confluent's Python Client for Apache Kafka is a wrapper around `librdkafka`. `libradkafka` does not come with prebuilt binary wheels for aarch64, so you will need to compile it yourself, which requires you to first build and install `librdkafka` from source. `libradkafka` build steps for Debian based systems and Alpine are listed below:
+
+**Debian based:**
+
+```
+    $ sudo apt install -y libssl-dev zlib1g-dev gcc g++ make 
+    $ git clone https://github.com/edenhill/librdkafka 
+    $ cd librdkafa 
+    $ ./configure --prefix=/usr 
+    $ make 
+    $ sudo make install
+```
+
+**Alpine:**
+`libradkafka` build steps are the same for Alpine, but some of the required packages are not available for Alpine. Replace the first step of Debian build with below command to satisfy the requirements:
+
+    $ sudo apk add libssl-dev zlib1g-dev gcc g++ make
+
+The rest would be the same as above.
+
 ## Generate Documentation
 
 Install sphinx and sphinx_rtd_theme packages:


### PR DESCRIPTION
Added the method mentioned in #462 for building libradkafka from source on aarch64 platforms to developer guide.

Also included the required packages for building libradkafka on alpine.

I had difficulties running confluent-kafka-python on aarch64 so I thought maybe this would be helpful for others as well.

Cheers.
