### PR TITLE
fix order of param

### DIFF
--- a/examples/avro_consumer.py
+++ b/examples/avro_consumer.py
@@ -83,8 +83,8 @@ def main(args):
     sr_conf = {'url': args.schema_registry}
     schema_registry_client = SchemaRegistryClient(sr_conf)
 
-    avro_deserializer = AvroDeserializer(schema_str,
-                                         schema_registry_client,
+    avro_deserializer = AvroDeserializer(schema_registry_client,
+                                         schema_str,
                                          dict_to_user)
     string_deserializer = StringDeserializer('utf_8')
 

--- a/examples/avro_producer.py
+++ b/examples/avro_producer.py
@@ -115,8 +115,8 @@ def main(args):
     schema_registry_conf = {'url': args.schema_registry}
     schema_registry_client = SchemaRegistryClient(schema_registry_conf)
 
-    avro_serializer = AvroSerializer(schema_str,
-                                     schema_registry_client,
+    avro_serializer = AvroSerializer(schema_registry_client,
+                                     schema_str,
                                      user_to_dict)
 
     producer_conf = {'bootstrap.servers': args.bootstrap_servers,


### PR DESCRIPTION
In example, AvroDeserializer/Serializer init with wrong order of param. This PR fix it.

https://github.com/confluentinc/confluent-kafka-python/blob/d2667e9bce37fe8629b9629d68f0c2b66d4b570e/src/confluent_kafka/schema_registry/avro.py#L155