### PR TITLE
updated readme code example

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,13 +41,14 @@ def delivery_report(err, msg):
         print('Message delivered to {} [{}]'.format(msg.topic(), msg.partition()))
 
 for data in some_data_source:
-    # Trigger any available delivery report callbacks from previous produce() calls
-    p.poll(0)
-
     # Asynchronously produce a message, the delivery report callback
     # will be triggered from poll() above, or flush() below, when the message has
     # been successfully delivered or failed permanently.
     p.produce('mytopic', data.encode('utf-8'), callback=delivery_report)
+    
+    # Trigger any available delivery report callbacks from previous produce() calls
+    p.poll(0)
+
 
 # Wait for any outstanding messages to be delivered and delivery report
 # callbacks to be triggered.


### PR DESCRIPTION
Updated producer code example to call `.produce()` before calling `.poll()` because calling `.poll()` first without produce hangs