### PR TITLE
Update Jenkinsfile to use maven settings helper

### DIFF
--- a/tests/system/Jenkinsfile
+++ b/tests/system/Jenkinsfile
@@ -8,16 +8,19 @@ def config = jobConfig {
 }
 
 def job = {
+    def mavenSettingsFile = "${env.WORKSPACE_TMP}/maven-global-settings.xml"
+
     configureGitSSH("github/confluent_jenkins", "private_key")
-    def mavenSettingsFile = "/home/jenkins/.m2/settings.xml"
     withVaultEnv([["artifactory/tools_jenkins", "user", "TOOLS_ARTIFACTORY_USER"],
         ["artifactory/tools_jenkins", "password", "TOOLS_ARTIFACTORY_PASSWORD"],
         ["sonatype/confluent", "user", "SONATYPE_OSSRH_USER"],
         ["sonatype/confluent", "password", "SONATYPE_OSSRH_PASSWORD"]]) {
         withVaultFile([["muckrake/2017-06-01", "pem", "muckrake-2017-06-01.pem", "MUCKRAKE_PEM"]]) {
             withMavenSettings("maven/jenkins_maven_global_settings", "settings", "MAVEN_GLOBAL_SETTINGS", mavenSettingsFile) {
-                stage("Run tests") {
-                    sh 'tests/system/run-tests.sh'
+                withMaven(globalMavenSettingsFilePath: mavenSettingsFile) {
+                    stage("Run tests") {
+                        sh 'tests/system/run-tests.sh'
+                    }
                 }
             }
         }

--- a/tests/system/Jenkinsfile
+++ b/tests/system/Jenkinsfile
@@ -9,15 +9,16 @@ def config = jobConfig {
 
 def job = {
     configureGitSSH("github/confluent_jenkins", "private_key")
+    def mavenSettingsFile = "/home/jenkins/.m2/settings.xml"
     withVaultEnv([["artifactory/tools_jenkins", "user", "TOOLS_ARTIFACTORY_USER"],
         ["artifactory/tools_jenkins", "password", "TOOLS_ARTIFACTORY_PASSWORD"],
         ["sonatype/confluent", "user", "SONATYPE_OSSRH_USER"],
         ["sonatype/confluent", "password", "SONATYPE_OSSRH_PASSWORD"]]) {
-        withVaultFile([["maven/jenkins_maven_global_settings", "settings_xml",
-            "/home/jenkins/.m2/settings.xml", "MAVEN_GLOBAL_SETTINGS"],
-            ["muckrake/2017-06-01", "pem", "muckrake-2017-06-01.pem", "MUCKRAKE_PEM"]]) {
-            stage("Run tests") {
-                sh 'tests/system/run-tests.sh'
+        withVaultFile([["muckrake/2017-06-01", "pem", "muckrake-2017-06-01.pem", "MUCKRAKE_PEM"]]) {
+            withMavenSettings("maven/jenkins_maven_global_settings", "settings", "MAVEN_GLOBAL_SETTINGS", mavenSettingsFile) {
+                stage("Run tests") {
+                    sh 'tests/system/run-tests.sh'
+                }
             }
         }
     }


### PR DESCRIPTION
Use the maven settings helper function [withMavenSettings()](https://github.com/confluentinc/jenkins-common/pull/415) which avoids including hardcoded credentials in our vault secrets.