### PR TITLE
Deserializing.consume method docstring update

### DIFF
--- a/src/confluent_kafka/deserializing_consumer.py
+++ b/src/confluent_kafka/deserializing_consumer.py
@@ -152,7 +152,7 @@ class DeserializingConsumer(_ConsumerImpl):
 
     def consume(self, num_messages=1, timeout=-1):
         """
-        :py:func:`Consumer.consume` not implemented, use
+        :py:func:`DeserializingConsumer.consume` not implemented, use
         :py:func:`DeserializingConsumer.poll` instead
         """
         raise NotImplementedError


### PR DESCRIPTION
The docstring of _DeserializingConsumer.consume_ method currently says
`       :py:func:`Consumer.consume` not implemented, use
        :py:func:`DeserializingConsumer.poll` instead`

but the method _raises_ **NotImplementedError** 

I assume it should be 
`       :py:func:`DeserializingConsumer.consume` not implemented, use
        :py:func:`DeserializingConsumer.poll` instead`

This PR updates the same.
Thanks :)

