### PR TITLE
typo in produce API documentation

### DIFF
--- a/src/confluent_kafka/deserializing_consumer.py
+++ b/src/confluent_kafka/deserializing_consumer.py
@@ -68,7 +68,7 @@ class DeserializingConsumer(_ConsumerImpl):
     |                         |                     | errors are typically to be considered informational |
     |                         |                     | since the client will automatically try to recover. |
     +-------------------------+---------------------+-----------------------------------------------------+
-    | ``log_cb``              | ``logging.Handler`` | Logging handler to forward logs                     |
+    | ``logger``              | ``logging.Handler`` | Logging handler to forward logs                     |
     +-------------------------+---------------------+-----------------------------------------------------+
     |                         |                     | Callable(str)                                       |
     |                         |                     |                                                     |

--- a/src/confluent_kafka/serializing_producer.py
+++ b/src/confluent_kafka/serializing_producer.py
@@ -76,7 +76,7 @@ class SerializingProducer(_ProducerImpl):
     |                         |                     | errors are typically to be considered informational |
     |                         |                     | since the client will automatically try to recover. |
     +-------------------------+---------------------+-----------------------------------------------------+
-    | ``log_cb``              | ``logging.Handler`` | Logging handler to forward logs                     |
+    | ``logger``              | ``logging.Handler`` | Logging handler to forward logs                     |
     +-------------------------+---------------------+-----------------------------------------------------+
     |                         |                     | Callable(str)                                       |
     |                         |                     |                                                     |

--- a/src/confluent_kafka/src/Producer.c
+++ b/src/confluent_kafka/src/Producer.c
@@ -584,7 +584,7 @@ static PyMethodDef Producer_methods[] = {
 	  "failed delivery\n"
           "  :param int timestamp: Message timestamp (CreateTime) in milliseconds since epoch UTC (requires librdkafka >= v0.9.4, api.version.request=true, and broker >= 0.10.0.0). Default value is current time.\n"
 	  "\n"
-          "  :param headers dict|list: Message headers to set on the message. The header key must be a string while the value must be binary, unicode or None. Accepts a list of (key,value) or a dict. (Requires librdkafka >= v0.11.4 and broker version >= 0.11.0.0)\n"
+          "  :param dict|list headers: Message headers to set on the message. The header key must be a string while the value must be binary, unicode or None. Accepts a list of (key,value) or a dict. (Requires librdkafka >= v0.11.4 and broker version >= 0.11.0.0)\n"
 	  "  :rtype: None\n"
 	  "  :raises BufferError: if the internal producer message queue is "
 	  "full (``queue.buffering.max.messages`` exceeded)\n"


### PR DESCRIPTION
This PR include 2 fixes:

1. There is typo in produce API do
<img width="916" alt="Screen Shot 2022-03-04 at 2 38 31 PM" src="https://user-images.githubusercontent.com/7269552/156851518-e66f21b7-3de8-4d27-8343-6e284f4ac276.png">

This is the screen shot on my local after the fix: 
<img width="883" alt="Screen Shot 2022-03-04 at 2 40 01 PM" src="https://user-images.githubusercontent.com/7269552/156851629-8e2728d6-6a58-4777-8f89-d6ca53c26bca.png">

2. log_cb in SerializingProducer and DeserializingConsumer docstring should be `logger`:
<img width="1392" alt="Screen Shot 2022-03-10 at 4 38 00 PM" src="https://user-images.githubusercontent.com/7269552/157779637-e1dbe113-2966-42aa-9c26-a574fe16b0cb.png">

