### PR TITLE
Add new option oauth_cb to SchemaRegistryClient

### DIFF
--- a/tests/schema_registry/conftest.py
+++ b/tests/schema_registry/conftest.py
@@ -144,6 +144,7 @@ class MockSchemaRegistryClient(SchemaRegistryClient):
     SCHEMA = 'basic_schema.avsc'
     SUBJECTS = ['subject1', 'subject2']
     USERINFO = 'mock_user:mock_password'
+    OAUTH_TOKEN = 'VALID_TOKEN'
 
     # Counts requests handled per path by HTTP method
     # {HTTP method: { path : count}}
@@ -192,10 +193,13 @@ class MockSchemaRegistryClient(SchemaRegistryClient):
         if authinfo is None:
             return None
 
-        # We only support the BASIC scheme today
         scheme, userinfo = authinfo.split(" ")
-        if b64decode(userinfo).decode('utf-8') == cls.USERINFO:
-            return None
+        if scheme.upper() == 'BEARER':
+            if userinfo == cls.OAUTH_TOKEN:
+                return None
+        if scheme.upper() == 'BASIC':
+            if b64decode(userinfo).decode('utf-8') == cls.USERINFO:
+                return None
 
         unauthorized = {'error_code': 401,
                         'message': "401 Unauthorized"}

--- a/tests/schema_registry/test_api_client.py
+++ b/tests/schema_registry/test_api_client.py
@@ -74,6 +74,29 @@ def test_basic_auth_authorized(mock_schema_registry, load_avsc):
     assert result == mock_schema_registry.SUBJECTS
 
 
+def test_oauth_cb_unauthorized(mock_schema_registry, load_avsc):
+    def oauth_callback():
+        return ('BAD_TOKEN', '123456')
+    conf = {'url': TEST_URL,
+            'oauth_cb': oauth_callback}
+    sr = mock_schema_registry(conf)
+
+    with pytest.raises(SchemaRegistryError, match="401 Unauthorized"):
+            sr.get_subjects()
+
+
+def test_oauth_cb_authorized(mock_schema_registry, load_avsc):
+    def oauth_callback():
+        return (mock_schema_registry.OAUTH_TOKEN, '123456')
+    conf = {'url': TEST_URL,
+        'oauth_cb': oauth_callback}
+    sr = mock_schema_registry(conf)
+
+    result = sr.get_subjects()
+
+    assert result == mock_schema_registry.SUBJECTS
+
+
 def test_register_schema(mock_schema_registry, load_avsc):
     conf = {'url': TEST_URL}
     sr = mock_schema_registry(conf)

--- a/tests/schema_registry/test_config.py
+++ b/tests/schema_registry/test_config.py
@@ -124,6 +124,24 @@ def test_config_auth_userinfo_invalid():
         SchemaRegistryClient(conf)
 
 
+def test_config_oauth_cb():
+    def mock_oauth_callback():
+        pass
+    conf = {'url': TEST_URL, 'oauth_cb': mock_oauth_callback}
+    test_client = SchemaRegistryClient(conf)
+    assert test_client._rest_client.oauth_cb == mock_oauth_callback
+
+def test_config_oauth_cb_and_userinfo():
+    def mock_oauth_callback():
+        pass
+    conf = {'url': 'http://'
+               + TEST_USERNAME + ":"
+               + TEST_USER_PASSWORD + '@SchemaRegistry:65534',
+             'oauth_cb': mock_oauth_callback}
+    with pytest.raises(ValueError, match="Must specify either basic auth user"
+                                         " info or oauth_cb, not both"):
+        SchemaRegistryClient(conf)
+
 def test_config_unknown_prop():
     conf = {'url': TEST_URL,
             'basic.auth.credentials.source': 'SASL_INHERIT',


### PR DESCRIPTION
This patch adds an option to supply an oauth callback to the
SchemaRegistryClient so that it accepts oauth tokens in the
same way that kafka brokers can receive tokens.

The function passes has the same return types as the same option
for kafka so that users can reusing their existing token service
for both kafka as well as the schema registry client.

If a user supplies this new option together with BASIC auth configuration,
it results in a ValueError.