### PR TITLE
Format args in the correct order

### DIFF
--- a/examples/protobuf_consumer.py
+++ b/examples/protobuf_consumer.py
@@ -68,8 +68,8 @@ def main(args):
                       "\tfavorite_number: {}\n"
                       "\tfavorite_color: {}\n"
                       .format(msg.key(), user.name,
-                              user.favorite_color,
-                              user.favorite_number))
+                              user.favorite_number,
+                              user.favorite_color))
         except KeyboardInterrupt:
             break
 


### PR DESCRIPTION
The args in this format statement within the print statement are in the wrong order