### PR TITLE
Add service.yml for adding new project to semaphore CI

### DIFF
--- a/service.yml
+++ b/service.yml
@@ -1,0 +1,11 @@
+name: confluent-kafka-python
+lang: python
+lang_version: 3.7
+# Add the following 2 lines if you want the automatically generated .semaphore files
+git:
+  enable: true
+github:
+  enable: true
+  repo_name: confluentinc/confluent-kafka-python # for example, confluentinc/cc-new-service
+semaphore:
+  enable: true

--- a/service.yml
+++ b/service.yml
@@ -1,11 +1,10 @@
 name: confluent-kafka-python
 lang: python
 lang_version: 3.7
-# Add the following 2 lines if you want the automatically generated .semaphore files
 git:
   enable: true
 github:
   enable: true
-  repo_name: confluentinc/confluent-kafka-python # for example, confluentinc/cc-new-service
+  repo_name: confluentinc/confluent-kafka-python
 semaphore:
   enable: true


### PR DESCRIPTION
For semaphore CI migration, we need to first add new project to semaphore CI.