### PR TITLE
Fix for duplicate acls

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -136,9 +136,9 @@ ResourceType
 
 .. _pythonclient_resource_pattern_type:
 
-**************
+*******************
 ResourcePatternType
-**************
+*******************
 
 .. autoclass:: confluent_kafka.admin.ResourcePatternType
    :members:
@@ -154,9 +154,9 @@ AclOperation
 
 .. _pythonclient_acl_permission_type:
 
-**************
+*****************
 AclPermissionType
-**************
+*****************
 
 .. autoclass:: confluent_kafka.admin.AclPermissionType
    :members:
@@ -172,9 +172,9 @@ AclBinding
 
 .. _pythonclient_acl_binding_filter:
 
-**************
+****************
 AclBindingFilter
-**************
+****************
 
 .. autoclass:: confluent_kafka.admin.AclBindingFilter
    :members:

--- a/examples/adminapi.py
+++ b/examples/adminapi.py
@@ -159,10 +159,6 @@ def example_create_acls(a, args):
         print(f"Invalid input: {e}")
         return
 
-    if fs is None:
-        print("Unknown error: fs is None")
-        return
-
     # Wait for operation to finish.
     for res, f in fs.items():
         try:
@@ -251,10 +247,6 @@ def example_delete_acls(a, args):
         fs = a.delete_acls(acl_binding_filters, request_timeout=10)
     except ValueError as e:
         print(f"Invalid input: {e}")
-        return
-    
-    if fs is None:
-        print("Unknown error: fs is None")
         return
 
     # Wait for operation to finish.

--- a/examples/adminapi.py
+++ b/examples/adminapi.py
@@ -152,7 +152,11 @@ def example_create_acls(a, args):
         )
     ]
 
-    fs = a.create_acls(acl_bindings, request_timeout=10)
+    try:
+        fs = a.create_acls(acl_bindings, request_timeout=10)
+    except ValueError as e:
+        print(f"Invalid input: {e}")
+        return
 
     # Wait for operation to finish.
     for res, f in fs.items():
@@ -237,7 +241,11 @@ def example_delete_acls(a, args):
         )
     ]
 
-    fs = a.delete_acls(acl_binding_filters, request_timeout=10)
+    try:
+        fs = a.delete_acls(acl_binding_filters, request_timeout=10)
+    except ValueError as e:
+        print(f"Invalid input: {e}")
+        return
 
     # Wait for operation to finish.
     for res, f in fs.items():

--- a/examples/adminapi.py
+++ b/examples/adminapi.py
@@ -152,10 +152,15 @@ def example_create_acls(a, args):
         )
     ]
 
+    fs = None
     try:
         fs = a.create_acls(acl_bindings, request_timeout=10)
     except ValueError as e:
         print(f"Invalid input: {e}")
+        return
+
+    if fs is None:
+        print("Unknown error: fs is None")
         return
 
     # Wait for operation to finish.
@@ -241,10 +246,15 @@ def example_delete_acls(a, args):
         )
     ]
 
+    fs = None
     try:
         fs = a.delete_acls(acl_binding_filters, request_timeout=10)
     except ValueError as e:
         print(f"Invalid input: {e}")
+        return
+    
+    if fs is None:
+        print("Unknown error: fs is None")
         return
 
     # Wait for operation to finish.

--- a/examples/adminapi.py
+++ b/examples/adminapi.py
@@ -152,11 +152,10 @@ def example_create_acls(a, args):
         )
     ]
 
-    fs = None
     try:
         fs = a.create_acls(acl_bindings, request_timeout=10)
     except ValueError as e:
-        print(f"Invalid input: {e}")
+        print(f"create_acls() failed: {e}")
         return
 
     # Wait for operation to finish.
@@ -242,11 +241,10 @@ def example_delete_acls(a, args):
         )
     ]
 
-    fs = None
     try:
         fs = a.delete_acls(acl_binding_filters, request_timeout=10)
     except ValueError as e:
-        print(f"Invalid input: {e}")
+        print(f"delete_acls() failed: {e}")
         return
 
     # Wait for operation to finish.

--- a/src/confluent_kafka/admin/__init__.py
+++ b/src/confluent_kafka/admin/__init__.py
@@ -182,7 +182,7 @@ class AdminClient (_AdminClientImpl):
         return f, futmap
 
     @staticmethod
-    def _has_duplicated(items):
+    def _has_duplicates(items):
         return len(set(items)) != len(items)
 
     def create_topics(self, new_topics, **kwargs):
@@ -384,8 +384,8 @@ class AdminClient (_AdminClientImpl):
         :raises TypeException: Invalid input.
         :raises ValueException: Invalid input.
         """
-        if AdminClient._has_duplicated(acls):
-            raise ValueError("pass only different ACL bindings")
+        if AdminClient._has_duplicates(acls):
+            raise ValueError("duplicate ACL bindings not allowed")
 
         f, futmap = AdminClient._make_futures(acls, AclBinding,
                                               AdminClient._make_acls_result)
@@ -450,8 +450,8 @@ class AdminClient (_AdminClientImpl):
         :raises TypeException: Invalid input.
         :raises ValueException: Invalid input.
         """
-        if AdminClient._has_duplicated(acl_binding_filters):
-            raise ValueError("pass only different ACL binding filters")
+        if AdminClient._has_duplicates(acl_binding_filters):
+            raise ValueError("duplicate ACL binding filters not allowed")
 
         f, futmap = AdminClient._make_futures(acl_binding_filters, AclBindingFilter,
                                               AdminClient._make_acls_result)

--- a/src/confluent_kafka/admin/__init__.py
+++ b/src/confluent_kafka/admin/__init__.py
@@ -395,7 +395,7 @@ class AdminClient (_AdminClientImpl):
         :param AclBindingFilter acl_binding_filter: a filter with attributes that
                   must match.
                   String attributes match exact values or any string if set to None.
-                  Enums attributes match exact values or any value if ending with `_ANY`.
+                  Enums attributes match exact values or any value if equal to `ANY`.
                   If :class:`ResourcePatternType` is set to :attr:`ResourcePatternType.MATCH` returns all
                   the ACL bindings with :attr:`ResourcePatternType.LITERAL`,
                   :attr:`ResourcePatternType.WILDCARD` or :attr:`ResourcePatternType.PREFIXED` pattern
@@ -426,7 +426,7 @@ class AdminClient (_AdminClientImpl):
         :param list(AclBindingFilter) acl_binding_filters: a list of ACL binding filters
                   to match ACLs to delete.
                   String attributes match exact values or any string if set to None.
-                  Enums attributes match exact values or any value if ending with `_ANY`.
+                  Enums attributes match exact values or any value if equal to `ANY`.
                   If :class:`ResourcePatternType` is set to :attr:`ResourcePatternType.MATCH`
                   deletes all the ACL bindings with :attr:`ResourcePatternType.LITERAL`,
                   :attr:`ResourcePatternType.WILDCARD` or :attr:`ResourcePatternType.PREFIXED`

--- a/src/confluent_kafka/admin/__init__.py
+++ b/src/confluent_kafka/admin/__init__.py
@@ -181,6 +181,10 @@ class AdminClient (_AdminClientImpl):
 
         return f, futmap
 
+    @staticmethod
+    def _has_duplicated(items):
+        return len(set(items)) != len(items)
+
     def create_topics(self, new_topics, **kwargs):
         """
         Create one or more new topics.
@@ -365,7 +369,7 @@ class AdminClient (_AdminClientImpl):
         """
         Create one or more ACL bindings.
 
-        :param list(AclBinding) acls: A list of ACL binding specifications (:class:`.AclBinding`)
+        :param list(AclBinding) acls: A list of unique ACL binding specifications (:class:`.AclBinding`)
                          to create.
         :param float request_timeout: The overall request timeout in seconds,
                   including broker lookup, request transmission, operation time
@@ -380,6 +384,8 @@ class AdminClient (_AdminClientImpl):
         :raises TypeException: Invalid input.
         :raises ValueException: Invalid input.
         """
+        if AdminClient._has_duplicated(acls):
+            raise ValueError("pass only different ACL bindings")
 
         f, futmap = AdminClient._make_futures(acls, AclBinding,
                                               AdminClient._make_acls_result)
@@ -423,7 +429,7 @@ class AdminClient (_AdminClientImpl):
         """
         Delete ACL bindings matching one or more ACL binding filters.
 
-        :param list(AclBindingFilter) acl_binding_filters: a list of ACL binding filters
+        :param list(AclBindingFilter) acl_binding_filters: a list of unique ACL binding filters
                   to match ACLs to delete.
                   String attributes match exact values or any string if set to None.
                   Enums attributes match exact values or any value if equal to `ANY`.
@@ -444,6 +450,8 @@ class AdminClient (_AdminClientImpl):
         :raises TypeException: Invalid input.
         :raises ValueException: Invalid input.
         """
+        if AdminClient._has_duplicated(acl_binding_filters):
+            raise ValueError("pass only different ACL binding filters")
 
         f, futmap = AdminClient._make_futures(acl_binding_filters, AclBindingFilter,
                                               AdminClient._make_acls_result)

--- a/tests/test_Admin.py
+++ b/tests/test_Admin.py
@@ -347,6 +347,9 @@ def test_create_acls_api():
     with pytest.raises(ValueError):
         a.create_acls([None, acl_binding1])
 
+    with pytest.raises(ValueError):
+        a.create_acls([acl_binding1, acl_binding1])
+
     fs = a.create_acls([acl_binding1, acl_binding2])
     with pytest.raises(KafkaException):
         for f in fs.values():
@@ -390,6 +393,9 @@ def test_delete_acls_api():
 
     with pytest.raises(ValueError):
         a.delete_acls([None, acl_binding_filter1])
+
+    with pytest.raises(ValueError):
+        a.delete_acls([acl_binding_filter1, acl_binding_filter1])
 
     fs = a.delete_acls([acl_binding_filter1, acl_binding_filter2])
     with pytest.raises(KafkaException):


### PR DESCRIPTION
In create_acls and delete_acls it returns a dict with AclBinding or AclBindingFilters as keys.
If sent parameters are not unique the returned dict has less entries than the sent ones and it causes and Exception.