### PR TITLE
feat: build wheels for python 3.10

### DIFF
--- a/tools/wheels/build-wheels.bat
+++ b/tools/wheels/build-wheels.bat
@@ -25,7 +25,7 @@ set CIBW_REPAIR_WHEEL_COMMAND=python -m delvewheel repair --add-path %DLL_DIR% -
 
 set PATH=%PATH%;c:\Program Files\Git\bin\
 
-python -m pip install cibuildwheel==1.11.0 || goto :error
+python -m pip install cibuildwheel==2.1.3 || goto :error
 
 python -m cibuildwheel --output-dir %WHEELHOUSE% --platform windows || goto :error
 

--- a/tools/wheels/build-wheels.sh
+++ b/tools/wheels/build-wheels.sh
@@ -51,7 +51,7 @@ esac
 
 $this_dir/install-librdkafka.sh $librdkafka_version dest
 
-install_pkgs=cibuildwheel==1.11.0
+install_pkgs=cibuildwheel==2.1.3
 
 python3 -m pip install $install_pkgs ||
     pip3 install $install_pkgs


### PR DESCRIPTION
Version 2.1.3 is the minimum version for 3.10 wheels in cibuildwheels.

Related to https://github.com/confluentinc/confluent-kafka-python/issues/1219