### PR TITLE
use s1-prod-macos-arm64 build agent

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -1,14 +1,16 @@
 version: v1.0
 name: Test on PR or create and upload wheels on tag.
-agent:
-  machine:
-    type: s1-prod-macos-arm64
 global_job_config:
   secrets:
     - name: vault_sem2_approle
   env_vars:
     - name: LIBRDKAFKA_VERSION
       value: v1.9.2
+  prologue:
+    commands:
+      - checkout
+      - export HOME=$WORKSPACE
+      - cd $WORKSPACE/confluent-kafka-python
 blocks:
   - name: "Wheels: OSX x64"
     dependencies: []
@@ -24,17 +26,15 @@ blocks:
       jobs:
         - name: Build
           commands:
-            - cd $SEM_WORKSPACE
-            - export HOME=$SEM_WORKSPACE
-            - checkout
-            # needed on the self-hosted agent
-            - if [ ! -d ./tools ]; then cd $SEM_WORKSPACE/confluent-kafka-python; fi
             - PIP_INSTALL_OPTIONS="--user" tools/wheels/build-wheels.sh "${LIBRDKAFKA_VERSION#v}" wheelhouse
             - tar -czf wheelhouse-macOS-${ARCH}.tgz wheelhouse
             - artifact push workflow wheelhouse-macOS-${ARCH}.tgz
   - name: "Wheels: OSX arm64"
     dependencies: []
     task:
+      agent:
+        machine:
+          type: s1-prod-macos-arm64
       env_vars:
         - name: OS_NAME
           value: osx
@@ -45,11 +45,6 @@ blocks:
       jobs:
         - name: Build
           commands:
-            - cd $SEM_WORKSPACE
-            - export HOME=$SEM_WORKSPACE
-            - checkout
-            # needed on the self-hosted agent
-            - if [ ! -d ./tools ]; then cd $SEM_WORKSPACE/confluent-kafka-python; fi
             - PIP_INSTALL_OPTIONS="--user" tools/wheels/build-wheels.sh "${LIBRDKAFKA_VERSION#v}" wheelhouse
             - tar -czf wheelhouse-macOS-${ARCH}.tgz wheelhouse
             - artifact push workflow wheelhouse-macOS-${ARCH}.tgz
@@ -68,11 +63,6 @@ blocks:
       jobs:
         - name: Build
           commands:
-            - cd $SEM_WORKSPACE
-            - export HOME=$SEM_WORKSPACE
-            - checkout
-            # needed on the self-hosted agent
-            - if [ ! -d ./tools ]; then cd $SEM_WORKSPACE/confluent-kafka-python; fi
             # use a virtualenv
             - python3 -m venv _venv && source _venv/bin/activate
             - pip install -r docs/requirements.txt


### PR DESCRIPTION
A few changes to the Semaphore pipeline:
* Use the `s1-prod-macos-arm64` agent for M1 macOS builds instead of `s1-prod-mac-m1`. This agent was created in a more scalable and maintainable manner. There are slight differences in this agent from the prior, but the new behavior is consistent with the `s1-prod-macos` agent. This required the change from `SEM_WORKSPACE` to `WORKSPACE` env vars. Also, note that the starting working directory for a job is `WORKSPACE`
* Remove the global agent configuration and instead set the agent at the job level for the only job missing an agent at the job level.
* Move some duplicated commands in all jobs to a `prologue` to reduce duplication.

### Testing
I ran the pipeline multiple times. Apparently, there is an existing issue with the pipeline that results in leaving the agents not in the state in which they were found in. This relates to `cibuildwheel` and the way it manages Python installations. Each time I ran the pipeline, the jobs got further along, eventually making it until successful completions. This is an issue that should be addressed, but it is outside the scope of this PR since it affects the x86 jobs.