### PR TITLE
Consumer `with` support

### DIFF
--- a/examples/avro_consumer.py
+++ b/examples/avro_consumer.py
@@ -88,28 +88,26 @@ def main(args):
                      'group.id': args.group,
                      'auto.offset.reset': "earliest"}
 
-    consumer = Consumer(consumer_conf)
-    consumer.subscribe([topic])
+    with Consumer(consumer_conf) as consumer:
+        consumer.subscribe([topic])
 
-    while True:
-        try:
-            # SIGINT can't be handled when polling, limit timeout to 1 second.
-            msg = consumer.poll(1.0)
-            if msg is None:
-                continue
+        while True:
+            try:
+                # SIGINT can't be handled when polling, limit timeout to 1 second.
+                msg = consumer.poll(1.0)
+                if msg is None:
+                    continue
 
-            user = avro_deserializer(msg.value(), SerializationContext(msg.topic(), MessageField.VALUE))
-            if user is not None:
-                print("User record {}: name: {}\n"
-                      "\tfavorite_number: {}\n"
-                      "\tfavorite_color: {}\n"
-                      .format(msg.key(), user.name,
-                              user.favorite_number,
-                              user.favorite_color))
-        except KeyboardInterrupt:
-            break
-
-    consumer.close()
+                user = avro_deserializer(msg.value(), SerializationContext(msg.topic(), MessageField.VALUE))
+                if user is not None:
+                    print("User record {}: name: {}\n"
+                          "\tfavorite_number: {}\n"
+                          "\tfavorite_color: {}\n"
+                          .format(msg.key(), user.name,
+                                  user.favorite_number,
+                                  user.favorite_color))
+            except KeyboardInterrupt:
+                break
 
 
 if __name__ == '__main__':

--- a/examples/confluent_cloud.py
+++ b/examples/confluent_cloud.py
@@ -109,7 +109,7 @@ p.flush(10)
 
 
 # Create consumer
-c = Consumer({
+with Consumer({
     'bootstrap.servers': '<ccloud bootstrap servers>',
     'sasl.mechanism': 'PLAIN',
     'security.protocol': 'SASL_SSL',
@@ -118,28 +118,24 @@ c = Consumer({
     'group.id': str(uuid.uuid1()),  # this will create a new consumer group on each invocation.
     'auto.offset.reset': 'earliest',
     'error_cb': error_cb,
-})
+}) as c:
 
-c.subscribe(['python-test-topic'])
+    c.subscribe(['python-test-topic'])
 
-try:
-    while True:
-        msg = c.poll(0.1)  # Wait for message or event/error
-        if msg is None:
-            # No message available within timeout.
-            # Initial message consumption may take up to `session.timeout.ms` for
-            #   the group to rebalance and start consuming.
-            continue
-        if msg.error():
-            # Errors are typically temporary, print error and continue.
-            print('Consumer error: {}'.format(msg.error()))
-            continue
+    try:
+        while True:
+            msg = c.poll(0.1)  # Wait for message or event/error
+            if msg is None:
+                # No message available within timeout.
+                # Initial message consumption may take up to `session.timeout.ms` for
+                #   the group to rebalance and start consuming.
+                continue
+            if msg.error():
+                # Errors are typically temporary, print error and continue.
+                print('Consumer error: {}'.format(msg.error()))
+                continue
 
-        print('Consumed: {}'.format(msg.value()))
+            print('Consumed: {}'.format(msg.value()))
 
-except KeyboardInterrupt:
-    pass
-
-finally:
-    # Leave group and commit final offsets
-    c.close()
+    except KeyboardInterrupt:
+        pass

--- a/examples/json_consumer.py
+++ b/examples/json_consumer.py
@@ -93,29 +93,27 @@ def main(args):
                      'group.id': args.group,
                      'auto.offset.reset': "earliest"}
 
-    consumer = Consumer(consumer_conf)
-    consumer.subscribe([topic])
+    with Consumer(consumer_conf) as consumer:
+        consumer.subscribe([topic])
 
-    while True:
-        try:
-            # SIGINT can't be handled when polling, limit timeout to 1 second.
-            msg = consumer.poll(1.0)
-            if msg is None:
-                continue
+        while True:
+            try:
+                # SIGINT can't be handled when polling, limit timeout to 1 second.
+                msg = consumer.poll(1.0)
+                if msg is None:
+                    continue
 
-            user = json_deserializer(msg.value(), SerializationContext(msg.topic(), MessageField.VALUE))
+                user = json_deserializer(msg.value(), SerializationContext(msg.topic(), MessageField.VALUE))
 
-            if user is not None:
-                print("User record {}: name: {}\n"
-                      "\tfavorite_number: {}\n"
-                      "\tfavorite_color: {}\n"
-                      .format(msg.key(), user.name,
-                              user.favorite_number,
-                              user.favorite_color))
-        except KeyboardInterrupt:
-            break
-
-    consumer.close()
+                if user is not None:
+                    print("User record {}: name: {}\n"
+                          "\tfavorite_number: {}\n"
+                          "\tfavorite_color: {}\n"
+                          .format(msg.key(), user.name,
+                                  user.favorite_number,
+                                  user.favorite_color))
+            except KeyboardInterrupt:
+                break
 
 
 if __name__ == '__main__':

--- a/examples/protobuf_consumer.py
+++ b/examples/protobuf_consumer.py
@@ -47,30 +47,28 @@ def main(args):
                      'group.id': args.group,
                      'auto.offset.reset': "earliest"}
 
-    consumer = Consumer(consumer_conf)
-    consumer.subscribe([topic])
+    with Consumer(consumer_conf) as consumer:
+        consumer.subscribe([topic])
 
-    while True:
-        try:
-            # SIGINT can't be handled when polling, limit timeout to 1 second.
-            msg = consumer.poll(1.0)
-            if msg is None:
-                continue
+        while True:
+            try:
+                # SIGINT can't be handled when polling, limit timeout to 1 second.
+                msg = consumer.poll(1.0)
+                if msg is None:
+                    continue
 
-            user = protobuf_deserializer(msg.value(), SerializationContext(topic, MessageField.VALUE))
+                user = protobuf_deserializer(msg.value(), SerializationContext(topic, MessageField.VALUE))
 
-            if user is not None:
-                print("User record {}:\n"
-                      "\tname: {}\n"
-                      "\tfavorite_number: {}\n"
-                      "\tfavorite_color: {}\n"
-                      .format(msg.key(), user.name,
-                              user.favorite_number,
-                              user.favorite_color))
-        except KeyboardInterrupt:
-            break
-
-    consumer.close()
+                if user is not None:
+                    print("User record {}:\n"
+                          "\tname: {}\n"
+                          "\tfavorite_number: {}\n"
+                          "\tfavorite_color: {}\n"
+                          .format(msg.key(), user.name,
+                                  user.favorite_number,
+                                  user.favorite_color))
+            except KeyboardInterrupt:
+                break
 
 
 if __name__ == '__main__':

--- a/src/confluent_kafka/src/Consumer.c
+++ b/src/confluent_kafka/src/Consumer.c
@@ -1049,7 +1049,7 @@ static PyObject *Consumer_consume (Handle *self, PyObject *args,
 }
 
 
-static PyObject *Consumer_close (Handle *self, PyObject *ignore) {
+static PyObject *Consumer_close (Handle *self) {
         CallState cs;
 
         if (!self->rk)

--- a/src/confluent_kafka/src/Consumer.c
+++ b/src/confluent_kafka/src/Consumer.c
@@ -1073,6 +1073,16 @@ static PyObject *Consumer_close (Handle *self) {
         Py_RETURN_NONE;
 }
 
+static PyObject *Consumer_enter (PyObject *self) {
+  Py_INCREF(self);
+  return self;
+}
+
+static PyObject *Consumer_exit (PyObject *self, PyObject *ignore) {
+  Consumer_close((Handle *)self);
+  return Py_False;
+}
+
 static PyObject *
 Consumer_consumer_group_metadata (Handle *self, PyObject *ignore) {
         rd_kafka_consumer_group_metadata_t *cgmd;
@@ -1425,6 +1435,28 @@ static PyMethodDef Consumer_methods[] = {
 	  "  :rtype: None\n"
 	  "\n"
 	},
+	{ "__enter__", (PyCFunction)Consumer_enter,
+	  METH_NOARGS,
+      "Enables support for python's `with` syntax.\n"
+      "\n"
+      "Creating a consumer using a `with` statement:\n"
+      "\n"
+      "  with Consumer(...) as c:\n"
+      "      c.subscribe(...)\n"
+      "      ...\n"
+      "\n"
+      "...ensures that the consumer will be automatically closed\n"
+      " when the block exits.\n"
+      "\n"
+      "`with` has been a part of Python since v2.5 and is the\n"
+      " recommended way to manage resource lifecycles\n"
+    },
+	{ "__exit__", (PyCFunction)Consumer_exit,
+	  METH_VARARGS,
+      "Enables support for python's `with` syntax.\n"
+      "\n"
+      "See `__enter__` for usage.\n"
+    },
         { "list_topics", (PyCFunction)list_topics, METH_VARARGS|METH_KEYWORDS,
           list_topics_doc
         },

--- a/tests/test_Consumer.py
+++ b/tests/test_Consumer.py
@@ -321,3 +321,21 @@ def test_consumer_without_groupid():
     with pytest.raises(ValueError) as ex:
         Consumer({'bootstrap.servers': "mybroker:9092"})
     assert ex.match('group.id must be set')
+
+
+def test_with_statement_calls_close():
+    """ A `with` statement should call close on the consumer when it exits
+    """
+    with Consumer({'group.id': 'test',
+                   'enable.auto.commit': True,
+                   'enable.auto.offset.store': False,
+                   'fetch.wait.max.ms': '100',
+                   'socket.timeout.ms': '1200',
+                   'session.timeout.ms': 100}) as c:
+        c.subscribe(["test"])
+
+        c.unsubscribe()
+
+    with pytest.raises(RuntimeError) as ex:
+        c.offsets_for_times([TopicPartition("test", 0)])
+    assert ex.match('Consumer closed')


### PR DESCRIPTION
Adding `with` support for consumers.

Creating a consumer using a `with` statement:

```python
  with Consumer(...) as c:
      c.subscribe(...)
      ...
```

...ensures that the consumer will be automatically closed when the block exits. There is no longer any need for a `finally: close()`block.

This change makes it easier for beginners and experts alike to use consumers correctly and cleanly. The fact that it's less to type is a nice bonus.

`with` has been a part of Python since v2.5 and is the recommended way to manage resource lifecycles.
