### PR TITLE
Implement nb_bool for Producer

### DIFF
--- a/src/confluent_kafka/src/Producer.c
+++ b/src/confluent_kafka/src/Producer.c
@@ -824,6 +824,23 @@ static PySequenceMethods Producer_seq_methods = {
 	(lenfunc)Producer__len__ /* sq_length */
 };
 
+static int Producer__bool__ (Handle *self) {
+        return 1;
+}
+
+static PyNumberMethods Producer_num_methods = {
+     0, // nb_add
+     0, // nb_subtract
+     0, // nb_multiply
+     0, // nb_remainder
+     0, // nb_divmod
+     0, // nb_power
+     0, // nb_negative
+     0, // nb_positive
+     0, // nb_absolute
+     (inquiry)Producer__bool__ // nb_bool
+};
+
 
 static int Producer_init (PyObject *selfobj, PyObject *args, PyObject *kwargs) {
         Handle *self = (Handle *)selfobj;
@@ -879,8 +896,8 @@ PyTypeObject ProducerType = {
 	0,                         /*tp_setattr*/
 	0,                         /*tp_compare*/
 	0,                         /*tp_repr*/
-	0,                         /*tp_as_number*/
-	&Producer_seq_methods,  /*tp_as_sequence*/
+	&Producer_num_methods,     /*tp_as_number*/
+	&Producer_seq_methods,     /*tp_as_sequence*/
 	0,                         /*tp_as_mapping*/
 	0,                         /*tp_hash */
 	0,                         /*tp_call*/

--- a/tests/test_Producer.py
+++ b/tests/test_Producer.py
@@ -271,3 +271,13 @@ def test_purge():
     p.purge()
     p.flush(0.002)
     assert cb_detector["on_delivery_called"]
+
+
+def test_producer_bool_value():
+    """
+    Make sure producer has a truth-y bool value
+    See https://github.com/confluentinc/confluent-kafka-python/issues/1427
+    """
+
+    p = Producer({})
+    assert bool(p)


### PR DESCRIPTION
This addresses  #1427
All tests passed locally.

This implements the nb_bool method for the consumer, so that the default (which uses __len__) will not be used. This avoids situations where producers with no enqueued items would have a False truth value.