### PR TITLE
enable Semaphore builds on all branches

### DIFF
--- a/.semaphore/project.yml
+++ b/.semaphore/project.yml
@@ -17,8 +17,17 @@ spec:
       pipeline_files:
       - path: .semaphore/semaphore.yml
         level: pipeline
-    whitelist:
-      branches:
-      - master
-      - main
-      - "/^v\\d+\\.\\d+\\.x$/"
+  custom_permissions: true
+  debug_permissions:
+  - empty
+  - default_branch
+  - non_default_branch
+  - pull_request
+  - forked_pull_request
+  - tag
+  attach_permissions:
+  - default_branch
+  - non_default_branch
+  - pull_request
+  - forked_pull_request
+  - tag

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -1,8 +1,5 @@
 version: v1.0
 name: Test on PR or create and upload wheels on tag.
-agent:
-  machine:
-    type: s1-prod-ubuntu20-04-amd64-1
 global_job_config:
   secrets:
     - name: vault_sem2_approle

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -1,34 +1,16 @@
 version: v1.0
-name: build-test-release
+name: Test on PR or create and upload wheels on tag.
 global_job_config:
   secrets:
     - name: vault_sem2_approle
+  env_vars:
+    - name: LIBRDKAFKA_VERSION
+      value: v1.9.2
   prologue:
     commands:
-      - chmod 400 ~/.ssh/id_rsa
-      - sem-version python 3.7
       - checkout
-      - make install-vault
-      - . mk-include/bin/vault-setup
-      - . vault-sem-get-secret gitconfig
-      - . vault-sem-get-secret ssh_id_rsa
-      - . vault-sem-get-secret ssh_config
-      - . vault-sem-get-secret netrc
-      - . vault-sem-get-secret artifactory-docker-helm
-      - . vault-sem-get-secret maven-settings
-      - . vault-sem-get-secret cpd_gcloud
-      - . vault-sem-get-secret aws_credentials
-      - . vault-sem-get-secret testbreak-reporting
-      - . vault-sem-get-secret python-pipenv
-      - . vault-sem-get-secret v1/ci/kv/service-foundations/cc-mk-include
-      - . vault-sem-get-secret dockerhub-semaphore-cred-ro
-      - exec &> >(tee -a build.log)
-      - make init-ci
-  epilogue:
-    always:
-      commands:
-        - make epilogue-ci
-
+      - export HOME=$WORKSPACE
+      - cd $WORKSPACE/confluent-kafka-python
 blocks:
   - name: "Wheels: OSX x64"
     run:
@@ -70,7 +52,7 @@ blocks:
             - PIP_INSTALL_OPTIONS="--user" tools/wheels/build-wheels.sh "${LIBRDKAFKA_VERSION#v}" wheelhouse
             - tar -czf wheelhouse-macOS-${ARCH}.tgz wheelhouse
             - artifact push workflow wheelhouse-macOS-${ARCH}.tgz
-
+  
   - name: Source package verification with Python 3 (OSX x64) +docs
     dependencies: []
     task:
@@ -99,14 +81,3 @@ blocks:
             # install confluent-kafka
             - python setup.py build && python setup.py install
             - make docs
-agent:
-  machine:
-    type: s1-prod-ubuntu20-04-amd64-1
-
-auto_cancel:
-  running:
-    when: "branch != 'master'"
-
-execution_time_limit:
-  hours: 1
-

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -31,6 +31,8 @@ global_job_config:
 
 blocks:
   - name: "Wheels: OSX x64"
+    run:
+      when: "tag =~ '.*'"
     dependencies: []
     task:
       agent:
@@ -48,6 +50,8 @@ blocks:
             - tar -czf wheelhouse-macOS-${ARCH}.tgz wheelhouse
             - artifact push workflow wheelhouse-macOS-${ARCH}.tgz
   - name: "Wheels: OSX arm64"
+    run:
+      when: "tag =~ '.*'"
     dependencies: []
     task:
       agent:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -1,16 +1,34 @@
 version: v1.0
-name: Test on PR or create and upload wheels on tag.
+name: build-test-release
 global_job_config:
   secrets:
     - name: vault_sem2_approle
-  env_vars:
-    - name: LIBRDKAFKA_VERSION
-      value: v1.9.2
   prologue:
     commands:
+      - chmod 400 ~/.ssh/id_rsa
+      - sem-version python 3.7
       - checkout
-      - export HOME=$WORKSPACE
-      - cd $WORKSPACE/confluent-kafka-python
+      - make install-vault
+      - . mk-include/bin/vault-setup
+      - . vault-sem-get-secret gitconfig
+      - . vault-sem-get-secret ssh_id_rsa
+      - . vault-sem-get-secret ssh_config
+      - . vault-sem-get-secret netrc
+      - . vault-sem-get-secret artifactory-docker-helm
+      - . vault-sem-get-secret maven-settings
+      - . vault-sem-get-secret cpd_gcloud
+      - . vault-sem-get-secret aws_credentials
+      - . vault-sem-get-secret testbreak-reporting
+      - . vault-sem-get-secret python-pipenv
+      - . vault-sem-get-secret v1/ci/kv/service-foundations/cc-mk-include
+      - . vault-sem-get-secret dockerhub-semaphore-cred-ro
+      - exec &> >(tee -a build.log)
+      - make init-ci
+  epilogue:
+    always:
+      commands:
+        - make epilogue-ci
+
 blocks:
   - name: "Wheels: OSX x64"
     run:
@@ -52,7 +70,7 @@ blocks:
             - PIP_INSTALL_OPTIONS="--user" tools/wheels/build-wheels.sh "${LIBRDKAFKA_VERSION#v}" wheelhouse
             - tar -czf wheelhouse-macOS-${ARCH}.tgz wheelhouse
             - artifact push workflow wheelhouse-macOS-${ARCH}.tgz
-  
+
   - name: Source package verification with Python 3 (OSX x64) +docs
     dependencies: []
     task:
@@ -81,3 +99,14 @@ blocks:
             # install confluent-kafka
             - python setup.py build && python setup.py install
             - make docs
+agent:
+  machine:
+    type: s1-prod-ubuntu20-04-amd64-1
+
+auto_cancel:
+  running:
+    when: "branch != 'master'"
+
+execution_time_limit:
+  hours: 1
+

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -1,5 +1,8 @@
 version: v1.0
 name: Test on PR or create and upload wheels on tag.
+agent:
+  machine:
+    type: s1-prod-ubuntu20-04-amd64-1
 global_job_config:
   secrets:
     - name: vault_sem2_approle

--- a/service.yml
+++ b/service.yml
@@ -8,3 +8,4 @@ github:
   repo_name: confluentinc/confluent-kafka-python
 semaphore:
   enable: true
+  branches: []

--- a/service.yml
+++ b/service.yml
@@ -8,4 +8,5 @@ github:
   repo_name: confluentinc/confluent-kafka-python
 semaphore:
   enable: true
+  pipeline_enable: false
   branches: []


### PR DESCRIPTION
This changes Semaphore builds to run on all branches instead of only the 
```
      - master
      - main
      - "/^v\\d+\\.\\d+\\.x$/"
```
branches.

Also, it changes wheel builds to only run on tagged versions, instead of all branches. This addresses a regression from https://github.com/confluentinc/confluent-kafka-python/commit/477bac4363412c9f5aad1c75caed0c880ed51c94#diff-f4c421dab68fb568a2a5f47b7851a85a409574b05f841f635bad1880b82db03bL15.

Lastly, this sets `pipeline_enable: false`, so that the service bot will not modify the `.semaphore/semaphore.yml` file, as was done in https://github.com/confluentinc/confluent-kafka-python/commit/6cd2e736976cc44fdf2d47717fed065e50021f0a#diff-f4c421dab68fb568a2a5f47b7851a85a409574b05f841f635bad1880b82db03bL6-L8.