### PR TITLE
CLIENTS-2934: Fixed a typo with transaction.timeout.ms in init_transactions method documentation

### DIFF
--- a/src/confluent_kafka/src/Producer.c
+++ b/src/confluent_kafka/src/Producer.c
@@ -665,7 +665,7 @@ static PyMethodDef Producer_methods[] = {
           "\n"
           "  Upon successful return from this function the application has to\n"
           "  perform at least one of the following operations within \n"
-          "  `transactional.timeout.ms` to avoid timing out the transaction\n"
+          "  `transaction.timeout.ms` to avoid timing out the transaction\n"
           "  on the broker:\n"
           "  * produce() (et.al)\n"
           "  * send_offsets_to_transaction()\n"


### PR DESCRIPTION
 Fixed a typo with transaction.timeout.ms in init_transactions method documentation