### PR TITLE
DP-9632: remediate duplicate Semaphore workflows

### DIFF
--- a/service.yml
+++ b/service.yml
@@ -9,4 +9,3 @@ github:
 semaphore:
   enable: true
   pipeline_enable: false
-  branches: []


### PR DESCRIPTION

This repo currently has a Semaphore project that triggers workflows on both pull requests (PR) and all branches. This configuration results in 2 workflow executions when a PR is created or updated. This PR changes the project configuration to use the default behavior, which is to whitelist branches that match `[master, main, /^v\d+\.\d+\.x$/]` and to trigger for `[branches, tags, pull_requests]`.
