### PR TITLE
Remove reference to vault_sem2_approle secret

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -4,8 +4,6 @@ agent:
   machine:
     type: s1-prod-ubuntu20-04-amd64-1
 global_job_config:
-  secrets:
-    - name: vault_sem2_approle
   env_vars:
     - name: LIBRDKAFKA_VERSION
       value: v1.9.2


### PR DESCRIPTION
This removes a reference to the `vault_sem2_approle` Semaphore secret. This secret was not used by the pipeline