### PR TITLE
Document that offsets_for_times accepts milliseconds

### DIFF
--- a/src/confluent_kafka/src/Consumer.c
+++ b/src/confluent_kafka/src/Consumer.c
@@ -1427,6 +1427,7 @@ static PyMethodDef Consumer_methods[] = {
           " timestamp is greater than or equal to the given timestamp in the\n"
           " corresponding partition. If the provided timestamp exceeds that of the\n"
           " last message in the partition, a value of -1 will be returned.\n"
+          " Timestamps are specified in milliseconds since the UTC epoch.\n"
           "\n"
           "  :param list(TopicPartition) partitions: topic+partitions with timestamps in the TopicPartition.offset field.\n"
           "  :param float timeout: Request timeout (seconds).\n"


### PR DESCRIPTION
Other confluent-kafka-python APIs accept seconds since epoch, but this one uses milliseconds, so it's easy to think it accepts seconds. That would generally result in replaying all events.