### PR TITLE
Add targets to check/format Py and C style

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,136 @@
+---
+Language:        Cpp
+AccessModifierOffset: -2
+AlignAfterOpenBracket: Align
+AlignConsecutiveMacros: true
+AlignConsecutiveAssignments: true
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlines: Right
+AlignOperands:   true
+AlignTrailingComments: true
+AllowAllArgumentsOnNextLine: true
+AllowAllConstructorInitializersOnNextLine: true
+AllowAllParametersOfDeclarationOnNextLine: false
+AllowShortBlocksOnASingleLine: Never
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: None
+AllowShortLambdasOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: Never
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: true
+AlwaysBreakTemplateDeclarations: MultiLine
+BinPackArguments: true
+BinPackParameters: false
+BraceWrapping:
+  AfterCaseLabel:  false
+  AfterClass:      false
+  AfterControlStatement: false
+  AfterEnum:       false
+  AfterFunction:   false
+  AfterNamespace:  false
+  AfterObjCDeclaration: false
+  AfterStruct:     false
+  AfterUnion:      false
+  AfterExternBlock: false
+  BeforeCatch:     false
+  BeforeElse:      false
+  IndentBraces:    false
+  SplitEmptyFunction: true
+  SplitEmptyRecord: true
+  SplitEmptyNamespace: true
+BreakBeforeBinaryOperators: None
+BreakBeforeBraces: Custom
+BreakBeforeInheritanceComma: false
+BreakInheritanceList: BeforeColon
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: false
+BreakConstructorInitializers: AfterColon
+BreakAfterJavaFieldAnnotations: false
+BreakStringLiterals: true
+ColumnLimit:     80
+CommentPragmas:  '^ IWYU pragma:'
+CompactNamespaces: false
+ConstructorInitializerAllOnOneLineOrOnePerLine: false
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DeriveLineEnding: true
+DerivePointerAlignment: false
+DisableFormat:   false
+ExperimentalAutoDetectBinPacking: false
+FixNamespaceComments: true
+ForEachMacros:
+  - foreach
+  - Q_FOREACH
+  - BOOST_FOREACH
+IncludeBlocks:   Preserve
+IncludeCategories:
+  - Regex:           '^"(llvm|llvm-c|clang|clang-c)/'
+    Priority:        2
+    SortPriority:    0
+  - Regex:           '^(<|"(gtest|gmock|isl|json)/)'
+    Priority:        3
+    SortPriority:    0
+  - Regex:           '.*'
+    Priority:        1
+    SortPriority:    0
+IncludeIsMainRegex: '(Test)?$'
+IncludeIsMainSourceRegex: ''
+IndentCaseLabels: false
+IndentGotoLabels: true
+IndentPPDirectives: None
+IndentWidth:     8
+IndentWrappedFunctionNames: false
+JavaScriptQuotes: Leave
+JavaScriptWrapImports: true
+KeepEmptyLinesAtTheStartOfBlocks: true
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 3
+NamespaceIndentation: None
+ObjCBinPackProtocolList: Auto
+ObjCBlockIndentWidth: 2
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: true
+PenaltyBreakAssignment: 2
+PenaltyBreakBeforeFirstCallParameter: 19
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyBreakTemplateDeclaration: 10
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 60
+PointerAlignment: Right
+ReflowComments:  true
+SortIncludes:    false
+SortUsingDeclarations: true
+SpaceAfterCStyleCast: false
+SpaceAfterLogicalNot: false
+SpaceAfterTemplateKeyword: true
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCpp11BracedList: true
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
+SpaceBeforeParens: ControlStatements
+SpaceBeforeRangeBasedForLoopColon: true
+SpaceInEmptyBlock: false
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 2
+SpacesInAngles:  false
+SpacesInConditionalStatement: false
+SpacesInContainerLiterals: false
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+SpaceBeforeSquareBrackets: false
+Standard:        Latest
+StatementMacros:
+  - Q_UNUSED
+  - QT_REQUIRE_VERSION
+TabWidth:        8
+UseCRLF:         false
+UseTab:          Never
+...
+

--- a/.formatignore
+++ b/.formatignore
@@ -1,0 +1,14 @@
+# Files to not check/fix coding style for.
+# These files are imported from other sources and we want to maintain
+# them in the original form to make future updates easier.
+docs/conf.py
+examples/protobuf/user_pb2.py
+tests/integration/schema_registry/data/proto/DependencyTestProto_pb2.py
+tests/integration/schema_registry/data/proto/NestedTestProto_pb2.py
+tests/integration/schema_registry/data/proto/PublicTestProto_pb2.py
+tests/integration/schema_registry/data/proto/SInt32Value_pb2.py
+tests/integration/schema_registry/data/proto/SInt64Value_pb2.py
+tests/integration/schema_registry/data/proto/TestProto_pb2.py
+tests/integration/schema_registry/data/proto/common_proto_pb2.py
+tests/integration/schema_registry/data/proto/exampleProtoCriteo_pb2.py
+tests/integration/schema_registry/data/proto/metadata_proto_pb2.py

--- a/Makefile
+++ b/Makefile
@@ -12,3 +12,19 @@ clean:
 
 docs:
 	$(MAKE) -C docs html
+
+style-check:
+	@(tools/style-format.sh \
+		$$(git ls-tree -r --name-only HEAD | egrep '\.(c|h|py)$$') )
+
+style-check-changed:
+	@(tools/style-format.sh \
+		$$( (git diff --name-only ; git diff --name-only --staged) | egrep '\.(c|h|py)$$'))
+
+style-fix:
+	@(tools/style-format.sh --fix \
+		$$(git ls-tree -r --name-only HEAD | egrep '\.(c|h|py)$$'))
+
+style-fix-changed:
+	@(tools/style-format.sh --fix \
+		$$( (git diff --name-only ; git diff --name-only --staged) | egrep '\.(c|h|py)$$'))

--- a/tools/style-format.sh
+++ b/tools/style-format.sh
@@ -1,0 +1,132 @@
+#!/bin/bash
+#
+# Check or apply/fix the project coding style to all files passed as arguments.
+# Uses clang-format for C and flake8 for Python.
+#
+# Requires clang-format version 10  (apt install clang-format-10).
+#
+
+
+CLANG_FORMAT=${CLANG_FORMAT:-clang-format}
+
+set -e
+
+ret=0
+
+if [[ -z $1 ]]; then
+    echo "Usage: $0 [--fix] srcfile1.c srcfile2.h srcfile3.c ..."
+    echo ""
+    exit 0
+fi
+
+if [[ $1 == "--fix" ]]; then
+    fix=1
+    shift
+else
+    fix=0
+fi
+
+clang_format_version=$(${CLANG_FORMAT} --version | sed -Ee 's/.*version ([[:digit:]]+)\.[[:digit:]]+\.[[:digit:]]+.*/\1/')
+if [[ $clang_format_version != "10" ]] ; then
+    echo "$0: clang-format version 10, '$clang_format_version' detected"
+    exit 1
+fi
+
+# Get list of files from .formatignore to ignore formatting for.
+ignore_files=( $(grep '^[^#]..' .formatignore) )
+
+function ignore {
+    local file=$1
+
+    local f
+    for f in "${ignore_files[@]}" ; do
+        [[ $file == $f ]] && return 0
+    done
+
+    return 1
+}
+
+extra_info=""
+
+for f in $*; do
+
+    if ignore $f ; then
+        echo "$f is ignored by .formatignore" 1>&2
+        continue
+    fi
+
+    lang="c"
+    if [[ $f == *.py ]]; then
+        lang="py"
+        style="pep8"
+        stylename="pep8"
+    else
+        style="file"  # Use .clang-format
+        stylename="C"
+    fi
+
+    check=0
+
+    if [[ $fix == 1 ]]; then
+        # Convert tabs to 8 spaces first.
+        if grep -ql $'\t' "$f"; then
+            sed -i -e 's/\t/        /g' "$f"
+            echo "$f: tabs converted to spaces"
+        fi
+
+        if [[ $lang == c ]]; then
+            # Run clang-format to reformat the file
+            ${CLANG_FORMAT} --style="$style" "$f" > _styletmp
+
+        else
+            # Run autopep8 to reformat the file.
+            python3 -m autopep8 -a "$f" > _styletmp
+            # autopep8 can't fix all errors, so we also perform a flake8 check.
+            check=1
+        fi
+
+        if ! cmp -s "$f" _styletmp; then
+            echo "$f: style fixed ($stylename)"
+            # Use cp to preserve target file mode/attrs.
+            cp _styletmp "$f"
+            rm _styletmp
+        fi
+    fi
+
+    if [[ $fix == 0 || $check == 1 ]]; then
+        # Check for tabs
+        if grep -q $'\t' "$f" ; then
+            echo "$f: contains tabs: convert to 8 spaces instead"
+            ret=1
+        fi
+
+        # Check style
+        if [[ $lang == c ]]; then
+            if ! ${CLANG_FORMAT} --style="$style" --Werror --dry-run "$f" ; then
+                echo "$f: had style errors ($stylename): see clang-format output above"
+                ret=1
+            fi
+        elif [[ $lang == py ]]; then
+            if ! python3 -m flake8 "$f"; then
+                echo "$f: had style errors ($stylename): see flake8 output above"
+                if [[ $fix == 1 ]]; then
+                    # autopep8 couldn't fix all errors. Let the user know.
+                    extra_info="Error: autopep8 could not fix all errors, fix the flake8 errors manually and run again."
+                fi
+                ret=1
+            fi
+        fi
+    fi
+
+done
+
+rm -f _styletmp
+
+if [[ $ret != 0 ]]; then
+    echo ""
+    echo "You can run the following command to automatically fix the style:"
+    echo "  $ make style-fix"
+    [[ -n $extra_info ]] && echo "$extra_info"
+fi
+
+exit $ret


### PR DESCRIPTION
Add autoformat with autopep8 and clang-format, following the same rules as librdkafka.