### PR TITLE
Add set_sasl_credentials binding across clients

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Confluent's Python client for Apache Kafka
 
+## vNext
+
+- Added `set_sasl_credentials`. This new method (on the Producer, Consumer, and AdminClient) allows modifying the stored
+  SASL PLAIN/SCRAM credentials that will be used for subsequent (new) connections to a broker (#1511).
+
 
 ## v2.0.2
 

--- a/src/confluent_kafka/admin/__init__.py
+++ b/src/confluent_kafka/admin/__init__.py
@@ -800,9 +800,6 @@ class AdminClient (_AdminClientImpl):
         :param str username: The username to set.
         :param str password: The password to set.
 
-        :returns: A dict of futures for each group, keyed by the group id.
-                  The future result() method returns :class:`ConsumerGroupTopicPartitions`.
-
         :rtype: None
 
         :raises KafkaException: Operation failed locally or on broker.

--- a/src/confluent_kafka/admin/__init__.py
+++ b/src/confluent_kafka/admin/__init__.py
@@ -787,3 +787,25 @@ class AdminClient (_AdminClientImpl):
         super(AdminClient, self).alter_consumer_group_offsets(alter_consumer_group_offsets_request, f, **kwargs)
 
         return futmap
+
+    def set_sasl_credentials(self, username, password):
+        """
+        Sets the SASL credentials used for this client.
+        These credentials will overwrite the old ones, and will be used the
+        next time the client needs to authenticate.
+        This method will not disconnect existing broker connections that
+        have been established with the old credentials.
+        This method is applicable only to SASL PLAIN and SCRAM mechanisms.
+
+        :param str username: The username to set.
+        :param str password: The password to set.
+
+        :returns: A dict of futures for each group, keyed by the group id.
+                  The future result() method returns :class:`ConsumerGroupTopicPartitions`.
+
+        :rtype: None
+
+        :raises KafkaException: Operation failed locally or on broker.
+        :raises TypeException: Invalid input.
+        """
+        super(AdminClient, self).set_sasl_credentials(username, password)

--- a/src/confluent_kafka/src/Admin.c
+++ b/src/confluent_kafka/src/Admin.c
@@ -2152,6 +2152,10 @@ static PyMethodDef Admin_methods[] = {
            Admin_delete_acls_doc
         },
 
+        { "set_sasl_credentials", (PyCFunction)set_sasl_credentials, METH_VARARGS|METH_KEYWORDS,
+           set_sasl_credentials_doc
+        },
+
         { NULL }
 };
 

--- a/src/confluent_kafka/src/Consumer.c
+++ b/src/confluent_kafka/src/Consumer.c
@@ -1477,6 +1477,9 @@ static PyMethodDef Consumer_methods[] = {
           "send_offsets_to_transaction() API.\n"
           "\n"
         },
+        { "set_sasl_credentials", (PyCFunction)set_sasl_credentials, METH_VARARGS|METH_KEYWORDS,
+           set_sasl_credentials_doc
+        },
 
 
 	{ NULL }

--- a/src/confluent_kafka/src/Producer.c
+++ b/src/confluent_kafka/src/Producer.c
@@ -811,6 +811,9 @@ static PyMethodDef Producer_methods[] = {
           "           Treat any other error as a fatal error.\n"
           "\n"
         },
+        { "set_sasl_credentials", (PyCFunction)set_sasl_credentials, METH_VARARGS|METH_KEYWORDS,
+           set_sasl_credentials_doc
+        },
         { NULL }
 };
 

--- a/src/confluent_kafka/src/confluent_kafka.c
+++ b/src/confluent_kafka/src/confluent_kafka.c
@@ -2581,6 +2581,48 @@ PyObject *cfl_int32_array_to_py_list (const int32_t *arr, size_t cnt) {
 /****************************************************************************
  *
  *
+ * Methods common across all types of clients.
+ *
+ *
+ *
+ *
+ ****************************************************************************/
+
+const char set_sasl_credentials_doc[] = PyDoc_STR(
+        ".. py:function:: set_sasl_credentials(username, password)\n"
+        "\n"
+        "  Sets the SASL credentials used for this client.\n"
+        "  These credentials will overwrite the old ones, and will be used the next time the client needs to authenticate.\n"
+        "  This method will not disconnect existing broker connections that have been established with the old credentials.\n"
+        "  This method is applicable only to SASL PLAIN and SCRAM mechanisms.\n");
+
+
+PyObject *set_sasl_credentials(Handle *self, PyObject *args, PyObject *kwargs) {
+        const char *username = NULL;
+        const char *password = NULL;
+        rd_kafka_error_t* error;
+        static char *kws[] = {"username", "password", NULL};
+
+        if (!PyArg_ParseTupleAndKeywords(args, kwargs, "ss", kws,
+                                         &username, &password)) {
+                return NULL;
+        }
+
+        error = rd_kafka_sasl_set_credentials(self->rk, username, password);
+
+        if (error) {
+                cfl_PyErr_from_error_destroy(error);
+                return NULL;
+        }
+
+        Py_RETURN_NONE;
+}
+
+
+
+/****************************************************************************
+ *
+ *
  * Base
  *
  *

--- a/src/confluent_kafka/src/confluent_kafka.h
+++ b/src/confluent_kafka/src/confluent_kafka.h
@@ -388,6 +388,7 @@ PyObject *list_topics (Handle *self, PyObject *args, PyObject *kwargs);
 PyObject *list_groups (Handle *self, PyObject *args, PyObject *kwargs);
 PyObject *set_sasl_credentials(Handle *self, PyObject *args, PyObject *kwargs);
 
+
 extern const char list_topics_doc[];
 extern const char list_groups_doc[];
 extern const char set_sasl_credentials_doc[];

--- a/src/confluent_kafka/src/confluent_kafka.h
+++ b/src/confluent_kafka/src/confluent_kafka.h
@@ -386,10 +386,11 @@ PyObject *c_Node_to_py(const rd_kafka_Node_t *c_node);
 rd_kafka_topic_partition_list_t *py_to_c_parts (PyObject *plist);
 PyObject *list_topics (Handle *self, PyObject *args, PyObject *kwargs);
 PyObject *list_groups (Handle *self, PyObject *args, PyObject *kwargs);
-
+PyObject *set_sasl_credentials(Handle *self, PyObject *args, PyObject *kwargs);
 
 extern const char list_topics_doc[];
 extern const char list_groups_doc[];
+extern const char set_sasl_credentials_doc[];
 
 
 #ifdef RD_KAFKA_V_HEADERS

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -263,6 +263,7 @@ def test_topic_config_update():
             pytest.xfail("Timeout exceeded")
         pytest.fail("Timeout exceeded")
 
+
 def test_set_sasl_credentials_api():
     clients = [
         AdminClient({}),

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -262,3 +262,20 @@ def test_topic_config_update():
         if "CI" in os.environ:
             pytest.xfail("Timeout exceeded")
         pytest.fail("Timeout exceeded")
+
+def test_set_sasl_credentials_api():
+    clients = [
+        AdminClient({}),
+        confluent_kafka.Consumer({"group.id": "dummy"}),
+        confluent_kafka.Producer({})]
+
+    for c in clients:
+        c.set_sasl_credentials('username', 'password')
+
+        c.set_sasl_credentials('override', 'override')
+
+        with pytest.raises(TypeError):
+            c.set_sasl_credentials(None, 'password')
+
+        with pytest.raises(TypeError):
+            c.set_sasl_credentials('username', None)


### PR DESCRIPTION
This binding calls internally rd_kafka_sasl_set_credentials. 
This binding is needed across consumers, producers, and adminclient.

Since this binding is required by all three bindings, I've added it in a common file.
If I need to create a new file, or a new test file, please let me know.