### PR TITLE
Refactor schema validation in JSONSerializer

### DIFF
--- a/src/confluent_kafka/schema_registry/json_schema.py
+++ b/src/confluent_kafka/schema_registry/json_schema.py
@@ -339,6 +339,10 @@ class JSONDeserializer(Deserializer):
         if not hasattr(validator, "validate"):
             raise ValueError("schema.validator must implement jsonschema.protocols.Validator")
 
+        if len(conf_copy) > 0:
+            raise ValueError("Unrecognized properties: {}"
+                             .format(", ".join(conf_copy.keys())))
+
         schema_dict = json.loads(schema.schema_str)
         self._parsed_schema = schema_dict
         self._schema = schema

--- a/src/confluent_kafka/schema_registry/json_schema.py
+++ b/src/confluent_kafka/schema_registry/json_schema.py
@@ -209,7 +209,7 @@ class JSONSerializer(Serializer):
             raise ValueError("subject.name.strategy must be callable")
 
         validator = conf_copy.pop('schema.validator')
-        if not hasattr(validator, "validate"):
+        if (validator is not None) and not hasattr(validator, "validate"):
             raise ValueError("schema.validator must implement jsonschema.protocols.Validator")
 
         if len(conf_copy) > 0:
@@ -336,7 +336,7 @@ class JSONDeserializer(Deserializer):
             conf_copy.update(conf)
 
         validator = conf_copy.pop('schema.validator')
-        if not hasattr(validator, "validate"):
+        if (validator is not None) and not hasattr(validator, "validate"):
             raise ValueError("schema.validator must implement jsonschema.protocols.Validator")
 
         if len(conf_copy) > 0:


### PR DESCRIPTION
Fixes #1564 

JSONSerializer changes:
- Added schema.validator parameter to conf, allowing use of different JSON validators
  - Default behavior [schema.validator == None] unchanged
- Added _validator attribute
- Added explicit schema validation step to __init__ [_validator.check_schema]
- Replaced default jsonschema.validate function with _validator.validate in __call__

JSONDeserializer changes:
- Added conf parameter to __init__
- Added schema.validator parameter to conf, allowing use of different JSON validators
  - Default behavior [schema.validator == None] unchanged
- Added _validator attribute
- Added explicit schema validation step to __init__ [_validator.check_schema]
- Replaced default jsonschema.validate function with _validator.validate in __call__