### PR TITLE
Fix call to deprecated class

### DIFF
--- a/src/confluent_kafka/schema_registry/protobuf.py
+++ b/src/confluent_kafka/schema_registry/protobuf.py
@@ -23,7 +23,7 @@ import warnings
 from collections import deque
 
 from google.protobuf.message import DecodeError
-from google.protobuf.message_factory import MessageFactory
+from google.protobuf.message_factory import GetMessageClass
 
 from . import (_MAGIC_BYTE,
                reference_subject_name_strategy,
@@ -510,7 +510,7 @@ class ProtobufDeserializer(object):
 
         descriptor = message_type.DESCRIPTOR
         self._index_array = _create_index_array(descriptor)
-        self._msg_class = MessageFactory().GetPrototype(descriptor)
+        self._msg_class = GetMessageClass(descriptor)
 
     @staticmethod
     def _decode_varint(buf, zigzag=True):


### PR DESCRIPTION
protobuf class [MessageFactory](https://github.com/protocolbuffers/protobuf/blob/main/python/google/protobuf/message_factory.py#L179) is deprecated, and it is generating deprecation warnings when called.

Instead of calling `MessageFactory().GetPrototype(descriptor)` (that will only generate a deprecation warning and call `GetMessageClass(descriptor)`), we should call `GetMessageClass(descriptor)` directly, as suggested by the deprecation warning.


