### PR TITLE
Support avro union schema serde

### DIFF
--- a/src/confluent_kafka/schema_registry/avro.py
+++ b/src/confluent_kafka/schema_registry/avro.py
@@ -82,7 +82,7 @@ def _resolve_named_schema(schema, schema_registry_client, named_schemas=None):
             referenced_schema = schema_registry_client.get_version(ref.subject, ref.version)
             _resolve_named_schema(referenced_schema.schema, schema_registry_client, named_schemas)
             parse_schema(loads(referenced_schema.schema.schema_str),
-                         named_schemas=named_schemas, expand=True)
+                         named_schemas=named_schemas)
     return named_schemas
 
 

--- a/src/confluent_kafka/schema_registry/avro.py
+++ b/src/confluent_kafka/schema_registry/avro.py
@@ -425,7 +425,7 @@ class AvroDeserializer(Deserializer):
             obj_dict = schemaless_reader(payload,
                                          writer_schema,
                                          self._reader_schema,
-                                         self._return_record_name)
+                                         self._return_record_name, return_record_name_override=True)
 
             if self._from_dict is not None:
                 return self._from_dict(obj_dict, ctx)

--- a/src/confluent_kafka/schema_registry/avro.py
+++ b/src/confluent_kafka/schema_registry/avro.py
@@ -81,7 +81,8 @@ def _resolve_named_schema(schema, schema_registry_client, named_schemas=None):
         for ref in schema.references:
             referenced_schema = schema_registry_client.get_version(ref.subject, ref.version)
             _resolve_named_schema(referenced_schema.schema, schema_registry_client, named_schemas)
-            parse_schema(loads(referenced_schema.schema.schema_str), named_schemas=named_schemas)
+            parse_schema(loads(referenced_schema.schema.schema_str),
+                         named_schemas=named_schemas, expand=True)
     return named_schemas
 
 
@@ -226,7 +227,8 @@ class AvroSerializer(Serializer):
 
         schema_dict = loads(schema.schema_str)
         self._named_schemas = _resolve_named_schema(schema, schema_registry_client)
-        parsed_schema = parse_schema(schema_dict, named_schemas=self._named_schemas)
+        parsed_schema = parse_schema(schema_dict,
+                                     named_schemas=self._named_schemas, expand=True)
 
         if isinstance(parsed_schema, list):
             # if parsed_schema is a list, we have an Avro union and there
@@ -361,7 +363,7 @@ class AvroDeserializer(Deserializer):
             schema_dict = loads(self._schema.schema_str)
             self._named_schemas = _resolve_named_schema(self._schema, schema_registry_client)
             self._reader_schema = parse_schema(schema_dict,
-                                               named_schemas=self._named_schemas)
+                                               named_schemas=self._named_schemas, expand=True)
         else:
             self._named_schemas = None
             self._reader_schema = None
@@ -416,8 +418,8 @@ class AvroDeserializer(Deserializer):
                 registered_schema = self._registry.get_schema(schema_id)
                 self._named_schemas = _resolve_named_schema(registered_schema, self._registry)
                 prepared_schema = _schema_loads(registered_schema.schema_str)
-                writer_schema = parse_schema(loads(
-                    prepared_schema.schema_str), named_schemas=self._named_schemas)
+                writer_schema = parse_schema(loads(prepared_schema.schema_str),
+                                             named_schemas=self._named_schemas, expand=True)
                 self._writer_schemas[schema_id] = writer_schema
 
             obj_dict = schemaless_reader(payload,

--- a/tests/integration/schema_registry/test_avro_serializers.py
+++ b/tests/integration/schema_registry/test_avro_serializers.py
@@ -222,7 +222,7 @@ def _register_avro_unions_and_build_award_or_user_schema(kafka_cluster, topic):
         "award", Schema(Award.schema_str, "AVRO", [award_properties_schema_ref])
     )
 
-    references = [user_schema_ref, award_schema_ref, award_properties_schema_ref]
+    references = [user_schema_ref, award_schema_ref]
     schema = Schema(union_schema_str, "AVRO", references)
 
     sr.register_schema(subject_name=f"{topic}-value", schema=schema)


### PR DESCRIPTION
fixes #1562 

This pr expand named schema fully to their true schemas to fix "UnknownType" error when using avro union schema like below.

```json
[
    "confluent.io.examples.serialization.avro.User",
    "confluent.io.examples.serialization.avro.Award"
]
```

