### PR TITLE
Fix parameter ordering in docstring

### DIFF
--- a/src/confluent_kafka/deserializing_consumer.py
+++ b/src/confluent_kafka/deserializing_consumer.py
@@ -40,11 +40,11 @@ class DeserializingConsumer(_ConsumerImpl):
     +-------------------------+---------------------+-----------------------------------------------------+
     | Property Name           | Type                | Description                                         |
     +=========================+=====================+=====================================================+
-    |                         |                     | Callable(SerializationContext, bytes) -> obj        |
+    |                         |                     | Callable(bytes, SerializationContext) -> obj        |
     | ``key.deserializer``    | callable            |                                                     |
     |                         |                     | Deserializer used for message keys.                 |
     +-------------------------+---------------------+-----------------------------------------------------+
-    |                         |                     | Callable(SerializationContext, bytes) -> obj        |
+    |                         |                     | Callable(bytes, SerializationContext) -> obj        |
     | ``value.deserializer``  | callable            |                                                     |
     |                         |                     | Deserializer used for message values.               |
     +-------------------------+---------------------+-----------------------------------------------------+


### PR DESCRIPTION
Minor documentation fix.

The docstring for DeserializingConsumer's says that the `key.deserializer` and `value.deserializer` configs are expected to be `Callable(SerializationContext, bytes)` but [the code](https://github.com/confluentinc/confluent-kafka-python/blob/76e4796c5af24201669b9e4b23b8ce03f004eacc/src/confluent_kafka/deserializing_consumer.py#L110-L118) actually calls them using `self._value_deserializer(value, ctx)` and `self._key_deserializer(key, ctx)`.

I also checked [SerializingProducer](https://github.com/confluentinc/confluent-kafka-python/blob/76e4796c5af24201669b9e4b23b8ce03f004eacc/src/confluent_kafka/serializing_producer.py#L39-L49) and verified that its documentation has the parameter order correct.