### PR TITLE
Run pipeline with docker login

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -134,6 +134,9 @@ blocks:
           value: linux
         - name: ARCH
           value: x64
+      prologue:
+        commands:
+          - docker login --username $DOCKERHUB_USER --password $DOCKERHUB_APIKEY
       jobs:
         - name: Build
           commands:


### PR DESCRIPTION
Logs into dockerhub using pre-exported credentials to prevent any dockerhub rate limiting issues.