### PR TITLE
ci: Update mac build agents versions

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -21,7 +21,7 @@ blocks:
     task:
       agent:
         machine:
-          type: s1-prod-macos
+          type: s1-prod-macos-13-5-amd64
       env_vars:
         - name: OS_NAME
           value: osx
@@ -40,7 +40,7 @@ blocks:
     task:
       agent:
         machine:
-          type: s1-prod-macos-arm64
+          type: s1-prod-macos-13-5-arm64
       env_vars:
         - name: OS_NAME
           value: osx
@@ -169,7 +169,7 @@ blocks:
     task:
       agent:
         machine:
-          type: s1-prod-macos
+          type: s1-prod-macos-13-5-amd64
       env_vars:
         - name: OS_NAME
           value: osx
@@ -188,7 +188,7 @@ blocks:
     task:
       agent:
         machine:
-          type: s1-prod-macos-arm64
+          type: s1-prod-macos-13-5-arm64
       env_vars:
         - name: OS_NAME
           value: osx


### PR DESCRIPTION
Update mac agent to 13.5 which is close to developer's local versions.
new mac agent syntax is same as ubuntu agents