### PR TITLE
Upgrade to macOS 13.5 Semaphore agents

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -21,7 +21,7 @@ blocks:
     task:
       agent:
         machine:
-          type: s1-prod-macos
+          type: s1-prod-macos-13-5-amd64
       env_vars:
         - name: OS_NAME
           value: osx
@@ -40,7 +40,7 @@ blocks:
     task:
       agent:
         machine:
-          type: s1-prod-macos-arm64
+          type: s1-prod-macos-13-5-arm64
       env_vars:
         - name: OS_NAME
           value: osx
@@ -169,7 +169,7 @@ blocks:
     task:
       agent:
         machine:
-          type: s1-prod-macos
+          type: s1-prod-macos-13-5-amd64
       env_vars:
         - name: OS_NAME
           value: osx
@@ -188,7 +188,7 @@ blocks:
     task:
       agent:
         machine:
-          type: s1-prod-macos-arm64
+          type: s1-prod-macos-13-5-arm64
       env_vars:
         - name: OS_NAME
           value: osx


### PR DESCRIPTION
This changes the Semaphore pipeline to macOS 13.5 agents instead of 12.4