### PR TITLE
Adjust function name in docs for Message.__len__ function

### DIFF
--- a/src/confluent_kafka/src/confluent_kafka.c
+++ b/src/confluent_kafka/src/confluent_kafka.c
@@ -744,7 +744,7 @@ PyTypeObject MessageType = {
         "\n"
 	"This class is not user-instantiable.\n"
 	"\n"
-	".. py:function:: len()\n"
+	".. py:function:: __len__()\n"
 	"\n"
 	"  :returns: Message value (payload) size in bytes\n"
 	"  :rtype: int\n"


### PR DESCRIPTION
The docs currently describe a Message.len() method.
This method does not exist, the method implemented is the normal Message.__len__ method, which then provides len(Message).
Change is to rename the function in the docs to __len__ so that it is clear that the built in `len` method is the one being created.

Caught me out recently, and has previously caught someone out: https://github.com/confluentinc/confluent-kafka-python/issues/1142