### PR TITLE
Adjust function name in docs for Message.__len__ function

### DIFF
--- a/src/confluent_kafka/src/confluent_kafka.c
+++ b/src/confluent_kafka/src/confluent_kafka.c
@@ -744,7 +744,7 @@ PyTypeObject MessageType = {
         "\n"
 	"This class is not user-instantiable.\n"
 	"\n"
-	".. py:function:: len()\n"
+	".. py:function:: __len__()\n"
 	"\n"
 	"  :returns: Message value (payload) size in bytes\n"
 	"  :rtype: int\n"


### PR DESCRIPTION
Adjust the docstring so it is clear the function is the built in `__len__` function and not some newly defined `len` function on this object.