### PR TITLE
Parser to string RegisteredSchema Class

### DIFF
--- a/src/confluent_kafka/schema_registry/schema_registry_client.py
+++ b/src/confluent_kafka/schema_registry/schema_registry_client.py
@@ -821,6 +821,8 @@ class RegisteredSchema(object):
         self.subject = subject
         self.version = version
 
+    def __str__(self) -> str:
+        return self.schema.schema_str
 
 class SchemaReference(object):
     """


### PR DESCRIPTION
Implemented for RegisteredSchema the method __str__, to return the schema as str when the schema is parsed to str().