### PR TITLE
Fixed an issue related to import error of TopicCollection and TopicPartitionInfo classes when importing through other module like mypy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ v2.4.1 is a maintenance release with the following fixes and enhancements:
 
  - Removed usage of `strcpy` to enhance security of the client (#1745)
  - Fixed invalid write in `OAUTHBEARER/OIDC` extensions copy (#1745)
+ - Fixed an issue related to import error of `TopicCollection` and `TopicPartitionInfo` classes when importing through other module like mypy.
 
 confluent-kafka-python is based on librdkafka v2.4.1, see the
 [librdkafka release notes](https://github.com/confluentinc/librdkafka/releases/tag/v2.4.1)

--- a/src/confluent_kafka/__init__.py
+++ b/src/confluent_kafka/__init__.py
@@ -49,7 +49,7 @@ __all__ = ['admin', 'Consumer',
            'SerializingProducer', 'TIMESTAMP_CREATE_TIME', 'TIMESTAMP_LOG_APPEND_TIME',
            'TIMESTAMP_NOT_AVAILABLE', 'TopicPartition', 'Node',
            'ConsumerGroupTopicPartitions', 'ConsumerGroupState', 'Uuid',
-           'IsolationLevel']
+           'IsolationLevel', 'TopicCollection', 'TopicPartitionInfo']
 
 __version__ = version()[0]
 


### PR DESCRIPTION
Fixes https://github.com/confluentinc/confluent-kafka-python/issues/1732