### PR TITLE
Retrieve schema from schema registry client in `JSONDeserialier` if `schema_str` not provided

### DIFF
--- a/src/confluent_kafka/schema_registry/json_schema.py
+++ b/src/confluent_kafka/schema_registry/json_schema.py
@@ -296,16 +296,18 @@ class JSONDeserializer(Deserializer):
     framing.
 
     Args:
-        schema_str (str, Schema):
+        schema_str (str, Schema, optional):
             `JSON schema definition <https://json-schema.org/understanding-json-schema/reference/generic.html>`_
             Accepts schema as either a string or a :py:class:`Schema` instance.
             Note that string definitions cannot reference other schemas. For referencing other schemas,
-            use a :py:class:`Schema` instance.
+            use a :py:class:`Schema` instance.  If not provided, schemas will be
+            retrieved from schema_registry_client based on the schema ID in the
+            wire header of each message.
 
         from_dict (callable, optional): Callable(dict, SerializationContext) -> object.
             Converts a dict to a Python object instance.
 
-        schema_registry_client (SchemaRegistryClient, optional): Schema Registry client instance. Needed if ``schema_str`` is a schema referencing other schemas.
+        schema_registry_client (SchemaRegistryClient, optional): Schema Registry client instance. Needed if ``schema_str`` is a schema referencing other schemas or is not provided.
     """  # noqa: E501
 
     __slots__ = ['_parsed_schema', '_from_dict', '_registry', '_are_references_provided', '_schema']


### PR DESCRIPTION
Fixes #1541.

I think this is worth including because it brings the `JSONDeserializer` into better alignment with the avro/protobuf deserializers.  Currently the JSON deserializer just throws away the schema ID information, yet still _requires_ that the schema string is passed in as input.  This makes it pretty annoying to work with on the client side (you must either hard code your schema string into your application or look up the schema from the registry by ID which also needs to be hard coded or subject which requires hard coding the subject naming convention).

Thanks to the recent improvements in caching in the schema registry client this won't result in excessive network requests.  There's a bit of optimization on the table here (could cache the `json.loads` for the schema ID) but I think this is probably fine to get started with.

I haven't attempted to update tests here at all, just the source code and docstrings.