### PR TITLE
Remove note about deadlock with partitioner

### DIFF
--- a/src/confluent_kafka/src/confluent_kafka.c
+++ b/src/confluent_kafka/src/confluent_kafka.c
@@ -22,13 +22,6 @@
 /**
  * @brief KNOWN ISSUES
  *
- *  - Partitioners will cause a dead-lock with librdkafka, because:
- *     GIL + topic lock in topic_new  is different lock order than
- *     topic lock in msg_partitioner + GIL.
- *     This needs to be sorted out in librdkafka, preferably making the
- *     partitioner run without any locks taken.
- *     Until this is fixed the partitioner is ignored and librdkafka's
- *     default will be used.
  *  - KafkaError type .tp_doc allocation is lost on exit.
  *
  */


### PR DESCRIPTION
Custom partitioner has been removed for a long time in favor of using the predefined set of partitioners from librdkafka (https://github.com/confluentinc/confluent-kafka-python/pull/396) but 'known bug' note still exists. This note is misleading regarding the use of the 'partitioner' configuration property.