### PR TITLE
Fix Basic Auth credentials parsing in SchemaRegistryClient

### DIFF
--- a/src/confluent_kafka/schema_registry/schema_registry_client.py
+++ b/src/confluent_kafka/schema_registry/schema_registry_client.py
@@ -105,7 +105,7 @@ class _RestClient(object):
                                  " remove basic.auth.user.info from the"
                                  " configuration")
 
-            userinfo = tuple(conf_copy.pop('basic.auth.user.info', '').split(':'))
+            userinfo = tuple(conf_copy.pop('basic.auth.user.info', '').split(':', 1))
 
             if len(userinfo) != 2:
                 raise ValueError("basic.auth.user.info must be in the form"


### PR DESCRIPTION
### Description:

Hello, I noticed that `SchemaRegistryClient` does not handle a special character (colon) in passwords correctly, which should be allowed according to [RFC-7617](https://www.rfc-editor.org/rfc/rfc7617.html):

> For the user-id, recipients MUST support all characters defined in
>  the "UsernameCasePreserved" profile defined in Section 3.3 of
>  [RFC7613], with the exception of the colon (":") character.
>
>   For the password, recipients MUST support all characters defined in
>   the "OpaqueString" profile defined in Section 4.2 of [RFC7613].

### Changes:

- Updated the parsing logic for `basic.auth.user.info` to split on the first occurrence of a colon, ensuring the username and password are separated correctly, even when colons are present in the password.