### PR TITLE
Admin client impl fixes

### DIFF
--- a/src/confluent_kafka/src/Admin.c
+++ b/src/confluent_kafka/src/Admin.c
@@ -2794,10 +2794,15 @@ PyObject *Admin_alter_consumer_group_offsets (Handle *self, PyObject *args, PyOb
          * admin operation is finished, so we need to keep our own refcount. */
         Py_INCREF(future);
 
-        if (PyList_Check(request) &&
-            (requests_cnt = (int)PyList_Size(request)) != 1) {
-                PyErr_SetString(PyExc_ValueError,
-                        "Currently we support alter consumer groups offset request for 1 group only");
+        if (PyList_Check(request)) {
+                if ((int)PyList_Size(request) != 1) {
+                        PyErr_SetString(PyExc_ValueError,
+                                "Currently we support alter consumer groups offset request for 1 group only");
+                        goto err;
+                }
+        } else {
+                PyErr_SetString(PyExc_TypeError,
+                        "Expected 'request' to be a list");
                 goto err;
         }
 

--- a/src/confluent_kafka/src/Admin.c
+++ b/src/confluent_kafka/src/Admin.c
@@ -2650,10 +2650,15 @@ PyObject *Admin_list_consumer_group_offsets (Handle *self, PyObject *args, PyObj
          * admin operation is finished, so we need to keep our own refcount. */
         Py_INCREF(future);
 
-        if (PyList_Check(request) &&
-            (requests_cnt = (int)PyList_Size(request)) != 1) {
-                PyErr_SetString(PyExc_ValueError,
-                        "Currently we support listing only 1 consumer groups offset information");
+        if (PyList_Check(request)) {
+                if ((int)PyList_Size(request) != 1) {
+                        PyErr_SetString(PyExc_ValueError,
+                                "Currently we support listing only 1 consumer groups offset inforation");
+                        goto err;
+                }
+        } else {
+                PyErr_SetString(PyExc_TypeError,
+                        "Expected 'request' to be a list");
                 goto err;
         }
 

--- a/src/confluent_kafka/src/Admin.c
+++ b/src/confluent_kafka/src/Admin.c
@@ -2305,8 +2305,8 @@ PyObject *Admin_describe_topics (Handle *self, PyObject *args, PyObject *kwargs)
         int topics_cnt = 0;
         int i = 0;
 
-        static char *kws[] = {"future",
-                             "topic_names",
+        static char *kws[] = {"topic_names",
+                             "future",
                              /* options */
                              "request_timeout",
                              "include_authorized_operations",

--- a/src/confluent_kafka/src/confluent_kafka.c
+++ b/src/confluent_kafka/src/confluent_kafka.c
@@ -1330,8 +1330,8 @@ rd_kafka_topic_partition_list_t *py_to_c_parts (PyObject *plist) {
 		TopicPartition *tp = (TopicPartition *)
 			PyList_GetItem(plist, i);
 
-		if (PyObject_Type((PyObject *)tp) !=
-		    (PyObject *)&TopicPartitionType) {
+		if (PyObject_TypeCheck((PyObject *)tp,
+		    (PyObject *)&TopicPartitionType) == 0) {
 			PyErr_Format(PyExc_TypeError,
 				     "expected %s",
 				     TopicPartitionType.tp_name);


### PR DESCRIPTION
A handful of minor fixes to cimpl. Probably nothing that will impact real-life use-cases, since these are all buried inside `_AdminClientImpl`, but they were bothering me.

1. Swaps `"topic_names"` and `"future"` in `kws` array in `Admin_describe_topics()`

If a user tried to pass `topic_names` or `future` into `_AdminClientImpl.describe_topics()` as keyword arguments, they would end up swapped, which would lead to confusing errors.

2. Raises `TypeError` in `Admin_list_consumer_group_offset()` if `request` is not a list
3. Raises `TypeError` in `Admin_alter_consumer_group_offsets()` if `request` is not a list

In both of these cases, the library would raise `ValueError` if `request` was a list with anything other than 1 item... but if `request` wasn't a list, it would result in an internal error when it tried to access its first item.

4. Allows elements of `plist` in `py_to_c_parts()` to be instances of a subtype of `TopicPartition`

If a user passed a list of instances of a subtype of `TopicPartition`, the library would raise a `TypeError`, even if the instances were otherwise valid.