### PR TITLE
KIP 848:Extend DescribeConfigs and IncrementalAlterConfigs to support GROUP Config

### DIFF
--- a/src/confluent_kafka/admin/__init__.py
+++ b/src/confluent_kafka/admin/__init__.py
@@ -72,6 +72,7 @@ from ..cimpl import (KafkaException,  # noqa: F401
                      CONFIG_SOURCE_DYNAMIC_DEFAULT_BROKER_CONFIG,
                      CONFIG_SOURCE_STATIC_BROKER_CONFIG,
                      CONFIG_SOURCE_DEFAULT_CONFIG,
+                     CONFIG_SOURCE_GROUP_CONFIG,
                      RESOURCE_UNKNOWN,
                      RESOURCE_ANY,
                      RESOURCE_TOPIC,

--- a/src/confluent_kafka/admin/_config.py
+++ b/src/confluent_kafka/admin/_config.py
@@ -56,6 +56,7 @@ class ConfigSource(Enum):
     DYNAMIC_DEFAULT_BROKER_CONFIG = _cimpl.CONFIG_SOURCE_DYNAMIC_DEFAULT_BROKER_CONFIG  #: Dynamic Default Broker
     STATIC_BROKER_CONFIG = _cimpl.CONFIG_SOURCE_STATIC_BROKER_CONFIG  #: Static Broker
     DEFAULT_CONFIG = _cimpl.CONFIG_SOURCE_DEFAULT_CONFIG  #: Default
+    GROUP_CONFIG = _cimpl.CONFIG_SOURCE_GROUP_CONFIG  #: Group
 
 
 class ConfigEntry(object):

--- a/src/confluent_kafka/src/AdminTypes.c
+++ b/src/confluent_kafka/src/AdminTypes.c
@@ -514,6 +514,8 @@ static void AdminTypes_AddObjectsConfigSource (PyObject *m) {
                                 RD_KAFKA_CONFIG_SOURCE_STATIC_BROKER_CONFIG);
         PyModule_AddIntConstant(m, "CONFIG_SOURCE_DEFAULT_CONFIG",
                                 RD_KAFKA_CONFIG_SOURCE_DEFAULT_CONFIG);
+        PyModule_AddIntConstant(m, "CONFIG_SOURCE_GROUP_CONFIG",
+                                RD_KAFKA_CONFIG_SOURCE_GROUP_CONFIG);
 }
 
 

--- a/tests/integration/admin/test_incremental_alter_configs.py
+++ b/tests/integration/admin/test_incremental_alter_configs.py
@@ -150,6 +150,8 @@ def test_incremental_alter_configs(kafka_cluster):
     # Assert expected config entries.
     assert_expected_config_entries(fs, 1, expected)
 
+    # TODO: enable this test for the classic run too, when
+    # Confluent Platform test cluster is upgraded to 8.0.0
     if TestUtils.use_group_protocol_consumer():
         group_id = "test-group"
 

--- a/tests/integration/admin/test_incremental_alter_configs.py
+++ b/tests/integration/admin/test_incremental_alter_configs.py
@@ -19,6 +19,8 @@ from confluent_kafka.admin import ConfigResource, \
     ConfigEntry, ResourceType, \
     AlterConfigOpType
 
+from tests.common import TestUtils
+
 
 def assert_expected_config_entries(fs, num_fs, expected):
     """
@@ -147,3 +149,34 @@ def test_incremental_alter_configs(kafka_cluster):
 
     # Assert expected config entries.
     assert_expected_config_entries(fs, 1, expected)
+
+    if TestUtils.use_group_protocol_consumer():
+        group_id = "test-group"
+
+        res_group = ConfigResource(
+            ResourceType.GROUP,
+            group_id,
+            incremental_configs=[
+                ConfigEntry("consumer.session.timeout.ms", "50000",
+                            incremental_operation=AlterConfigOpType.SET)
+            ]
+        )
+
+        expected[res_group] = ['consumer.session.timeout.ms="50000"']
+        
+        #
+        # Incrementally alter some configuration values
+        #
+        fs = admin_client.incremental_alter_configs([res_group])
+
+        assert_operation_succeeded(fs, 1)
+
+        time.sleep(1)
+
+        #
+        # Get current group config
+        #
+        fs = admin_client.describe_configs([res_group])
+
+        # Assert expected config entries.
+        assert_expected_config_entries(fs, 1, expected)

--- a/tests/integration/admin/test_incremental_alter_configs.py
+++ b/tests/integration/admin/test_incremental_alter_configs.py
@@ -163,7 +163,7 @@ def test_incremental_alter_configs(kafka_cluster):
         )
 
         expected[res_group] = ['consumer.session.timeout.ms="50000"']
-        
+
         #
         # Incrementally alter some configuration values
         #


### PR DESCRIPTION
This PR intends to add support for Group Resource type for IncrementalAlterConfigs API as specified in KIP 848 and extended the DescribeConfigs support till API version 3.
Additional changed the integration test to check for Group Resource Type.
Librdkafka PR:  [#4939](https://github.com/confluentinc/librdkafka/pull/4939)