### PR TITLE
Fixed documentation for Avro Serializer

### DIFF
--- a/src/confluent_kafka/schema_registry/avro.py
+++ b/src/confluent_kafka/schema_registry/avro.py
@@ -118,7 +118,7 @@ class AvroSerializer(BaseSerializer):
 
     +-----------------------------+----------+--------------------------------------------------+
     | Property Name               | Type     | Description                                      |
-    +===========================--+==========+==================================================+
+    +=============================+==========+==================================================+
     |                             |          | If True, automatically register the configured   |
     | ``auto.register.schemas``   | bool     | schema with Confluent Schema Registry if it has  |
     |                             |          | not previously been associated with the relevant |


### PR DESCRIPTION

What
----
Fix to AvroSerializer documentation.

```
/home/prathi/.pyenv/versions/3.11.7/envs/venv_311/lib/python3.11/site-packages/confluent_kafka/schema_registry/avro.py:docstring of confluent_kafka.schema_registry.avro.AvroSerializer:8: WARNING: Block quote ends without a blank line; unexpected unindent. [docutils]
/home/prathi/.pyenv/versions/3.11.7/envs/venv_311/lib/python3.11/site-packages/confluent_kafka/schema_registry/avro.py:docstring of confluent_kafka.schema_registry.avro.AvroSerializer:8: WARNING: Block quote ends without a blank line; unexpected unindent. [docutils]
```


Test & Review
------------
Before
![image](https://github.com/user-attachments/assets/02e17dc2-4252-4bde-af2f-fcda6abd3496)

After the Fix
![image](https://github.com/user-attachments/assets/486e2a86-2bf4-418a-8f24-9e092c4aaaf5)

