### PR TITLE
Add missing dependency on googleapis-common-protos when using protobufs

### DIFF
--- a/requirements/requirements-protobuf.txt
+++ b/requirements/requirements-protobuf.txt
@@ -1,1 +1,2 @@
+googleapis-common-protos
 protobuf


### PR DESCRIPTION
<!--
Suggested PR template: Fill/delete/add sections as needed. Optionally delete any commented block.
-->
What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include implementation strategy.
-->
When using the Schema Registry with Protobufs, `confluent_kafka/schema_registry/protobuf.py` imports from the `google.type` package, which is part of the [googleapis-common-protos](https://pypi.org/project/googleapis-common-protos/) library, but the library is not specified as a dependency.

This adds that library as a dependency to make sure it is installed, so users won't hit an issue trying to import to Protobuf schema registry code in case they don't have googleapis-common-protos installed.

Checklist
------------------
- [ ] Contains customer facing changes? Including API/behavior changes <!-- This can help identify if it has introduced any breaking changes -->
- [ ] Did you add sufficient unit test and/or integration test coverage for this PR?
  - If not, please explain why it is not required

References
----------
JIRA: 
<!--
Copy&paste links: to Jira ticket, other PRs, issues, Slack conversations...
For code bumps: link to PR, tag or GitHub `/compare/master...master`
-->

Test & Review
------------
<!--
Has it been tested? how?
Copy&paste any handy instructions, steps or requirements that can save time to the reviewer or any reader.
-->

Open questions / Follow-ups
--------------------------
<!--
Optional: anything open to discussion for the reviewer, out of scope, or follow-ups.
-->

<!--
Review stakeholders
------------------
<!--
Optional: mention stakeholders or if special context that is required to review.
-->
