### PR TITLE
Keep previous (setup.py) schema registry optional dependency name for compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ include-package-data = false
 [tool.setuptools.dynamic]
 dependencies = {file = ["requirements/requirements.txt"]}
 optional-dependencies.schemaregistry = { file = ["requirements/requirements-schemaregistry.txt"] }
+optional-dependencies.schema_registry = { file = ["requirements/requirements-schemaregistry.txt"] }
 optional-dependencies.rules = { file = ["requirements/requirements-rules.txt", "requirements/requirements-schemaregistry.txt"] }
 optional-dependencies.avro = { file = ["requirements/requirements-avro.txt", "requirements/requirements-schemaregistry.txt"] }
 optional-dependencies.json = { file = ["requirements/requirements-json.txt", "requirements/requirements-schemaregistry.txt"] }


### PR DESCRIPTION
In rare cases this dependency was used alone, but its dependencies were also included in avro, json or protobuf extras, so this is a minor fix.
Optional dependencies cannot be named with a hyphen so when used in requirements.txt files or pip install they will be replaced with an underscore.


<!--
Suggested PR template: Fill/delete/add sections as needed. Optionally delete any commented block.
-->
What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include implementation strategy.
-->

Checklist
------------------
- [ ] Contains customer facing changes? Including API/behavior changes <!-- This can help identify if it has introduced any breaking changes -->
- [ ] Did you add sufficient unit test and/or integration test coverage for this PR?



Test & Review
------------
  - it can be tested by running `pip install .[schema-registry]` as happened in previous versions.
