### PR TITLE
Feat: Add custom JSON encoder/decoder support

### DIFF
--- a/requirements/requirements-tests.txt
+++ b/requirements/requirements-tests.txt
@@ -2,6 +2,7 @@
 urllib3<2; python_version<="3.7"
 urllib3<3; python_version>"3.7"
 flake8
+orjson
 pytest
 pytest-timeout
 requests-mock

--- a/tests/schema_registry/test_json.py
+++ b/tests/schema_registry/test_json.py
@@ -16,10 +16,19 @@
 # limitations under the License.
 #
 
+import json
+from unittest.mock import Mock
+
+import orjson
 import pytest
 
-from confluent_kafka.schema_registry import SchemaReference, Schema
-from confluent_kafka.schema_registry.json_schema import JSONDeserializer
+from confluent_kafka.schema_registry import (
+    Schema,
+    SchemaReference,
+    SchemaRegistryClient,
+)
+from confluent_kafka.schema_registry.json_schema import JSONDeserializer, JSONSerializer
+from confluent_kafka.serialization import SerializationContext
 
 
 def test_json_deserializer_referenced_schema_no_schema_registry_client(load_avsc):
@@ -41,3 +50,137 @@ def test_json_deserializer_invalid_schema_type():
     """
     with pytest.raises(TypeError, match="You must pass either str or Schema"):
         JSONDeserializer(1)
+
+
+def test_custom_json_encoder():
+    """Test custom JSON encoder using orjson for better performance"""
+    schema_str = """
+    {
+        "type": "object",
+        "properties": {
+            "name": {"type": "string"},
+            "age": {"type": "integer"}
+        }
+    }"""
+
+    test_data = {"name": "John", "age": 30}
+    ctx = SerializationContext("topic-name", "value")
+
+    # Create mock SchemaRegistryClient
+    mock_schema_registry_client = Mock(spec=SchemaRegistryClient)
+    mock_schema_registry_client.register_schema.return_value = 1  # schema_id
+
+    # Use orjson.dumps as the custom encoder
+    serializer = JSONSerializer(
+        schema_str, mock_schema_registry_client, json_encode=orjson.dumps
+    )
+
+    result = serializer(test_data, ctx)
+
+    # Since result includes schema registry framing (5 bytes prefix),
+    # we need to decode from bytes starting after the prefix
+    decoded = orjson.loads(result[5:])
+    assert decoded["name"] == "John"
+    assert decoded["age"] == 30
+
+
+def test_custom_json_decoder():
+    """Test custom JSON decoder using orjson for better performance"""
+    schema_str = """
+    {
+        "type": "object",
+        "properties": {
+            "name": {"type": "string"},
+            "age": {"type": "integer"}
+        }
+    }"""
+
+    test_data = b'\x00\x00\x00\x00\x01{"name": "John", "age": 30}'
+
+    # Use orjson for decoding with custom transformation
+    def custom_decoder(data):
+        decoded = orjson.loads(data)
+        return {k.upper(): v for k, v in decoded.items()}
+
+    deserializer = JSONDeserializer(schema_str, json_decode=custom_decoder)
+    ctx = SerializationContext("topic-name", "value")
+    result = deserializer(test_data, ctx)
+
+    # Verify custom decoder transformed keys to uppercase
+    assert result["NAME"] == "John"
+    assert result["AGE"] == 30
+
+
+def test_custom_encoder_decoder_chain():
+    """Test serialization/deserialization chain with custom encoding"""
+    schema_str = """
+    {
+        "type": "object",
+        "properties": {
+            "data": {"type": "string"}
+        }
+    }"""
+
+    test_data = {"data": "test value"}
+    ctx = SerializationContext("topic-name", "value")
+
+    mock_schema_registry_client = Mock(spec=SchemaRegistryClient)
+    mock_schema_registry_client.register_schema.return_value = 1
+
+    def custom_encoder(obj):
+        return orjson.dumps(obj, option=orjson.OPT_SORT_KEYS)
+
+    def custom_decoder(data):
+        return orjson.loads(data)
+
+    serializer = JSONSerializer(
+        schema_str,
+        mock_schema_registry_client,
+        json_encode=custom_encoder,
+    )
+    deserializer = JSONDeserializer(schema_str, json_decode=custom_decoder)
+
+    # Serialize then deserialize
+    encoded = serializer(test_data, ctx)
+    decoded = deserializer(encoded, ctx)
+
+    assert decoded == test_data
+
+
+def test_custom_encoding_with_complex_data():
+    """Test custom encoding with nested structures"""
+    schema_str = """
+    {
+        "type": "object",
+        "properties": {
+            "nested": {
+                "type": "object",
+                "properties": {
+                    "array": {"type": "array", "items": {"type": "integer"}},
+                    "string": {"type": "string"}
+                }
+            }
+        }
+    }"""
+
+    test_data = {"nested": {"array": [1, 2, 3], "string": "test"}}
+    mock_schema_registry_client = Mock(spec=SchemaRegistryClient)
+    mock_schema_registry_client.register_schema.return_value = 1
+
+    def custom_encoder(obj):
+        return json.dumps(obj, indent=2)
+
+    def custom_decoder(data):
+        return json.loads(data)
+
+    serializer = JSONSerializer(
+        schema_str,
+        mock_schema_registry_client,
+        json_encode=custom_encoder,
+    )
+    deserializer = JSONDeserializer(schema_str, json_decode=custom_decoder)
+    ctx = SerializationContext("topic-name", "value")
+    encoded = serializer(test_data, ctx)
+    decoded = deserializer(encoded, ctx)
+
+    assert decoded == test_data

--- a/tests/schema_registry/test_json.py
+++ b/tests/schema_registry/test_json.py
@@ -28,6 +28,7 @@ from confluent_kafka.schema_registry import (
     SchemaRegistryClient,
 )
 from confluent_kafka.schema_registry.json_schema import JSONDeserializer, JSONSerializer
+from confluent_kafka.schema_registry.rule_registry import RuleRegistry
 from confluent_kafka.serialization import SerializationContext
 
 
@@ -72,7 +73,8 @@ def test_custom_json_encoder():
 
     # Use orjson.dumps as the custom encoder
     serializer = JSONSerializer(
-        schema_str, mock_schema_registry_client, json_encode=orjson.dumps
+        schema_str, mock_schema_registry_client, json_encode=orjson.dumps,
+        rule_registry=RuleRegistry()
     )
 
     result = serializer(test_data, ctx)
@@ -102,7 +104,8 @@ def test_custom_json_decoder():
         decoded = orjson.loads(data)
         return {k.upper(): v for k, v in decoded.items()}
 
-    deserializer = JSONDeserializer(schema_str, json_decode=custom_decoder)
+    deserializer = JSONDeserializer(schema_str, json_decode=custom_decoder,
+                                    rule_registry=RuleRegistry())
     ctx = SerializationContext("topic-name", "value")
     result = deserializer(test_data, ctx)
 
@@ -137,8 +140,10 @@ def test_custom_encoder_decoder_chain():
         schema_str,
         mock_schema_registry_client,
         json_encode=custom_encoder,
+        rule_registry=RuleRegistry()
     )
-    deserializer = JSONDeserializer(schema_str, json_decode=custom_decoder)
+    deserializer = JSONDeserializer(schema_str, json_decode=custom_decoder,
+                                    rule_registry=RuleRegistry())
 
     # Serialize then deserialize
     encoded = serializer(test_data, ctx)
@@ -177,8 +182,10 @@ def test_custom_encoding_with_complex_data():
         schema_str,
         mock_schema_registry_client,
         json_encode=custom_encoder,
+        rule_registry=RuleRegistry()
     )
-    deserializer = JSONDeserializer(schema_str, json_decode=custom_decoder)
+    deserializer = JSONDeserializer(schema_str, json_decode=custom_decoder,
+                                    rule_registry=RuleRegistry())
     ctx = SerializationContext("topic-name", "value")
     encoded = serializer(test_data, ctx)
     decoded = deserializer(encoded, ctx)


### PR DESCRIPTION
<!--
Suggested PR template: Fill/delete/add sections as needed. Optionally delete any commented block.
-->
What
### Added
- Custom JSON encoder/decoder support for JSONSerializer and JSONDeserializer
- New optional parameters:
  - `json_encode` in JSONSerializer
  - `json_decode` in JSONDeserializer 

### Enhanced
- Serialization performance optimization capability through custom encoders
- Support for alternative JSON libraries (e.g., orjson)
- Flexible JSON transformation during encoding/decoding

### Test Coverage Added
- test_custom_json_encoder: Validates custom encoder functionality using orjson
- test_custom_json_decoder: Verifies custom decoder with key transformation
- test_custom_encoder_decoder_chain: Tests full serialization/deserialization cycle
- test_custom_encoding_with_complex_data: Validates nested structure handling
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include implementation strategy.
-->

Checklist
------------------
- [ ] Contains customer facing changes? Including API/behavior changes <!-- This can help identify if it has introduced any breaking changes -->
- [X] Did you add sufficient unit test and/or integration test coverage for this PR?
- 
References
----------
JIRA: 
https://github.com/confluentinc/confluent-kafka-python/issues/1916
<!--
Copy&paste links: to Jira ticket, other PRs, issues, Slack conversations...
For code bumps: link to PR, tag or GitHub `/compare/master...master`
-->

Test & Review

Test cases are added,
Also final Example Usage:

```python
import orjson
serializer = JSONSerializer(schema_str, client, json_encode=orjson.dumps)
deserializer = JSONDeserializer(schema_str, json_decode=orjson.loads)
```
------------
<!--
Has it been tested? how? 
Copy&paste any handy instructions, steps or requirements that can save time to the reviewer or any reader.
-->

Open questions / Follow-ups
--------------------------
<!--
Optional: anything open to discussion for the reviewer, out of scope, or follow-ups.
-->

<!--
Review stakeholders
------------------
<!--
Optional: mention stakeholders or if special context that is required to review.
-->
