### PR TITLE
fix: Handled ctx=None for AvroDeserializer and ProtobufDeserializer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Confluent's Python client for Apache Kafka
 
+## v2.10.1
+
+v2.10.0 is a fix release with the following fixes
+
+- Handled `None` value for optional `ctx` parameter in  `ProtobufDeserializer` (#1939)
+- Handled `None` value for optional `ctx` parameter in  `AvroDeserializer` (#1973)
+
 ## v2.10.0
 
 v2.10.0 is a feature release with the following fixes and enhancements:

--- a/src/confluent_kafka/schema_registry/avro.py
+++ b/src/confluent_kafka/schema_registry/avro.py
@@ -557,7 +557,7 @@ class AvroDeserializer(BaseDeserializer):
                                      "message was not produced with a Confluent "
                                      "Schema Registry serializer".format(len(data)))
 
-        subject = self._subject_name_func(ctx, None)
+        subject = self._subject_name_func(ctx, None) if ctx else None
         latest_schema = None
         if subject is not None:
             latest_schema = self._get_reader_schema(subject)
@@ -573,7 +573,7 @@ class AvroDeserializer(BaseDeserializer):
             writer_schema = self._get_parsed_schema(writer_schema_raw)
 
             if subject is None:
-                subject = self._subject_name_func(ctx, writer_schema.get("name"))
+                subject = self._subject_name_func(ctx, writer_schema.get("name")) if ctx else None
                 if subject is not None:
                     latest_schema = self._get_reader_schema(subject)
 

--- a/src/confluent_kafka/schema_registry/protobuf.py
+++ b/src/confluent_kafka/schema_registry/protobuf.py
@@ -565,14 +565,15 @@ class ProtobufSerializer(BaseSerializer):
             raise ValueError("message must be of type {} not {}"
                              .format(self._msg_class, type(message)))
 
-        subject = self._subject_name_func(ctx,
-                                          message.DESCRIPTOR.full_name)
-        latest_schema = self._get_reader_schema(subject, fmt='serialized')
+        subject = self._subject_name_func(ctx, message.DESCRIPTOR.full_name) if ctx else None
+        latest_schema = None
+        if subject is not None:
+            latest_schema = self._get_reader_schema(subject, fmt='serialized')
+
         if latest_schema is not None:
             self._schema_id = latest_schema.schema_id
-        elif subject not in self._known_subjects:
-            references = self._resolve_dependencies(
-                ctx, message.DESCRIPTOR.file)
+        elif subject not in self._known_subjects and ctx is not None:
+            references = self._resolve_dependencies(ctx, message.DESCRIPTOR.file)
             self._schema = Schema(
                 self._schema.schema_str,
                 self._schema.schema_type,


### PR DESCRIPTION
Handled `None` value for optional parameter called `ctx` in both AvroDeserializer and ProtobufDeserializer.

closes #1939
closes #1973

----

The "optional" `ctx` parameter in `__call__` method in AvroDeserializer and ProtobufDeserializer isn't optional at all... Despite method annotation that specifies type of this parameter as `ctx: Optional[SerializationContext] = None` is was required in the method logic and `None` value wasn't handled. This misbehavior (compered to previous releases) was already noticed in the issues mentioned above.

This PR contains fix that handles None value and hence gives backward compatibility.

Checklist
------------------
- [x] Contains customer facing changes? Including API/behavior changes <!-- This can help identify if it has introduced any breaking changes -->
- [x] Did you add sufficient unit test and/or integration test coverage for this PR?

References
----------
GH:
- #1939 
- #1973 

Open questions / Follow-ups
--------------------------

If this behavior is intended for some reason I would suggest:
- marking it as breaking change (e.g. version 3.0.0)
- changing type annotation for `ctx` parameter 

