### PR TITLE
Update requirements-schemaregistry.txt - authlib min version

### DIFF
--- a/requirements/requirements-schemaregistry.txt
+++ b/requirements/requirements-schemaregistry.txt
@@ -1,4 +1,4 @@
 attrs
 cachetools
 httpx>=0.26
-authlib
+authlib>=1.0.0


### PR DESCRIPTION
What
----
[Recent changes have added an authlib dependency](https://github.com/confluentinc/confluent-kafka-python/commit/4a3694bf7908cee8b474ee83095c114d522cacf4) to schema registry code - specifically, `from authlib.integrations.httpx_client import OAuth2Client`

This is code that does not exist in older authlib versions (added [here](https://github.com/lepture/authlib/commit/f965634004ceb66b77a9feadd84ead2131276c68)) and thus will break on import, if confluent_kafka is added to a repo which already contains an older version of authlib, since it "satisfies the dependency".
**Theoretically** one can use authlib >= 0.13.0, **but** since the next couple of versions are all "fix httpx", the first version I would trust to not break compatibility with what you tested would be version 1.0.0.

Checklist
------------------
- [ ] Contains customer facing changes? Including API/behavior changes
- [ ] Did you add sufficient unit test and/or integration test coverage for this PR?
  - Tested the min version, this adds no new code

References
----------

Test & Review
------------
Tested both import and usage with 1.0.0, works fine