### PR TITLE
Minor workaround for PyCharm syntax checker

### DIFF
--- a/src/confluent_kafka/schema_registry/_async/avro.py
+++ b/src/confluent_kafka/schema_registry/_async/avro.py
@@ -184,7 +184,7 @@ class AsyncAvroSerializer(AsyncBaseSerializer):
                      'subject.name.strategy': topic_subject_name_strategy,
                      'schema.id.serializer': prefix_schema_id_serializer}
 
-    async def __init__(
+    async def __init_impl(
         self,
         schema_registry_client: AsyncSchemaRegistryClient,
         schema_str: Union[str, Schema, None] = None,
@@ -281,6 +281,8 @@ class AsyncAvroSerializer(AsyncBaseSerializer):
         for rule in self._rule_registry.get_executors():
             rule.configure(self._registry.config() if self._registry else {},
                            rule_conf if rule_conf else {})
+
+    __init__ = __init_impl
 
     def __call__(self, obj: object, ctx: Optional[SerializationContext] = None) -> Optional[bytes]:
         return self.__serialize(obj, ctx)
@@ -436,7 +438,7 @@ class AsyncAvroDeserializer(AsyncBaseDeserializer):
                      'subject.name.strategy': topic_subject_name_strategy,
                      'schema.id.deserializer': dual_schema_id_deserializer}
 
-    async def __init__(
+    async def __init_impl(
         self,
         schema_registry_client: AsyncSchemaRegistryClient,
         schema_str: Union[str, Schema, None] = None,
@@ -504,6 +506,8 @@ class AsyncAvroDeserializer(AsyncBaseDeserializer):
         for rule in self._rule_registry.get_executors():
             rule.configure(self._registry.config() if self._registry else {},
                            rule_conf if rule_conf else {})
+
+    __init__ = __init_impl
 
     def __call__(self, data: bytes, ctx: Optional[SerializationContext] = None) -> Union[dict, object, None]:
         return self.__deserialize(data, ctx)

--- a/src/confluent_kafka/schema_registry/_async/json_schema.py
+++ b/src/confluent_kafka/schema_registry/_async/json_schema.py
@@ -201,7 +201,7 @@ class AsyncJSONSerializer(AsyncBaseSerializer):
                      'schema.id.serializer': prefix_schema_id_serializer,
                      'validate': True}
 
-    async def __init__(
+    async def __init_impl(
         self,
         schema_str: Union[str, Schema, None],
         schema_registry_client: AsyncSchemaRegistryClient,
@@ -292,6 +292,8 @@ class AsyncJSONSerializer(AsyncBaseSerializer):
         for rule in self._rule_registry.get_executors():
             rule.configure(self._registry.config() if self._registry else {},
                            rule_conf if rule_conf else {})
+
+    __init__ = __init_impl
 
     def __call__(self, obj: object, ctx: Optional[SerializationContext] = None) -> Optional[bytes]:
         return self.__serialize(obj, ctx)
@@ -468,7 +470,7 @@ class AsyncJSONDeserializer(AsyncBaseDeserializer):
                      'schema.id.deserializer': dual_schema_id_deserializer,
                      'validate': True}
 
-    async def __init__(
+    async def __init_impl(
         self,
         schema_str: Union[str, Schema, None],
         from_dict: Optional[Callable[[dict, SerializationContext], object]] = None,
@@ -546,6 +548,8 @@ class AsyncJSONDeserializer(AsyncBaseDeserializer):
         for rule in self._rule_registry.get_executors():
             rule.configure(self._registry.config() if self._registry else {},
                            rule_conf if rule_conf else {})
+
+    __init__ = __init_impl
 
     def __call__(self, data: bytes, ctx: Optional[SerializationContext] = None) -> Optional[bytes]:
         return self.__serialize(data, ctx)

--- a/src/confluent_kafka/schema_registry/_async/protobuf.py
+++ b/src/confluent_kafka/schema_registry/_async/protobuf.py
@@ -201,7 +201,7 @@ class AsyncProtobufSerializer(AsyncBaseSerializer):
         'use.deprecated.format': False,
     }
 
-    async def __init__(
+    async def __init_impl(
         self,
         msg_type: Message,
         schema_registry_client: AsyncSchemaRegistryClient,
@@ -281,6 +281,8 @@ class AsyncProtobufSerializer(AsyncBaseSerializer):
         for rule in self._rule_registry.get_executors():
             rule.configure(self._registry.config() if self._registry else {},
                            rule_conf if rule_conf else {})
+
+    __init__ = __init_impl
 
     @staticmethod
     def _write_varint(buf: io.BytesIO, val: int, zigzag: bool = True):
@@ -495,7 +497,7 @@ class AsyncProtobufDeserializer(AsyncBaseDeserializer):
         'use.deprecated.format': False,
     }
 
-    async def __init__(
+    async def __init_impl(
         self,
         message_type: Message,
         conf: Optional[dict] = None,
@@ -543,6 +545,8 @@ class AsyncProtobufDeserializer(AsyncBaseDeserializer):
         for rule in self._rule_registry.get_executors():
             rule.configure(self._registry.config() if self._registry else {},
                            rule_conf if rule_conf else {})
+
+    __init__ = __init_impl
 
     def __call__(self, data: bytes, ctx: Optional[SerializationContext] = None) -> Optional[bytes]:
         return self.__serialize(data, ctx)

--- a/src/confluent_kafka/schema_registry/_sync/avro.py
+++ b/src/confluent_kafka/schema_registry/_sync/avro.py
@@ -184,7 +184,7 @@ class AvroSerializer(BaseSerializer):
                      'subject.name.strategy': topic_subject_name_strategy,
                      'schema.id.serializer': prefix_schema_id_serializer}
 
-    def __init__(
+    def __init_impl(
         self,
         schema_registry_client: SchemaRegistryClient,
         schema_str: Union[str, Schema, None] = None,
@@ -281,6 +281,8 @@ class AvroSerializer(BaseSerializer):
         for rule in self._rule_registry.get_executors():
             rule.configure(self._registry.config() if self._registry else {},
                            rule_conf if rule_conf else {})
+
+    __init__ = __init_impl
 
     def __call__(self, obj: object, ctx: Optional[SerializationContext] = None) -> Optional[bytes]:
         return self.__serialize(obj, ctx)
@@ -436,7 +438,7 @@ class AvroDeserializer(BaseDeserializer):
                      'subject.name.strategy': topic_subject_name_strategy,
                      'schema.id.deserializer': dual_schema_id_deserializer}
 
-    def __init__(
+    def __init_impl(
         self,
         schema_registry_client: SchemaRegistryClient,
         schema_str: Union[str, Schema, None] = None,
@@ -504,6 +506,8 @@ class AvroDeserializer(BaseDeserializer):
         for rule in self._rule_registry.get_executors():
             rule.configure(self._registry.config() if self._registry else {},
                            rule_conf if rule_conf else {})
+
+    __init__ = __init_impl
 
     def __call__(self, data: bytes, ctx: Optional[SerializationContext] = None) -> Union[dict, object, None]:
         return self.__deserialize(data, ctx)

--- a/src/confluent_kafka/schema_registry/_sync/json_schema.py
+++ b/src/confluent_kafka/schema_registry/_sync/json_schema.py
@@ -201,7 +201,7 @@ class JSONSerializer(BaseSerializer):
                      'schema.id.serializer': prefix_schema_id_serializer,
                      'validate': True}
 
-    def __init__(
+    def __init_impl(
         self,
         schema_str: Union[str, Schema, None],
         schema_registry_client: SchemaRegistryClient,
@@ -292,6 +292,8 @@ class JSONSerializer(BaseSerializer):
         for rule in self._rule_registry.get_executors():
             rule.configure(self._registry.config() if self._registry else {},
                            rule_conf if rule_conf else {})
+
+    __init__ = __init_impl
 
     def __call__(self, obj: object, ctx: Optional[SerializationContext] = None) -> Optional[bytes]:
         return self.__serialize(obj, ctx)
@@ -468,7 +470,7 @@ class JSONDeserializer(BaseDeserializer):
                      'schema.id.deserializer': dual_schema_id_deserializer,
                      'validate': True}
 
-    def __init__(
+    def __init_impl(
         self,
         schema_str: Union[str, Schema, None],
         from_dict: Optional[Callable[[dict, SerializationContext], object]] = None,
@@ -546,6 +548,8 @@ class JSONDeserializer(BaseDeserializer):
         for rule in self._rule_registry.get_executors():
             rule.configure(self._registry.config() if self._registry else {},
                            rule_conf if rule_conf else {})
+
+    __init__ = __init_impl
 
     def __call__(self, data: bytes, ctx: Optional[SerializationContext] = None) -> Optional[bytes]:
         return self.__serialize(data, ctx)

--- a/src/confluent_kafka/schema_registry/_sync/protobuf.py
+++ b/src/confluent_kafka/schema_registry/_sync/protobuf.py
@@ -201,7 +201,7 @@ class ProtobufSerializer(BaseSerializer):
         'use.deprecated.format': False,
     }
 
-    def __init__(
+    def __init_impl(
         self,
         msg_type: Message,
         schema_registry_client: SchemaRegistryClient,
@@ -281,6 +281,8 @@ class ProtobufSerializer(BaseSerializer):
         for rule in self._rule_registry.get_executors():
             rule.configure(self._registry.config() if self._registry else {},
                            rule_conf if rule_conf else {})
+
+    __init__ = __init_impl
 
     @staticmethod
     def _write_varint(buf: io.BytesIO, val: int, zigzag: bool = True):
@@ -495,7 +497,7 @@ class ProtobufDeserializer(BaseDeserializer):
         'use.deprecated.format': False,
     }
 
-    def __init__(
+    def __init_impl(
         self,
         message_type: Message,
         conf: Optional[dict] = None,
@@ -543,6 +545,8 @@ class ProtobufDeserializer(BaseDeserializer):
         for rule in self._rule_registry.get_executors():
             rule.configure(self._registry.config() if self._registry else {},
                            rule_conf if rule_conf else {})
+
+    __init__ = __init_impl
 
     def __call__(self, data: bytes, ctx: Optional[SerializationContext] = None) -> Optional[bytes]:
         return self.__serialize(data, ctx)


### PR DESCRIPTION
<!--
Suggested PR template: Fill/delete/add sections as needed. Optionally delete any commented block.
-->
What
----
Pycharm complains if `__init__` is defined as async.  This PR uses the workaround as described in https://youtrack.jetbrains.com/issue/PY-42925/bug-pycharm-incorrectly-stating-function-init-cannot-be-async
<!--
Briefly describe **what** you have changed and **why**.
Optionally include implementation strategy.
-->

Checklist
------------------
- [ ] Contains customer facing changes? Including API/behavior changes <!-- This can help identify if it has introduced any breaking changes -->
- [ ] Did you add sufficient unit test and/or integration test coverage for this PR?
  - If not, please explain why it is not required

References
----------
JIRA: 
<!--
Copy&paste links: to Jira ticket, other PRs, issues, Slack conversations...
For code bumps: link to PR, tag or GitHub `/compare/master...master`
-->

Test & Review
------------
<!--
Has it been tested? how?
Copy&paste any handy instructions, steps or requirements that can save time to the reviewer or any reader.
-->

Open questions / Follow-ups
--------------------------
<!--
Optional: anything open to discussion for the reviewer, out of scope, or follow-ups.
-->

<!--
Review stakeholders
------------------
<!--
Optional: mention stakeholders or if special context that is required to review.
-->
