### PR TITLE
Set registered schema subject correctly

### DIFF
--- a/src/confluent_kafka/schema_registry/_async/schema_registry_client.py
+++ b/src/confluent_kafka/schema_registry/_async/schema_registry_client.py
@@ -645,7 +645,15 @@ class AsyncSchemaRegistryClient(object):
             'subjects/{}/versions?normalize={}'.format(_urlencode(subject_name), normalize_schemas),
             body=request)
 
-        registered_schema = RegisteredSchema.from_dict(response)
+        result = RegisteredSchema.from_dict(response)
+
+        registered_schema = RegisteredSchema(
+            schema_id=result.schema_id,
+            guid=result.guid,
+            subject=result.subject or subject_name,
+            version=result.version,
+            schema=result.schema,
+        )
 
         # The registered schema may not be fully populated
         s = registered_schema.schema if registered_schema.schema.schema_str is not None else schema

--- a/src/confluent_kafka/schema_registry/_sync/schema_registry_client.py
+++ b/src/confluent_kafka/schema_registry/_sync/schema_registry_client.py
@@ -655,7 +655,6 @@ class SchemaRegistryClient(object):
             schema=result.schema,
         )
 
-
         # The registered schema may not be fully populated
         s = registered_schema.schema if registered_schema.schema.schema_str is not None else schema
         self._cache.set_schema(subject_name, registered_schema.schema_id,

--- a/src/confluent_kafka/schema_registry/_sync/schema_registry_client.py
+++ b/src/confluent_kafka/schema_registry/_sync/schema_registry_client.py
@@ -645,7 +645,16 @@ class SchemaRegistryClient(object):
             'subjects/{}/versions?normalize={}'.format(_urlencode(subject_name), normalize_schemas),
             body=request)
 
-        registered_schema = RegisteredSchema.from_dict(response)
+        result = RegisteredSchema.from_dict(response)
+
+        registered_schema = RegisteredSchema(
+            schema_id=result.schema_id,
+            guid=result.guid,
+            subject=result.subject or subject_name,
+            version=result.version,
+            schema=result.schema,
+        )
+
 
         # The registered schema may not be fully populated
         s = registered_schema.schema if registered_schema.schema.schema_str is not None else schema


### PR DESCRIPTION
What
----
Schema Registry server on new schema registration with specifiied subject could return [no subject](https://docs.confluent.io/platform/current/schema-registry/develop/api.html#post--subjects-(string-%20subject)-versions) name in response,
like Confluent Schema Registry, so, register_schema_full_response method does not set it correctly, and returned registered schema is without subject.
This pull request fixs this issue.
