### PR TITLE
Initialize ducktape setup

### DIFF
--- a/tests/ducktape/README.md
+++ b/tests/ducktape/README.md
@@ -1,0 +1,24 @@
+# Ducktape Producer Tests
+
+Ducktape-based producer tests for the Confluent Kafka Python client.
+
+## Prerequisites
+
+- `pip install ducktape confluent-kafka`
+- Kafka running on `localhost:9092`
+
+## Running Tests
+
+```bash
+# Run all tests
+./tests/ducktape/run_ducktape_test.py
+
+# Run specific test
+./tests/ducktape/run_ducktape_test.py SimpleProducerTest.test_basic_produce
+```
+
+## Test Cases
+
+- **test_basic_produce**: Basic message production with callbacks
+- **test_produce_multiple_batches**: Parameterized tests (5, 10, 50 messages)  
+- **test_produce_with_compression**: Matrix tests (none, gzip, snappy)

--- a/tests/ducktape/__init__.py
+++ b/tests/ducktape/__init__.py
@@ -1,0 +1,1 @@
+# Ducktape tests for Confluent Kafka Python

--- a/tests/ducktape/run_ducktape_test.py
+++ b/tests/ducktape/run_ducktape_test.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""
+Simple test runner for Ducktape Producer tests
+"""
+import sys
+import os
+import subprocess
+import tempfile
+import json
+
+# Add the project root to Python path
+project_root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.insert(0, project_root)
+
+def create_cluster_config():
+    """Create a simple cluster configuration for local testing"""
+    cluster_config = {
+        "cluster_type": "ducktape.cluster.localhost.LocalhostCluster",
+        "num_nodes": 3
+    }
+    return cluster_config
+
+def create_test_config():
+    """Create test configuration file"""
+    config = {
+        "ducktape_dir": os.path.dirname(os.path.abspath(__file__)),
+        "results_dir": os.path.join(tempfile.gettempdir(), "ducktape_results")
+    }
+    return config
+
+def main():
+    """Run the ducktape producer test"""
+    print("Confluent Kafka Python - Ducktape Producer Test Runner")
+    print("=" * 60)
+    
+    # Check if ducktape is installed
+    try:
+        import ducktape
+        print(f"Using ducktape version: {ducktape.__version__}")
+    except ImportError:
+        print("ERROR: ducktape is not installed.")
+        print("Install it with: pip install ducktape")
+        return 1
+        
+    # Check if confluent_kafka is available
+    try:
+        import confluent_kafka
+        print(f"Using confluent-kafka version: {confluent_kafka.version()}")
+    except ImportError:
+        print("ERROR: confluent_kafka is not installed.")
+        print("Install it with: pip install confluent-kafka")
+        return 1
+    
+    # Get test directory and file
+    test_dir = os.path.dirname(os.path.abspath(__file__))
+    test_file = os.path.join(test_dir, "test_producer.py")
+    
+    if not os.path.exists(test_file):
+        print(f"ERROR: Test file not found: {test_file}")
+        return 1
+        
+    # Create results directory
+    results_dir = os.path.join(tempfile.gettempdir(), "ducktape_results")
+    os.makedirs(results_dir, exist_ok=True)
+    
+    print(f"Test file: {test_file}")
+    print(f"Results directory: {results_dir}")
+    print()
+    
+    # Build ducktape command
+    cmd = [
+        "ducktape",
+        "--debug",  # Enable debug output
+        "--results-root", results_dir,
+        "--cluster", "ducktape.cluster.localhost.LocalhostCluster",
+        "--default-num-nodes", "1",  # Reduced since we don't need nodes for services
+        test_file
+    ]
+    
+    # Add specific test if provided as argument
+    if len(sys.argv) > 1:
+        test_method = sys.argv[1]
+        cmd[-1] = f"{test_file}::{test_method}"
+        print(f"Running specific test: {test_method}")
+    else:
+        print("Running all producer tests")
+        
+    print("Command:", " ".join(cmd))
+    print()
+    
+    # Set up environment with proper Python path
+    env = os.environ.copy()
+    env['PYTHONPATH'] = project_root
+    
+    # Run the test
+    try:
+        result = subprocess.run(cmd, cwd=project_root, env=env)
+        return result.returncode
+    except KeyboardInterrupt:
+        print("\nTest interrupted by user")
+        return 1
+    except Exception as e:
+        print(f"Error running test: {e}")
+        return 1
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/ducktape/run_ducktape_test.py
+++ b/tests/ducktape/run_ducktape_test.py
@@ -7,10 +7,7 @@ import os
 import subprocess
 import tempfile
 import json
-
-# Add the project root to Python path
-project_root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-sys.path.insert(0, project_root)
+import ducktape
 
 def create_cluster_config():
     """Create a simple cluster configuration for local testing"""
@@ -33,14 +30,7 @@ def main():
     print("Confluent Kafka Python - Ducktape Producer Test Runner")
     print("=" * 60)
     
-    # Check if ducktape is installed
-    try:
-        import ducktape
-        print(f"Using ducktape version: {ducktape.__version__}")
-    except ImportError:
-        print("ERROR: ducktape is not installed.")
-        print("Install it with: pip install ducktape")
-        return 1
+    print(f"Using ducktape version: {ducktape.__version__}")
         
     # Check if confluent_kafka is available
     try:
@@ -51,7 +41,7 @@ def main():
         print("Install it with: pip install confluent-kafka")
         return 1
     
-    # Get test directory and file
+    # Get test file path (ducktape expects file paths, not module paths)
     test_dir = os.path.dirname(os.path.abspath(__file__))
     test_file = os.path.join(test_dir, "test_producer.py")
     
@@ -67,9 +57,9 @@ def main():
     print(f"Results directory: {results_dir}")
     print()
     
-    # Build ducktape command
+    # Build ducktape command using improved subprocess approach
     cmd = [
-        "ducktape",
+        sys.executable, "-m", "ducktape",
         "--debug",  # Enable debug output
         "--results-root", results_dir,
         "--cluster", "ducktape.cluster.localhost.LocalhostCluster",
@@ -88,13 +78,9 @@ def main():
     print("Command:", " ".join(cmd))
     print()
     
-    # Set up environment with proper Python path
-    env = os.environ.copy()
-    env['PYTHONPATH'] = project_root
-    
     # Run the test
     try:
-        result = subprocess.run(cmd, cwd=project_root, env=env)
+        result = subprocess.run(cmd)
         return result.returncode
     except KeyboardInterrupt:
         print("\nTest interrupted by user")

--- a/tests/ducktape/services/__init__.py
+++ b/tests/ducktape/services/__init__.py
@@ -1,0 +1,1 @@
+# Ducktape services for Confluent Kafka Python testing

--- a/tests/ducktape/services/kafka.py
+++ b/tests/ducktape/services/kafka.py
@@ -1,0 +1,100 @@
+"""
+Kafka client wrapper for Ducktape tests
+Assumes Kafka is already running on localhost:9092
+"""
+import time
+from ducktape.services.service import Service
+
+
+class KafkaClient(Service):
+    """Kafka client wrapper - assumes external Kafka is running"""
+    
+    def __init__(self, context, bootstrap_servers="localhost:9092"):
+        # Use num_nodes=0 since we're not managing any nodes
+        super(KafkaClient, self).__init__(context, num_nodes=0)
+        self.bootstrap_servers_str = bootstrap_servers
+        
+    def start_node(self, node):
+        """No-op since we assume Kafka is already running"""
+        self.logger.info("Assuming Kafka is already running on %s", self.bootstrap_servers_str)
+        
+    def stop_node(self, node):
+        """No-op since we don't manage the Kafka service"""
+        self.logger.info("Not stopping external Kafka service")
+        
+    def clean_node(self, node):
+        """No-op since we don't manage any files"""
+        self.logger.info("No cleanup needed for external Kafka service")
+                         
+    def bootstrap_servers(self):
+        """Get bootstrap servers string for clients"""
+        return self.bootstrap_servers_str
+        
+    def verify_connection(self):
+        """Verify that Kafka is accessible"""
+        try:
+            from confluent_kafka.admin import AdminClient
+            admin_client = AdminClient({'bootstrap.servers': self.bootstrap_servers_str})
+            
+            # Try to get cluster metadata to verify connection
+            metadata = admin_client.list_topics(timeout=10)
+            self.logger.info("Successfully connected to Kafka. Available topics: %s", 
+                           list(metadata.topics.keys()))
+            return True
+        except Exception as e:
+            self.logger.error("Failed to connect to Kafka at %s: %s", self.bootstrap_servers_str, e)
+            return False
+        
+    def create_topic(self, topic, partitions=1, replication_factor=1):
+        """Create a topic using Kafka admin client"""
+        try:
+            from confluent_kafka.admin import AdminClient, NewTopic
+            
+            admin_client = AdminClient({'bootstrap.servers': self.bootstrap_servers_str})
+            
+            topic_config = NewTopic(
+                topic=topic,
+                num_partitions=partitions,
+                replication_factor=replication_factor
+            )
+            
+            self.logger.info("Creating topic: %s (partitions=%d, replication=%d)", 
+                           topic, partitions, replication_factor)
+            
+            # Create topic
+            fs = admin_client.create_topics([topic_config])
+            
+            # Wait for topic creation to complete
+            for topic_name, f in fs.items():
+                try:
+                    f.result(timeout=30)  # Wait up to 30 seconds
+                    self.logger.info("Topic %s created successfully", topic_name)
+                except Exception as e:
+                    if "already exists" in str(e).lower():
+                        self.logger.info("Topic %s already exists", topic_name)
+                    else:
+                        self.logger.warning("Failed to create topic %s: %s", topic_name, e)
+                        
+        except ImportError:
+            self.logger.error("confluent_kafka not available for topic creation")
+        except Exception as e:
+            self.logger.error("Failed to create topic %s: %s", topic, e)
+            
+    def list_topics(self):
+        """List all topics using admin client"""
+        try:
+            from confluent_kafka.admin import AdminClient
+            
+            admin_client = AdminClient({'bootstrap.servers': self.bootstrap_servers_str})
+            metadata = admin_client.list_topics(timeout=10)
+            
+            topics = list(metadata.topics.keys())
+            self.logger.debug("Available topics: %s", topics)
+            return topics
+            
+        except ImportError:
+            self.logger.error("confluent_kafka not available for listing topics")
+            return []
+        except Exception as e:
+            self.logger.error("Failed to list topics: %s", e)
+            return []

--- a/tests/ducktape/test_producer.py
+++ b/tests/ducktape/test_producer.py
@@ -1,0 +1,216 @@
+"""
+Ducktape test for Confluent Kafka Python Producer
+Assumes Kafka is already running on localhost:9092
+"""
+import time
+from ducktape.tests.test import Test
+from ducktape.mark import matrix, parametrize
+
+from tests.ducktape.services.kafka import KafkaClient
+
+try:
+    from confluent_kafka import Producer, KafkaError
+except ImportError:
+    # Handle case where confluent_kafka is not installed
+    Producer = None
+    KafkaError = None
+
+
+class SimpleProducerTest(Test):
+    """Test basic producer functionality with external Kafka"""
+    
+    def __init__(self, test_context):
+        super(SimpleProducerTest, self).__init__(test_context=test_context)
+        
+        # Set up Kafka client (assumes external Kafka running)
+        self.kafka = KafkaClient(test_context, bootstrap_servers="localhost:9092")
+        
+    def setUp(self):
+        """Set up test environment"""
+        self.logger.info("Verifying connection to external Kafka at localhost:9092")
+        
+        if not self.kafka.verify_connection():
+            raise Exception("Cannot connect to Kafka at localhost:9092. "
+                          "Please ensure Kafka is running.")
+        
+        self.logger.info("Successfully connected to Kafka")
+        
+    def test_basic_produce(self):
+        """Test basic message production to a topic"""
+        if Producer is None:
+            self.logger.error("confluent_kafka not available, skipping test")
+            return
+            
+        topic_name = "test-topic"
+        num_messages = 10
+        
+        # Create topic
+        self.kafka.create_topic(topic_name, partitions=1, replication_factor=1)
+        
+        # Wait for topic to be created
+        time.sleep(2)
+        
+        # Verify topic exists
+        topics = self.kafka.list_topics()
+        assert topic_name in topics, f"Topic {topic_name} was not created. Available topics: {topics}"
+        
+        # Configure producer
+        producer_config = {
+            'bootstrap.servers': self.kafka.bootstrap_servers(),
+            'client.id': 'ducktape-test-producer'
+        }
+        
+        self.logger.info("Creating producer with config: %s", producer_config)
+        producer = Producer(producer_config)
+        
+        # Track delivery results
+        delivered_messages = []
+        failed_messages = []
+        
+        def delivery_callback(err, msg):
+            """Delivery report callback"""
+            if err is not None:
+                self.logger.error("Message delivery failed: %s", err)
+                failed_messages.append(err)
+            else:
+                self.logger.debug("Message delivered to %s [%d] at offset %d",
+                                msg.topic(), msg.partition(), msg.offset())
+                delivered_messages.append(msg)
+        
+        # Produce messages
+        self.logger.info("Producing %d messages to topic %s", num_messages, topic_name)
+        for i in range(num_messages):
+            message_value = f"Test message {i}"
+            message_key = f"key-{i}"
+            
+            producer.produce(
+                topic=topic_name,
+                value=message_value,
+                key=message_key,
+                callback=delivery_callback
+            )
+            
+            # Poll to trigger delivery callbacks
+            producer.poll(0)
+            
+        # Flush to ensure all messages are sent
+        self.logger.info("Flushing producer...")
+        producer.flush(timeout=30)
+        
+        # Verify all messages were delivered
+        self.logger.info("Delivered: %d, Failed: %d", len(delivered_messages), len(failed_messages))
+        
+        assert len(failed_messages) == 0, f"Some messages failed to deliver: {failed_messages}"
+        assert len(delivered_messages) == num_messages, \
+            f"Expected {num_messages} delivered messages, got {len(delivered_messages)}"
+            
+        self.logger.info("Successfully produced %d messages to topic %s", 
+                        len(delivered_messages), topic_name)
+                        
+    @parametrize(num_messages=5)
+    @parametrize(num_messages=10)
+    @parametrize(num_messages=50)
+    def test_produce_multiple_batches(self, num_messages):
+        """Test producing different numbers of messages"""
+        if Producer is None:
+            self.logger.error("confluent_kafka not available, skipping test")
+            return
+            
+        topic_name = f"batch-test-topic-{num_messages}"
+        
+        # Create topic
+        self.kafka.create_topic(topic_name, partitions=2, replication_factor=1)
+        time.sleep(2)
+        
+        # Configure producer
+        producer_config = {
+            'bootstrap.servers': self.kafka.bootstrap_servers(),
+            'client.id': f'batch-test-producer-{num_messages}',
+            'batch.size': 1000,  # Small batch size for testing
+            'linger.ms': 100     # Small linger time for testing
+        }
+        
+        producer = Producer(producer_config)
+        
+        delivered_count = [0]  # Use list to modify from callback
+        
+        def delivery_callback(err, msg):
+            if err is None:
+                delivered_count[0] += 1
+            else:
+                self.logger.error("Delivery failed: %s", err)
+                
+        # Produce messages
+        self.logger.info("Producing %d messages in batches", num_messages)
+        for i in range(num_messages):
+            producer.produce(
+                topic=topic_name,
+                value=f"Batch message {i}",
+                key=f"batch-key-{i % 10}",  # Use modulo for key distribution
+                callback=delivery_callback
+            )
+            
+            # Poll occasionally
+            if i % 10 == 0:
+                producer.poll(0)
+                
+        # Final flush
+        producer.flush(timeout=30)
+        
+        # Verify results
+        assert delivered_count[0] == num_messages, \
+            f"Expected {num_messages} delivered, got {delivered_count[0]}"
+            
+        self.logger.info("Successfully produced %d messages in batches", delivered_count[0])
+        
+    @matrix(compression_type=['none', 'gzip', 'snappy'])
+    def test_produce_with_compression(self, compression_type):
+        """Test producing messages with different compression types"""
+        if Producer is None:
+            self.logger.error("confluent_kafka not available, skipping test")
+            return
+            
+        topic_name = f"compression-test-{compression_type}"
+        
+        # Create topic
+        self.kafka.create_topic(topic_name, partitions=1, replication_factor=1)
+        time.sleep(2)
+        
+        # Configure producer with compression
+        producer_config = {
+            'bootstrap.servers': self.kafka.bootstrap_servers(),
+            'client.id': f'compression-test-{compression_type}',
+            'compression.type': compression_type
+        }
+        
+        producer = Producer(producer_config)
+        
+        # Create larger messages to test compression
+        large_message = "x" * 1000  # 1KB message
+        delivered_count = [0]
+        
+        def delivery_callback(err, msg):
+            if err is None:
+                delivered_count[0] += 1
+                
+        # Produce messages
+        self.logger.info("Producing messages with %s compression", compression_type)
+        for i in range(20):
+            producer.produce(
+                topic=topic_name,
+                value=f"{large_message}-{i}",
+                key=f"comp-key-{i}",
+                callback=delivery_callback
+            )
+            producer.poll(0)
+            
+        producer.flush(timeout=30)
+        
+        assert delivered_count[0] == 20, \
+            f"Expected 20 delivered messages, got {delivered_count[0]}"
+            
+        self.logger.info("Successfully produced 20 messages with %s compression", compression_type)
+        
+    def tearDown(self):
+        """Clean up test environment"""
+        self.logger.info("Test completed - external Kafka service remains running")

--- a/tests/ducktape/test_producer.py
+++ b/tests/ducktape/test_producer.py
@@ -47,12 +47,9 @@ class SimpleProducerTest(Test):
         # Create topic
         self.kafka.create_topic(topic_name, partitions=1, replication_factor=1)
         
-        # Wait for topic to be created
-        time.sleep(2)
-        
-        # Verify topic exists
-        topics = self.kafka.list_topics()
-        assert topic_name in topics, f"Topic {topic_name} was not created. Available topics: {topics}"
+        # Wait for topic to be available with retry logic
+        topic_ready = self.kafka.wait_for_topic(topic_name, max_wait_time=30)
+        assert topic_ready, f"Topic {topic_name} was not created within timeout. Available topics: {self.kafka.list_topics()}"
         
         # Configure producer
         producer_config = {
@@ -120,7 +117,10 @@ class SimpleProducerTest(Test):
         
         # Create topic
         self.kafka.create_topic(topic_name, partitions=2, replication_factor=1)
-        time.sleep(2)
+        
+        # Wait for topic to be available with retry logic
+        topic_ready = self.kafka.wait_for_topic(topic_name, max_wait_time=30)
+        assert topic_ready, f"Topic {topic_name} was not created within timeout"
         
         # Configure producer
         producer_config = {
@@ -174,7 +174,10 @@ class SimpleProducerTest(Test):
         
         # Create topic
         self.kafka.create_topic(topic_name, partitions=1, replication_factor=1)
-        time.sleep(2)
+        
+        # Wait for topic to be available with retry logic
+        topic_ready = self.kafka.wait_for_topic(topic_name, max_wait_time=30)
+        assert topic_ready, f"Topic {topic_name} was not created within timeout"
         
         # Configure producer with compression
         producer_config = {


### PR DESCRIPTION
Summary
----
This pull request introduces a new Ducktape-based integration test suite for the Confluent Kafka Python client, enabling automated producer tests against a locally running Kafka instance. 

**Ducktape test infrastructure and runner:**

* Added `run_ducktape_test.py` script to automate running Ducktape producer tests, with support for running all or specific test cases, environment setup, and result directory management.
* Created `services/kafka.py` with a `KafkaClient` wrapper to interact with an external Kafka instance, including topic management and connection verification.

**Producer test cases:**

* Implemented `test_producer.py` with the `SimpleProducerTest` class, covering basic message production, parameterized batch message tests, and matrix tests for different compression types.

**Documentation and structure:**

* Added a README (`README.md`) explaining prerequisites, usage, and available test cases for the Ducktape producer tests.
