### PR TITLE
Support key password for schema registry client.

### DIFF
--- a/requirements/requirements-schemaregistry.txt
+++ b/requirements/requirements-schemaregistry.txt
@@ -1,5 +1,6 @@
 attrs>=21.2.0
 cachetools>=5.5.0
+certifi
 httpx>=0.26
 authlib>=1.0.0
 orjson >= 3.10

--- a/src/confluent_kafka/schema_registry/_async/schema_registry_client.py
+++ b/src/confluent_kafka/schema_registry/_async/schema_registry_client.py
@@ -16,8 +16,11 @@
 # limitations under the License.
 #
 import asyncio
+import certifi
 import orjson
 import logging
+import os
+import ssl
 import time
 import urllib
 from urllib.parse import unquote, urlparse
@@ -147,24 +150,43 @@ class _AsyncBaseRestClient(object):
             raise ValueError("Missing required configuration property url")
         self.base_urls = base_urls
 
-        self.verify = True
-        ca = conf_copy.pop('ssl.ca.location', None)
-        if ca is not None:
-            self.verify = ca
-
+        ca: Union[str, bool, None] = conf_copy.pop('ssl.ca.location', None)
         key: Optional[str] = conf_copy.pop('ssl.key.location', None)
+        key_password: Optional[str] = conf_copy.pop('ssl.key.password', None)
         client_cert: Optional[str] = conf_copy.pop('ssl.certificate.location', None)
-        self.cert: Union[str, Tuple[str, str], None] = None
 
-        if client_cert is not None and key is not None:
-            self.cert = (client_cert, key)
+        # this mimicks legacy, deprecated behaviour of httpx
+        # self.verify is always set to an ssl.SSLContext in case we need to load_cert_chain
+        if ca is False:
+            self.verify = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+            self.verify.check_hostname = False
+            self.verify.verify_mode = ssl.CERT_NONE
+        elif isinstance(ca, str):
+            if os.path.isdir(ca):
+                self.verify = ssl.create_default_context(capath=ca)
+            else:
+                self.verify = ssl.create_default_context(cafile=ca)
+        else:
+            if os.environ.get("SSL_CERT_FILE"):
+                self.verify = ssl.create_default_context(cafile=os.environ["SSL_CERT_FILE"])
+            elif os.environ.get("SSL_CERT_DIR"):
+                self.verify = ssl.create_default_context(capath=os.environ["SSL_CERT_DIR"])
+            else:
+                self.verify = ssl.create_default_context(cafile=certifi.where())
 
-        if client_cert is not None and key is None:
-            self.cert = client_cert
+        if client_cert is not None:
+            if key is not None and key_password is not None:
+                self.verify.load_cert_chain(certfile=client_cert, keyfile=key, password=key_password)
+            elif key is not None:
+                self.verify.load_cert_chain(certfile=client_cert, keyfile=key)
+            elif key_password is not None:
+                self.verify.load_cert_chain(certfile=client_cert, password=key_password)
+            else:
+                self.verify.load_cert_chain(certfile=client_cert)
 
-        if key is not None and client_cert is None:
+        if (key is not None or key_password is not None) and client_cert is None:
             raise ValueError("ssl.certificate.location required when"
-                             " configuring ssl.key.location")
+                             " configuring ssl.key.location or ssl.key.password")
 
         parsed = urlparse(self.base_urls[0])
         try:
@@ -350,7 +372,6 @@ class _AsyncRestClient(_AsyncBaseRestClient):
 
         self.session = httpx.AsyncClient(
             verify=self.verify,
-            cert=self.cert,
             auth=self.auth,
             proxy=self.proxy,
             timeout=self.timeout
@@ -515,10 +536,18 @@ class AsyncSchemaRegistryClient(object):
     | ``ssl.key.location``         | str  |                                                 |
     |                              |      | ``ssl.certificate.location`` must also be set.  |
     +------------------------------+------+-------------------------------------------------+
-    |                              |      | Path to client's public key (PEM) used for      |
+    |                              |      | Password to use to decrypt the client's private |
+    |                              |      | key.                                            |
+    |                              |      |                                                 |
+    | ``ssl.key.password``         | str  | The private key may be provided using           |
+    |                              |      | ``ssl.key.location``, or bundled with the       |
+    |                              |      | certificate in ``ssl.certificate.location``.    |
+    |                              |      | Password is optional (key may be unencrypted).  |
+    +------------------------------+------+-------------------------------------------------+
+    |                              |      | Path to client's certificate (PEM) used for     |
     |                              |      | authentication.                                 |
     | ``ssl.certificate.location`` | str  |                                                 |
-    |                              |      | May be set without ssl.key.location if the      |
+    |                              |      | May be set without ``ssl.key.location`` if the  |
     |                              |      | private key is stored within the PEM as well.   |
     +------------------------------+------+-------------------------------------------------+
     |                              |      | Client HTTP credentials in the form of          |

--- a/src/confluent_kafka/schema_registry/_async/schema_registry_client.py
+++ b/src/confluent_kafka/schema_registry/_async/schema_registry_client.py
@@ -26,7 +26,7 @@ import urllib
 from urllib.parse import unquote, urlparse
 
 import httpx
-from typing import List, Dict, Optional, Union, Any, Tuple, Callable
+from typing import List, Dict, Optional, Union, Any, Callable
 
 from cachetools import TTLCache, LRUCache
 from httpx import Response

--- a/src/confluent_kafka/schema_registry/_sync/schema_registry_client.py
+++ b/src/confluent_kafka/schema_registry/_sync/schema_registry_client.py
@@ -16,8 +16,11 @@
 # limitations under the License.
 #
 
+import certifi
 import orjson
 import logging
+import os
+import ssl
 import time
 import urllib
 from urllib.parse import unquote, urlparse
@@ -147,24 +150,43 @@ class _BaseRestClient(object):
             raise ValueError("Missing required configuration property url")
         self.base_urls = base_urls
 
-        self.verify = True
-        ca = conf_copy.pop('ssl.ca.location', None)
-        if ca is not None:
-            self.verify = ca
-
+        ca: Union[str, bool, None] = conf_copy.pop('ssl.ca.location', None)
         key: Optional[str] = conf_copy.pop('ssl.key.location', None)
+        key_password: Optional[str] = conf_copy.pop('ssl.key.password', None)
         client_cert: Optional[str] = conf_copy.pop('ssl.certificate.location', None)
-        self.cert: Union[str, Tuple[str, str], None] = None
 
-        if client_cert is not None and key is not None:
-            self.cert = (client_cert, key)
+        # this mimicks legacy, deprecated behaviour of httpx
+        # self.verify is always set to an ssl.SSLContext in case we need to load_cert_chain
+        if ca is False:
+            self.verify = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+            self.verify.check_hostname = False
+            self.verify.verify_mode = ssl.CERT_NONE
+        elif isinstance(ca, str):
+            if os.path.isdir(ca):
+                self.verify = ssl.create_default_context(capath=ca)
+            else:
+                self.verify = ssl.create_default_context(cafile=ca)
+        else:
+            if os.environ.get("SSL_CERT_FILE"):
+                self.verify = ssl.create_default_context(cafile=os.environ["SSL_CERT_FILE"])
+            elif os.environ.get("SSL_CERT_DIR"):
+                self.verify = ssl.create_default_context(capath=os.environ["SSL_CERT_DIR"])
+            else:
+                self.verify = ssl.create_default_context(cafile=certifi.where())
 
-        if client_cert is not None and key is None:
-            self.cert = client_cert
+        if client_cert is not None:
+            if key is not None and key_password is not None:
+                self.verify.load_cert_chain(certfile=client_cert, keyfile=key, password=key_password)
+            elif key is not None:
+                self.verify.load_cert_chain(certfile=client_cert, keyfile=key)
+            elif key_password is not None:
+                self.verify.load_cert_chain(certfile=client_cert, password=key_password)
+            else:
+                self.verify.load_cert_chain(certfile=client_cert)
 
-        if key is not None and client_cert is None:
+        if (key is not None or key_password is not None) and client_cert is None:
             raise ValueError("ssl.certificate.location required when"
-                             " configuring ssl.key.location")
+                             " configuring ssl.key.location or ssl.key.password")
 
         parsed = urlparse(self.base_urls[0])
         try:
@@ -350,7 +372,6 @@ class _RestClient(_BaseRestClient):
 
         self.session = httpx.Client(
             verify=self.verify,
-            cert=self.cert,
             auth=self.auth,
             proxy=self.proxy,
             timeout=self.timeout
@@ -515,10 +536,18 @@ class SchemaRegistryClient(object):
     | ``ssl.key.location``         | str  |                                                 |
     |                              |      | ``ssl.certificate.location`` must also be set.  |
     +------------------------------+------+-------------------------------------------------+
-    |                              |      | Path to client's public key (PEM) used for      |
+    |                              |      | Password to use to decrypt the client's private |
+    |                              |      | key.                                            |
+    |                              |      |                                                 |
+    | ``ssl.key.password``         | str  | The private key may be provided using           |
+    |                              |      | ``ssl.key.location``, or bundled with the       |
+    |                              |      | certificate in ``ssl.certificate.location``.    |
+    |                              |      | Password is optional (key may be unencrypted).  |
+    +------------------------------+------+-------------------------------------------------+
+    |                              |      | Path to client's certificate (PEM) used for     |
     |                              |      | authentication.                                 |
     | ``ssl.certificate.location`` | str  |                                                 |
-    |                              |      | May be set without ssl.key.location if the      |
+    |                              |      | May be set without ``ssl.key.location`` if the  |
     |                              |      | private key is stored within the PEM as well.   |
     +------------------------------+------+-------------------------------------------------+
     |                              |      | Client HTTP credentials in the form of          |

--- a/src/confluent_kafka/schema_registry/_sync/schema_registry_client.py
+++ b/src/confluent_kafka/schema_registry/_sync/schema_registry_client.py
@@ -26,7 +26,7 @@ import urllib
 from urllib.parse import unquote, urlparse
 
 import httpx
-from typing import List, Dict, Optional, Union, Any, Tuple, Callable
+from typing import List, Dict, Optional, Union, Any, Callable
 
 from cachetools import TTLCache, LRUCache
 from httpx import Response

--- a/tests/schema_registry/_async/test_config.py
+++ b/tests/schema_registry/_async/test_config.py
@@ -68,7 +68,17 @@ def test_config_ssl_key_no_certificate():
     conf = {'url': TEST_URL,
             'ssl.key.location': '/ssl/keys/client'}
     with pytest.raises(ValueError, match="ssl.certificate.location required"
-                                         " when configuring ssl.key.location"):
+                                         " when configuring ssl.key.location"
+                                         " or ssl.key.password"):
+        AsyncSchemaRegistryClient(conf)
+
+
+def test_config_ssl_password_no_certificate():
+    conf = {'url': TEST_URL,
+            'ssl.key.password': 'sesame'}
+    with pytest.raises(ValueError, match="ssl.certificate.location required"
+                                         " when configuring ssl.key.location"
+                                         " or ssl.key.password"):
         AsyncSchemaRegistryClient(conf)
 
 

--- a/tests/schema_registry/_sync/test_config.py
+++ b/tests/schema_registry/_sync/test_config.py
@@ -68,7 +68,17 @@ def test_config_ssl_key_no_certificate():
     conf = {'url': TEST_URL,
             'ssl.key.location': '/ssl/keys/client'}
     with pytest.raises(ValueError, match="ssl.certificate.location required"
-                                         " when configuring ssl.key.location"):
+                                         " when configuring ssl.key.location"
+                                         " or ssl.key.password"):
+        SchemaRegistryClient(conf)
+
+
+def test_config_ssl_password_no_certificate():
+    conf = {'url': TEST_URL,
+            'ssl.key.password': 'sesame'}
+    with pytest.raises(ValueError, match="ssl.certificate.location required"
+                                         " when configuring ssl.key.location"
+                                         " or ssl.key.password"):
         SchemaRegistryClient(conf)
 
 


### PR DESCRIPTION
Support key password for schema registry client
----
When a client certificate is used, it is common for the private key to be encrypted. The schema registry client currently does not support this. This PR adds the support, at the same time migrating away from features that have been deprecated in current versions of `httpx`.

Checklist
------------------
- [X] Contains customer facing changes? Including API/behavior changes
- [X] Did you add sufficient unit test and/or integration test coverage for this PR?
  - I have updated the existing test covering this code, and added a new one. The existing coverage is slim, and I have not increased it, however all the heavy lifting is done by `httpx` and Python's `ssl` module.

References
----------
- `httpx` code that I have mimicked in part of this implementation (which however has a bug preventing usage of custom ca certs with client certificates which I have _not_ mimicked): https://github.com/encode/httpx/blob/26d48e0634e6ee9cdc0533996db289ce4b430177/httpx/_config.py#L23-L69
- `httpx` dependencies, indicating that `certifi` is a transitive dependency, so the direct dependency I have added is merely formal, not introducing any new dependency in practice: https://github.com/encode/httpx/blob/26d48e0634e6ee9cdc0533996db289ce4b430177/pyproject.toml#L31

Test & Review
------------
In addition to the updated unit tests, I am working on testing this in a real-world environment.