### PR TITLE
Fix 'propogation' a typo - 'propagation'

### DIFF
--- a/tests/integration/admin/test_basic_operations.py
+++ b/tests/integration/admin/test_basic_operations.py
@@ -208,7 +208,7 @@ def test_basic_operations(kafka_cluster):
     # Second iteration: create topic.
     #
     for validate in (True, False):
-        our_topic = kafka_cluster.create_topic_and_wait_propogation(topic_prefix,
+        our_topic = kafka_cluster.create_topic_and_wait_propagation(topic_prefix,
                                                                     {
                                                                         "num_partitions": num_partitions,
                                                                         "config": topic_config,

--- a/tests/integration/admin/test_delete_records.py
+++ b/tests/integration/admin/test_delete_records.py
@@ -25,7 +25,7 @@ def test_delete_records(kafka_cluster):
     admin_client = kafka_cluster.admin()
 
     # Create a topic with a single partition
-    topic = kafka_cluster.create_topic_and_wait_propogation("test-del-records",
+    topic = kafka_cluster.create_topic_and_wait_propagation("test-del-records",
                                                             {
                                                                 "num_partitions": 1,
                                                                 "replication_factor": 1,
@@ -73,12 +73,12 @@ def test_delete_records_multiple_topics_and_partitions(kafka_cluster):
     admin_client = kafka_cluster.admin()
     num_partitions = 3
     # Create two topics with a single partition
-    topic = kafka_cluster.create_topic_and_wait_propogation("test-del-records",
+    topic = kafka_cluster.create_topic_and_wait_propagation("test-del-records",
                                                             {
                                                                 "num_partitions": num_partitions,
                                                                 "replication_factor": 1,
                                                             })
-    topic2 = kafka_cluster.create_topic_and_wait_propogation("test-del-records2",
+    topic2 = kafka_cluster.create_topic_and_wait_propagation("test-del-records2",
                                                              {
                                                                  "num_partitions": num_partitions,
                                                                  "replication_factor": 1,

--- a/tests/integration/admin/test_describe_operations.py
+++ b/tests/integration/admin/test_describe_operations.py
@@ -204,7 +204,7 @@ def test_describe_operations(sasl_cluster):
 
     # Create Topic
     topic_config = {"compression.type": "gzip"}
-    our_topic = sasl_cluster.create_topic_and_wait_propogation(topic_prefix,
+    our_topic = sasl_cluster.create_topic_and_wait_propagation(topic_prefix,
                                                                {
                                                                    "num_partitions": 1,
                                                                    "config": topic_config,

--- a/tests/integration/admin/test_incremental_alter_configs.py
+++ b/tests/integration/admin/test_incremental_alter_configs.py
@@ -56,13 +56,13 @@ def test_incremental_alter_configs(kafka_cluster):
     num_partitions = 2
     topic_config = {"compression.type": "gzip"}
 
-    our_topic = kafka_cluster.create_topic_and_wait_propogation(topic_prefix,
+    our_topic = kafka_cluster.create_topic_and_wait_propagation(topic_prefix,
                                                                 {
                                                                     "num_partitions": num_partitions,
                                                                     "config": topic_config,
                                                                     "replication_factor": 1,
                                                                 })
-    our_topic2 = kafka_cluster.create_topic_and_wait_propogation(topic_prefix2,
+    our_topic2 = kafka_cluster.create_topic_and_wait_propagation(topic_prefix2,
                                                                  {
                                                                      "num_partitions": num_partitions,
                                                                      "config": topic_config,

--- a/tests/integration/admin/test_list_offsets.py
+++ b/tests/integration/admin/test_list_offsets.py
@@ -27,7 +27,7 @@ def test_list_offsets(kafka_cluster):
     admin_client = kafka_cluster.admin()
 
     # Create a topic with a single partition
-    topic = kafka_cluster.create_topic_and_wait_propogation("test-topic-verify-list-offsets",
+    topic = kafka_cluster.create_topic_and_wait_propagation("test-topic-verify-list-offsets",
                                                             {
                                                                 "num_partitions": 1,
                                                                 "replication_factor": 1,

--- a/tests/integration/cluster_fixture.py
+++ b/tests/integration/cluster_fixture.py
@@ -247,9 +247,9 @@ class KafkaClusterFixture(object):
         except Exception as e:
             print("Failed to delete topic {}: {}".format(topic, e))
 
-    def create_topic_and_wait_propogation(self, prefix, conf=None, **create_topic_kwargs):
+    def create_topic_and_wait_propagation(self, prefix, conf=None, **create_topic_kwargs):
         """
-        Creates a new topic with this cluster. Wait for the topic to be propogated to all brokers.
+        Creates a new topic with this cluster. Wait for the topic to be propagated to all brokers.
 
         :param str prefix: topic name
         :param dict conf: additions/overrides to topic configuration.
@@ -258,7 +258,7 @@ class KafkaClusterFixture(object):
         """
         name = self.create_topic(prefix, conf, **create_topic_kwargs)
 
-        # wait for topic propogation across all the brokers.
+        # wait for topic propagation across all the brokers.
         # FIXME: find a better way to wait for topic creation
         #        for all languages, given option to send request to
         #        a specific broker isn't present everywhere.

--- a/tests/integration/consumer/test_consumer_error.py
+++ b/tests/integration/consumer/test_consumer_error.py
@@ -29,7 +29,7 @@ def test_consume_error(kafka_cluster):
     Tests to ensure librdkafka errors are propagated as
     an instance of ConsumeError.
     """
-    topic = kafka_cluster.create_topic_and_wait_propogation("test_commit_transaction")
+    topic = kafka_cluster.create_topic_and_wait_propagation("test_commit_transaction")
     consumer_conf = {'group.id': 'pytest', 'enable.partition.eof': True}
 
     producer = kafka_cluster.producer()
@@ -59,7 +59,7 @@ def test_consume_error_commit(kafka_cluster):
     """
     Tests to ensure that we handle messages with errors when commiting.
     """
-    topic = kafka_cluster.create_topic_and_wait_propogation("test_commit_transaction")
+    topic = kafka_cluster.create_topic_and_wait_propagation("test_commit_transaction")
     consumer_conf = {'group.id': 'pytest',
                      'session.timeout.ms': 100}
 
@@ -91,7 +91,7 @@ def test_consume_error_store_offsets(kafka_cluster):
     """
     Tests to ensure that we handle messages with errors when storing offsets.
     """
-    topic = kafka_cluster.create_topic_and_wait_propogation("test_commit_transaction")
+    topic = kafka_cluster.create_topic_and_wait_propagation("test_commit_transaction")
     consumer_conf = {'group.id': 'pytest',
                      'session.timeout.ms': 100,
                      'enable.auto.offset.store': True,

--- a/tests/integration/consumer/test_consumer_memberid.py
+++ b/tests/integration/consumer/test_consumer_memberid.py
@@ -28,7 +28,7 @@ def test_consumer_memberid(kafka_cluster):
 
     topic = "testmemberid"
 
-    kafka_cluster.create_topic_and_wait_propogation(topic)
+    kafka_cluster.create_topic_and_wait_propagation(topic)
 
     consumer = kafka_cluster.consumer(consumer_conf)
 

--- a/tests/integration/consumer/test_consumer_topicpartition_metadata.py
+++ b/tests/integration/consumer/test_consumer_topicpartition_metadata.py
@@ -30,7 +30,7 @@ def commit_and_check(consumer, topic, metadata):
 
 
 def test_consumer_topicpartition_metadata(kafka_cluster):
-    topic = kafka_cluster.create_topic_and_wait_propogation("test_topicpartition")
+    topic = kafka_cluster.create_topic_and_wait_propagation("test_topicpartition")
     consumer_conf = {'group.id': 'test_topicpartition'}
 
     c = kafka_cluster.consumer(consumer_conf)

--- a/tests/integration/consumer/test_consumer_upgrade_downgrade.py
+++ b/tests/integration/consumer/test_consumer_upgrade_downgrade.py
@@ -79,7 +79,7 @@ def perform_consumer_upgrade_downgrade_test_with_partition_assignment_strategy(
     Test consumer upgrade and downgrade.
     """
     topic_name_prefix = f"{topic_prefix}_{partition_assignment_strategy}"
-    topic = kafka_cluster.create_topic_and_wait_propogation(topic_name_prefix,
+    topic = kafka_cluster.create_topic_and_wait_propagation(topic_name_prefix,
                                                             {
                                                                 "num_partitions": number_of_partitions
                                                             })

--- a/tests/integration/consumer/test_cooperative_rebalance_1.py
+++ b/tests/integration/consumer/test_cooperative_rebalance_1.py
@@ -60,8 +60,8 @@ def test_cooperative_rebalance_1(kafka_cluster):
 
     reb = RebalanceState()
 
-    topic1 = kafka_cluster.create_topic_and_wait_propogation("topic1")
-    topic2 = kafka_cluster.create_topic_and_wait_propogation("topic2")
+    topic1 = kafka_cluster.create_topic_and_wait_propagation("topic1")
+    topic2 = kafka_cluster.create_topic_and_wait_propagation("topic2")
 
     consumer = kafka_cluster.consumer(consumer_conf)
 

--- a/tests/integration/consumer/test_cooperative_rebalance_2.py
+++ b/tests/integration/consumer/test_cooperative_rebalance_2.py
@@ -52,7 +52,7 @@ def test_cooperative_rebalance_2(kafka_cluster):
 
     reb = RebalanceState()
 
-    topic1 = kafka_cluster.create_topic_and_wait_propogation("topic1")
+    topic1 = kafka_cluster.create_topic_and_wait_propagation("topic1")
 
     consumer = kafka_cluster.consumer(consumer_conf)
 

--- a/tests/integration/consumer/test_incremental_assign.py
+++ b/tests/integration/consumer/test_incremental_assign.py
@@ -30,8 +30,8 @@ def test_incremental_assign(kafka_cluster):
                      'enable.auto.commit': 'false',
                      'auto.offset.reset': 'error'}
 
-    topic1 = kafka_cluster.create_topic_and_wait_propogation("topic1")
-    topic2 = kafka_cluster.create_topic_and_wait_propogation("topic2")
+    topic1 = kafka_cluster.create_topic_and_wait_propagation("topic1")
+    topic2 = kafka_cluster.create_topic_and_wait_propagation("topic2")
 
     kafka_cluster.seed_topic(topic1, value_source=[b'a'])
     kafka_cluster.seed_topic(topic2, value_source=[b'b'])

--- a/tests/integration/producer/test_transactions.py
+++ b/tests/integration/producer/test_transactions.py
@@ -51,7 +51,7 @@ def prefixed_delivery_cb(prefix):
 
 
 def test_commit_transaction(kafka_cluster):
-    output_topic = kafka_cluster.create_topic_and_wait_propogation("output_topic")
+    output_topic = kafka_cluster.create_topic_and_wait_propagation("output_topic")
 
     producer = kafka_cluster.producer({
         'transactional.id': 'example_transactional_id',
@@ -66,7 +66,7 @@ def test_commit_transaction(kafka_cluster):
 
 
 def test_abort_transaction(kafka_cluster):
-    output_topic = kafka_cluster.create_topic_and_wait_propogation("output_topic")
+    output_topic = kafka_cluster.create_topic_and_wait_propagation("output_topic")
 
     producer = kafka_cluster.producer({
         'transactional.id': 'example_transactional_id',
@@ -81,7 +81,7 @@ def test_abort_transaction(kafka_cluster):
 
 
 def test_abort_retry_commit_transaction(kafka_cluster):
-    output_topic = kafka_cluster.create_topic_and_wait_propogation("output_topic")
+    output_topic = kafka_cluster.create_topic_and_wait_propagation("output_topic")
 
     producer = kafka_cluster.producer({
         'transactional.id': 'example_transactional_id',
@@ -99,8 +99,8 @@ def test_abort_retry_commit_transaction(kafka_cluster):
 
 
 def test_send_offsets_committed_transaction(kafka_cluster):
-    input_topic = kafka_cluster.create_topic_and_wait_propogation("input_topic")
-    output_topic = kafka_cluster.create_topic_and_wait_propogation("output_topic")
+    input_topic = kafka_cluster.create_topic_and_wait_propagation("input_topic")
+    output_topic = kafka_cluster.create_topic_and_wait_propagation("output_topic")
     error_cb = prefixed_error_cb('test_send_offsets_committed_transaction')
     producer = kafka_cluster.producer({
         'client.id': 'producer1',

--- a/tests/integration/schema_registry/_async/test_avro_serializers.py
+++ b/tests/integration/schema_registry/_async/test_avro_serializers.py
@@ -151,7 +151,7 @@ async def _references_test_common(kafka_cluster, awarded_user, serializer_schema
     Args:
         kafka_cluster (KafkaClusterFixture): cluster fixture
     """
-    topic = kafka_cluster.create_topic_and_wait_propogation("reference-avro")
+    topic = kafka_cluster.create_topic_and_wait_propagation("reference-avro")
     sr = kafka_cluster.async_schema_registry()
 
     value_serializer = await AsyncAvroSerializer(
@@ -223,7 +223,7 @@ async def test_avro_record_serialization(kafka_cluster, load_file, avsc, data, r
         data (object): data to be serialized
 
     """
-    topic = kafka_cluster.create_topic_and_wait_propogation("serialization-avro")
+    topic = kafka_cluster.create_topic_and_wait_propagation("serialization-avro")
     sr = kafka_cluster.async_schema_registry()
 
     schema_str = load_file(avsc)
@@ -267,7 +267,7 @@ async def test_delivery_report_serialization(kafka_cluster, load_file, avsc, dat
         data (object): data to be serialized
 
     """
-    topic = kafka_cluster.create_topic_and_wait_propogation("serialization-avro-dr")
+    topic = kafka_cluster.create_topic_and_wait_propagation("serialization-avro-dr")
     sr = kafka_cluster.async_schema_registry()
     schema_str = load_file(avsc)
 
@@ -314,7 +314,7 @@ async def test_avro_record_serialization_custom(kafka_cluster):
         kafka_cluster (KafkaClusterFixture): cluster fixture
 
     """
-    topic = kafka_cluster.create_topic_and_wait_propogation("serialization-avro")
+    topic = kafka_cluster.create_topic_and_wait_propagation("serialization-avro")
     sr = kafka_cluster.async_schema_registry()
 
     user = User('Bowie', 47, 'purple')

--- a/tests/integration/schema_registry/_async/test_json_serializers.py
+++ b/tests/integration/schema_registry/_async/test_json_serializers.py
@@ -257,7 +257,7 @@ async def test_json_record_serialization(kafka_cluster, load_file):
         load_file (callable(str)): JSON Schema file reader
 
     """
-    topic = kafka_cluster.create_topic_and_wait_propogation("serialization-json")
+    topic = kafka_cluster.create_topic_and_wait_propagation("serialization-json")
     sr = kafka_cluster.async_schema_registry()
 
     schema_str = load_file("product.json")
@@ -305,7 +305,7 @@ async def test_json_record_serialization_incompatible(kafka_cluster, load_file):
         load_file (callable(str)): JSON Schema file reader
 
     """
-    topic = kafka_cluster.create_topic_and_wait_propogation("serialization-json")
+    topic = kafka_cluster.create_topic_and_wait_propagation("serialization-json")
     sr = kafka_cluster.async_schema_registry()
 
     schema_str = load_file("product.json")
@@ -332,7 +332,7 @@ async def test_json_record_serialization_custom(kafka_cluster, load_file):
         load_file (callable(str)): JSON Schema file reader
 
     """
-    topic = kafka_cluster.create_topic_and_wait_propogation("serialization-json")
+    topic = kafka_cluster.create_topic_and_wait_propagation("serialization-json")
     sr = kafka_cluster.async_schema_registry()
 
     schema_str = load_file("product.json")
@@ -377,7 +377,7 @@ async def test_json_record_deserialization_mismatch(kafka_cluster, load_file):
         load_file (callable(str)): JSON Schema file reader
 
     """
-    topic = kafka_cluster.create_topic_and_wait_propogation("serialization-json")
+    topic = kafka_cluster.create_topic_and_wait_propagation("serialization-json")
     sr = kafka_cluster.async_schema_registry()
 
     schema_str = load_file("contractor.json")
@@ -418,7 +418,7 @@ async def _register_referenced_schemas(sr: AsyncSchemaRegistryClient, load_file)
 
 
 async def test_json_reference(kafka_cluster, load_file):
-    topic = kafka_cluster.create_topic_and_wait_propogation("serialization-json")
+    topic = kafka_cluster.create_topic_and_wait_propagation("serialization-json")
     sr = kafka_cluster.async_schema_registry()
 
     product = {"productId": 1,
@@ -457,7 +457,7 @@ async def test_json_reference(kafka_cluster, load_file):
 
 
 async def test_json_reference_custom(kafka_cluster, load_file):
-    topic = kafka_cluster.create_topic_and_wait_propogation("serialization-json")
+    topic = kafka_cluster.create_topic_and_wait_propagation("serialization-json")
     sr = kafka_cluster.async_schema_registry()
 
     product = _TestProduct(product_id=1,

--- a/tests/integration/schema_registry/_async/test_proto_serializers.py
+++ b/tests/integration/schema_registry/_async/test_proto_serializers.py
@@ -52,7 +52,7 @@ async def test_protobuf_message_serialization(kafka_cluster, pb2, data):
     Validates that we get the same message back that we put in.
 
     """
-    topic = kafka_cluster.create_topic_and_wait_propogation("serialization-proto")
+    topic = kafka_cluster.create_topic_and_wait_propagation("serialization-proto")
     sr = kafka_cluster.async_schema_registry()
 
     value_serializer = await AsyncProtobufSerializer(pb2, sr, {'use.deprecated.format': False})
@@ -85,7 +85,7 @@ async def test_protobuf_reference_registration(kafka_cluster, pb2, expected_refs
 
     """
     sr = kafka_cluster.async_schema_registry()
-    topic = kafka_cluster.create_topic_and_wait_propogation("serialization-proto-refs")
+    topic = kafka_cluster.create_topic_and_wait_propagation("serialization-proto-refs")
     serializer = await AsyncProtobufSerializer(pb2, sr, {'use.deprecated.format': False})
     producer = kafka_cluster.async_producer(key_serializer=serializer)
 
@@ -106,7 +106,7 @@ async def test_protobuf_serializer_type_mismatch(kafka_cluster):
     pb2_2 = NestedTestProto_pb2.NestedMessage
 
     sr = kafka_cluster.async_schema_registry()
-    topic = kafka_cluster.create_topic_and_wait_propogation("serialization-proto-refs")
+    topic = kafka_cluster.create_topic_and_wait_propagation("serialization-proto-refs")
     serializer = await AsyncProtobufSerializer(pb2_1, sr, {'use.deprecated.format': False})
 
     producer = kafka_cluster.async_producer(key_serializer=serializer)
@@ -127,7 +127,7 @@ async def test_protobuf_deserializer_type_mismatch(kafka_cluster):
     pb2_2 = metadata_proto_pb2.HDFSOptions
 
     sr = kafka_cluster.async_schema_registry()
-    topic = kafka_cluster.create_topic_and_wait_propogation("serialization-proto-refs")
+    topic = kafka_cluster.create_topic_and_wait_propagation("serialization-proto-refs")
     serializer = await AsyncProtobufSerializer(pb2_1, sr, {'use.deprecated.format': False})
     deserializer = await AsyncProtobufDeserializer(pb2_2, {'use.deprecated.format': False})
 

--- a/tests/integration/schema_registry/_sync/test_avro_serializers.py
+++ b/tests/integration/schema_registry/_sync/test_avro_serializers.py
@@ -151,7 +151,7 @@ def _references_test_common(kafka_cluster, awarded_user, serializer_schema, dese
     Args:
         kafka_cluster (KafkaClusterFixture): cluster fixture
     """
-    topic = kafka_cluster.create_topic_and_wait_propogation("reference-avro")
+    topic = kafka_cluster.create_topic_and_wait_propagation("reference-avro")
     sr = kafka_cluster.schema_registry()
 
     value_serializer = AvroSerializer(
@@ -223,7 +223,7 @@ def test_avro_record_serialization(kafka_cluster, load_file, avsc, data, record_
         data (object): data to be serialized
 
     """
-    topic = kafka_cluster.create_topic_and_wait_propogation("serialization-avro")
+    topic = kafka_cluster.create_topic_and_wait_propagation("serialization-avro")
     sr = kafka_cluster.schema_registry()
 
     schema_str = load_file(avsc)
@@ -267,7 +267,7 @@ def test_delivery_report_serialization(kafka_cluster, load_file, avsc, data, rec
         data (object): data to be serialized
 
     """
-    topic = kafka_cluster.create_topic_and_wait_propogation("serialization-avro-dr")
+    topic = kafka_cluster.create_topic_and_wait_propagation("serialization-avro-dr")
     sr = kafka_cluster.schema_registry()
     schema_str = load_file(avsc)
 
@@ -314,7 +314,7 @@ def test_avro_record_serialization_custom(kafka_cluster):
         kafka_cluster (KafkaClusterFixture): cluster fixture
 
     """
-    topic = kafka_cluster.create_topic_and_wait_propogation("serialization-avro")
+    topic = kafka_cluster.create_topic_and_wait_propagation("serialization-avro")
     sr = kafka_cluster.schema_registry()
 
     user = User('Bowie', 47, 'purple')

--- a/tests/integration/schema_registry/_sync/test_json_serializers.py
+++ b/tests/integration/schema_registry/_sync/test_json_serializers.py
@@ -257,7 +257,7 @@ def test_json_record_serialization(kafka_cluster, load_file):
         load_file (callable(str)): JSON Schema file reader
 
     """
-    topic = kafka_cluster.create_topic_and_wait_propogation("serialization-json")
+    topic = kafka_cluster.create_topic_and_wait_propagation("serialization-json")
     sr = kafka_cluster.schema_registry()
 
     schema_str = load_file("product.json")
@@ -305,7 +305,7 @@ def test_json_record_serialization_incompatible(kafka_cluster, load_file):
         load_file (callable(str)): JSON Schema file reader
 
     """
-    topic = kafka_cluster.create_topic_and_wait_propogation("serialization-json")
+    topic = kafka_cluster.create_topic_and_wait_propagation("serialization-json")
     sr = kafka_cluster.schema_registry()
 
     schema_str = load_file("product.json")
@@ -332,7 +332,7 @@ def test_json_record_serialization_custom(kafka_cluster, load_file):
         load_file (callable(str)): JSON Schema file reader
 
     """
-    topic = kafka_cluster.create_topic_and_wait_propogation("serialization-json")
+    topic = kafka_cluster.create_topic_and_wait_propagation("serialization-json")
     sr = kafka_cluster.schema_registry()
 
     schema_str = load_file("product.json")
@@ -377,7 +377,7 @@ def test_json_record_deserialization_mismatch(kafka_cluster, load_file):
         load_file (callable(str)): JSON Schema file reader
 
     """
-    topic = kafka_cluster.create_topic_and_wait_propogation("serialization-json")
+    topic = kafka_cluster.create_topic_and_wait_propagation("serialization-json")
     sr = kafka_cluster.schema_registry()
 
     schema_str = load_file("contractor.json")
@@ -418,7 +418,7 @@ def _register_referenced_schemas(sr: SchemaRegistryClient, load_file):
 
 
 def test_json_reference(kafka_cluster, load_file):
-    topic = kafka_cluster.create_topic_and_wait_propogation("serialization-json")
+    topic = kafka_cluster.create_topic_and_wait_propagation("serialization-json")
     sr = kafka_cluster.schema_registry()
 
     product = {"productId": 1,
@@ -457,7 +457,7 @@ def test_json_reference(kafka_cluster, load_file):
 
 
 def test_json_reference_custom(kafka_cluster, load_file):
-    topic = kafka_cluster.create_topic_and_wait_propogation("serialization-json")
+    topic = kafka_cluster.create_topic_and_wait_propagation("serialization-json")
     sr = kafka_cluster.schema_registry()
 
     product = _TestProduct(product_id=1,

--- a/tests/integration/schema_registry/_sync/test_proto_serializers.py
+++ b/tests/integration/schema_registry/_sync/test_proto_serializers.py
@@ -52,7 +52,7 @@ def test_protobuf_message_serialization(kafka_cluster, pb2, data):
     Validates that we get the same message back that we put in.
 
     """
-    topic = kafka_cluster.create_topic_and_wait_propogation("serialization-proto")
+    topic = kafka_cluster.create_topic_and_wait_propagation("serialization-proto")
     sr = kafka_cluster.schema_registry()
 
     value_serializer = ProtobufSerializer(pb2, sr, {'use.deprecated.format': False})
@@ -85,7 +85,7 @@ def test_protobuf_reference_registration(kafka_cluster, pb2, expected_refs):
 
     """
     sr = kafka_cluster.schema_registry()
-    topic = kafka_cluster.create_topic_and_wait_propogation("serialization-proto-refs")
+    topic = kafka_cluster.create_topic_and_wait_propagation("serialization-proto-refs")
     serializer = ProtobufSerializer(pb2, sr, {'use.deprecated.format': False})
     producer = kafka_cluster.producer(key_serializer=serializer)
 
@@ -106,7 +106,7 @@ def test_protobuf_serializer_type_mismatch(kafka_cluster):
     pb2_2 = NestedTestProto_pb2.NestedMessage
 
     sr = kafka_cluster.schema_registry()
-    topic = kafka_cluster.create_topic_and_wait_propogation("serialization-proto-refs")
+    topic = kafka_cluster.create_topic_and_wait_propagation("serialization-proto-refs")
     serializer = ProtobufSerializer(pb2_1, sr, {'use.deprecated.format': False})
 
     producer = kafka_cluster.producer(key_serializer=serializer)
@@ -127,7 +127,7 @@ def test_protobuf_deserializer_type_mismatch(kafka_cluster):
     pb2_2 = metadata_proto_pb2.HDFSOptions
 
     sr = kafka_cluster.schema_registry()
-    topic = kafka_cluster.create_topic_and_wait_propogation("serialization-proto-refs")
+    topic = kafka_cluster.create_topic_and_wait_propagation("serialization-proto-refs")
     serializer = ProtobufSerializer(pb2_1, sr, {'use.deprecated.format': False})
     deserializer = ProtobufDeserializer(pb2_2, {'use.deprecated.format': False})
 

--- a/tests/integration/serialization/test_serializers.py
+++ b/tests/integration/serialization/test_serializers.py
@@ -45,7 +45,7 @@ def test_numeric_serialization(kafka_cluster, serializer, deserializer, data):
         data(object): input data
 
     """
-    topic = kafka_cluster.create_topic_and_wait_propogation("serialization-numeric")
+    topic = kafka_cluster.create_topic_and_wait_propagation("serialization-numeric")
 
     producer = kafka_cluster.producer(value_serializer=serializer)
     producer.produce(topic, value=data)
@@ -77,7 +77,7 @@ def test_string_serialization(kafka_cluster, data, codec):
         codec (str): encoding type
 
     """
-    topic = kafka_cluster.create_topic_and_wait_propogation("serialization-string")
+    topic = kafka_cluster.create_topic_and_wait_propagation("serialization-string")
 
     producer = kafka_cluster.producer(value_serializer=StringSerializer(codec))
 
@@ -119,7 +119,7 @@ def test_mixed_serialization(kafka_cluster, key_serializer, value_serializer,
         value (object): value data
 
     """
-    topic = kafka_cluster.create_topic_and_wait_propogation("serialization-numeric")
+    topic = kafka_cluster.create_topic_and_wait_propagation("serialization-numeric")
 
     producer = kafka_cluster.producer(key_serializer=key_serializer,
                                       value_serializer=value_serializer)


### PR DESCRIPTION
A typo fix. From 'propogation' to 'propagation'

