### PR TITLE
AsyncIO: Only clear messages from buffer if executor passed

### DIFF
--- a/src/confluent_kafka/aio/producer/_buffer_timeout_manager.py
+++ b/src/confluent_kafka/aio/producer/_buffer_timeout_manager.py
@@ -124,15 +124,10 @@ class BufferTimeoutManager:
 
         This method handles the complete timeout flush workflow:
         1. Create batches from the batch processor
-        2. Execute each batch via the Kafka executor
-        3. Clear the processed messages from the buffer
+        2. Execute batches from the batch processor 
         """
         # Create batches from current buffer
         batches = self._batch_processor.create_batches()
-
-        # Execute all batches
-        for batch in batches:
-            await self._kafka_executor.execute_batch(batch.topic, batch.messages)
-
-        # Clear the buffer since all messages were processed
-        self._batch_processor.clear_buffer()
+        
+        # Execute batches with cleanup using the common function
+        await self._batch_processor._execute_batches(batches)


### PR DESCRIPTION
### Problem:

- AIOProducer was losing messages during broker disconnections
- Messages were cleared from buffer when executor failed, causing data loss when network failures occurred

 ### Solution:

- Modified ProducerBatchManager.flush_buffer() to clear buffer after successful execution. This atomic batch processing to ensure (at-least-once delivery 

 ###  Key Changes:
- `_producer_batch_processor.py`:Fixed buffer clearing logic in flush_buffer() method
- `_buffer_timeout_manager.py`: Updated timeout flush to use consistent error handling
- Refactored duplicate code into common buffer proccessor file's _execute_batches() function