### PR TITLE
Fix SR delete behavior with client-side caching

### DIFF
--- a/src/confluent_kafka/schema_registry/_async/schema_registry_client.py
+++ b/src/confluent_kafka/schema_registry/_async/schema_registry_client.py
@@ -1174,11 +1174,13 @@ class AsyncSchemaRegistryClient(object):
             response = await self._rest_client.delete(
                 'subjects/{}/versions/{}?permanent=true'.format(_urlencode(subject_name), version)
             )
-            self._cache.remove_by_subject_version(subject_name, version)
         else:
             response = await self._rest_client.delete(
                 'subjects/{}/versions/{}'.format(_urlencode(subject_name), version)
             )
+
+        # Clear cache for both soft and hard deletes to maintain consistency
+        self._cache.remove_by_subject_version(subject_name, version)
 
         return response
 

--- a/src/confluent_kafka/schema_registry/_sync/schema_registry_client.py
+++ b/src/confluent_kafka/schema_registry/_sync/schema_registry_client.py
@@ -1174,11 +1174,13 @@ class SchemaRegistryClient(object):
             response = self._rest_client.delete(
                 'subjects/{}/versions/{}?permanent=true'.format(_urlencode(subject_name), version)
             )
-            self._cache.remove_by_subject_version(subject_name, version)
         else:
             response = self._rest_client.delete(
                 'subjects/{}/versions/{}'.format(_urlencode(subject_name), version)
             )
+
+        # Clear cache for both soft and hard deletes to maintain consistency
+        self._cache.remove_by_subject_version(subject_name, version)
 
         return response
 

--- a/src/confluent_kafka/schema_registry/common/schema_registry_client.py
+++ b/src/confluent_kafka/schema_registry/common/schema_registry_client.py
@@ -268,11 +268,12 @@ class _SchemaCache(object):
 
         with self.lock:
             if subject in self.rs_id_index:
-                for schema_id, registered_schema in self.rs_id_index[subject].items():
+                for schema_id, registered_schema in list(self.rs_id_index[subject].items()):
                     if registered_schema.version == version:
-                        del self.rs_schema_index[subject][schema_id]
+                        del self.rs_id_index[subject][schema_id]
+
             if subject in self.rs_schema_index:
-                for schema, registered_schema in self.rs_schema_index[subject].items():
+                for schema, registered_schema in list(self.rs_schema_index[subject].items()):
                     if registered_schema.version == version:
                         del self.rs_schema_index[subject][schema]
             rs = None
@@ -284,6 +285,7 @@ class _SchemaCache(object):
                 if subject in self.schema_id_index:
                     if rs.schema_id in self.schema_id_index[subject]:
                         del self.schema_id_index[subject][rs.schema_id]
+                if subject in self.schema_index:
                     if rs.schema in self.schema_index[subject]:
                         del self.schema_index[subject][rs.schema]
 

--- a/tests/integration/schema_registry/_async/test_api_client.py
+++ b/tests/integration/schema_registry/_async/test_api_client.py
@@ -422,6 +422,34 @@ async def test_api_delete_subject_version(kafka_cluster, load_file):
     assert subject not in await sr.get_subjects()
 
 
+async def test_api_delete_version_soft_then_hard(kafka_cluster, load_file):
+    """
+    Performs a soft delete followed by a hard delete with cache populated and cleared correctly.
+    """
+    sr = kafka_cluster.async_schema_registry()
+
+    schema = Schema(load_file('basic_schema.avsc'), schema_type='AVRO')
+    subject = str(uuid1())
+
+    # Register schema and trigger cache population
+    await sr.register_schema(subject, schema)
+    registered = await sr.lookup_schema(subject, schema)
+    version = registered.version
+    assert sr._cache.get_registered_by_subject_version(subject, version) is not None
+
+    # Verify soft delete clears cache
+    deleted_version = await sr.delete_version(subject, version, permanent=False)
+    assert deleted_version == version
+    assert sr._cache.get_registered_by_subject_version(subject, version) is None
+
+    # Verify hard delete proceeds without error
+    deleted_version = await sr.delete_version(subject, version, permanent=True)
+    assert deleted_version == version
+
+    # Verify subject is fully deleted
+    assert subject not in await sr.get_subjects()
+
+
 async def test_api_subject_config_update(kafka_cluster, load_file):
     """
     Updates a subjects compatibility policy then ensures the same policy

--- a/tests/integration/schema_registry/_sync/test_api_client.py
+++ b/tests/integration/schema_registry/_sync/test_api_client.py
@@ -422,6 +422,34 @@ def test_api_delete_subject_version(kafka_cluster, load_file):
     assert subject not in sr.get_subjects()
 
 
+def test_api_delete_version_soft_then_hard(kafka_cluster, load_file):
+    """
+    Performs a soft delete followed by a hard delete with cache populated and cleared correctly.
+    """
+    sr = kafka_cluster.schema_registry()
+
+    schema = Schema(load_file('basic_schema.avsc'), schema_type='AVRO')
+    subject = str(uuid1())
+
+    # Register schema and trigger cache population
+    sr.register_schema(subject, schema)
+    registered = sr.lookup_schema(subject, schema)
+    version = registered.version
+    assert sr._cache.get_registered_by_subject_version(subject, version) is not None
+
+    # Verify soft delete clears cache
+    deleted_version = sr.delete_version(subject, version, permanent=False)
+    assert deleted_version == version
+    assert sr._cache.get_registered_by_subject_version(subject, version) is None
+
+    # Verify hard delete proceeds without error
+    deleted_version = sr.delete_version(subject, version, permanent=True)
+    assert deleted_version == version
+
+    # Verify subject is fully deleted
+    assert subject not in sr.get_subjects()
+
+
 def test_api_subject_config_update(kafka_cluster, load_file):
     """
     Updates a subjects compatibility policy then ensures the same policy


### PR DESCRIPTION
<!--
Suggested PR template: Fill/delete/add sections as needed. Optionally delete any commented block.
-->
What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include implementation strategy.
-->
Fixed two interconnected bugs in the Schema Registry client's delete_version() method:
- Soft deletes (permanent=False) did not clear the client-side cache, causing stale entries to persist after the server marked versions as deleted.
  - Fix: Cache is now cleared for both soft and hard deletes to maintain consistency with server state.
- When the cache was fully populated, calling delete_version() with permanent=True would crash with a KeyError. This occurred because remove_by_subject_version() attempted to delete from rs_schema_index (keyed by Schema objects) using an integer schema_id. 
  - Fix: Changed line 273 in common/schema_registry_client.py to correctly delete from rs_id_index instead.


Checklist
------------------
- [ ] Contains customer facing changes? Including API/behavior changes <!-- This can help identify if it has introduced any breaking changes -->
- [ ] Did you add sufficient unit test and/or integration test coverage for this PR?
  - If not, please explain why it is not required

References
----------
JIRA: https://confluentinc.atlassian.net/browse/NONJAVACLI-4095
<!--
Copy&paste links: to Jira ticket, other PRs, issues, Slack conversations...
For code bumps: link to PR, tag or GitHub `/compare/master...master`
-->
Issue: https://github.com/confluentinc/confluent-kafka-python/issues/1912

Test & Review
------------
<!--
Has it been tested? how?
Copy&paste any handy instructions, steps or requirements that can save time to the reviewer or any reader.
-->

Open questions / Follow-ups
--------------------------
<!--
Optional: anything open to discussion for the reviewer, out of scope, or follow-ups.
-->

<!--
Review stakeholders
------------------
<!--
Optional: mention stakeholders or if special context that is required to review.
-->
