### PR TITLE
Handle null group name to prevent segfault in Admin list_consumer_group_offsets()

### DIFF
--- a/src/confluent_kafka/src/Admin.c
+++ b/src/confluent_kafka/src/Admin.c
@@ -4539,7 +4539,7 @@ static PyObject * Admin_c_SingleGroupResult_to_py(const rd_kafka_group_result_t 
         /* Safely handle potential NULL group name from librdkafka */
         const char *group_name = rd_kafka_group_result_name(c_group_result_response);
         if (!group_name) {
-                cfl_PyErr_Format(RD_KAFKA_RESP_ERR__INVALID_ARG,
+                cfl_PyErr_Format(RD_KAFKA_RESP_ERR__FAIL,
                                 "Received NULL group name from librdkafka");
                 Py_DECREF(kwargs);
                 Py_DECREF(GroupResult_type);


### PR DESCRIPTION
<!--
Suggested PR template: Fill/delete/add sections as needed. Optionally delete any commented block.
-->
What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include implementation strategy.
-->

### Problem
User reported a segmentation fault when calling `list_consumer_group_offsets()` on non-existing consumer groups in v2.10.0. The process crashed instead of raising an exception.

### Investigation

**Normal behavior verified:** When calling `list_consumer_group_offsets()` on a non-existing group, the API successfully returns an empty list (https://github.com/confluentinc/confluent-kafka-python/blob/06c0744986b1796947b2c20629a2b3cac90e642f/src/confluent_kafka/src/Admin.c#L5011). This is the expected behavior - Kafka/librdkafka does not treat a non-existing consumer group as an error condition.

**Why the segfault occur (theory):** Since the normal "non-existing group" path works correctly, the crash must occur in **error scenarios** where librdkafka encounters internal failures. Through code analysis, we identified a vulnerability: the C binding passes `rd_kafka_group_result_name()` directly to `PyUnicode_FromString()` without NULL checking (https://github.com/confluentinc/confluent-kafka-python/blob/06c0744986b1796947b2c20629a2b3cac90e642f/src/confluent_kafka/src/Admin.c#L4539):
- If `rd_kafka_group_result_name()` returns NULL (possible in edge cases like network timeouts, coordinator unavailability, broker communication failures, or race conditions in error handling), this causes a NULL pointer dereference in `PyUnicode_FromString()`, resulting in SIGSEGV.

### Solution
In `Admin_c_SingleGroupResult_to_py()`, add defensive check for NULL group_name. 

Checklist
------------------
- [ ] Contains customer facing changes? Including API/behavior changes <!-- This can help identify if it has introduced any breaking changes -->
- [ ] Did you add sufficient unit test and/or integration test coverage for this PR?
  - If not, please explain why it is not required

References
----------
JIRA: https://confluentinc.atlassian.net/browse/NONJAVACLI-4100
Issue: https://github.com/confluentinc/confluent-kafka-python/issues/1982
<!--
Copy&paste links: to Jira ticket, other PRs, issues, Slack conversations...
For code bumps: link to PR, tag or GitHub `/compare/master...master`
-->

Test & Review
------------
<!--
Has it been tested? how?
Copy&paste any handy instructions, steps or requirements that can save time to the reviewer or any reader.
-->

Open questions / Follow-ups
--------------------------
<!--
Optional: anything open to discussion for the reviewer, out of scope, or follow-ups.
-->

<!--
Review stakeholders
------------------
<!--
Optional: mention stakeholders or if special context that is required to review.
-->
