### PR TITLE
Fix the intermittent segfault issue due to GC in Admin tests

### DIFF
--- a/src/confluent_kafka/admin/__init__.py
+++ b/src/confluent_kafka/admin/__init__.py
@@ -15,6 +15,7 @@
 """
 Kafka admin client: create, view, alter, and delete topics and resources.
 """
+import gc
 import warnings
 import concurrent.futures
 from typing import Any, Dict, List, Optional, Union, Tuple, Set
@@ -135,7 +136,6 @@ class AdminClient (_AdminClientImpl):
         Map per-topic results to per-topic futures in futmap.
         The result value of each (successful) future is None.
         """
-        import gc
         gc_was_enabled = gc.isenabled()
         gc.disable()
         try:
@@ -166,7 +166,6 @@ class AdminClient (_AdminClientImpl):
         Map per-resource results to per-resource futures in futmap.
         The result value of each (successful) future is a ConfigResource.
         """
-        import gc
         gc_was_enabled = gc.isenabled()
         gc.disable()
         try:
@@ -201,7 +200,6 @@ class AdminClient (_AdminClientImpl):
         """
         Map per-group results to per-group futures in futmap.
         """
-        import gc
         gc_was_enabled = gc.isenabled()
         gc.disable()
         try:
@@ -233,8 +231,6 @@ class AdminClient (_AdminClientImpl):
         Map per-group results to per-group futures in futmap.
         The result value of each (successful) future is ConsumerGroupTopicPartitions.
         """
-        import gc
-
         # Disable GC during callback to prevent AdminClient destruction from librdkafka thread.
         # This callback runs in librdkafka's background thread, and if GC runs here, it may
         # try to destroy AdminClient objects, which librdkafka forbids from its own threads.
@@ -271,7 +267,6 @@ class AdminClient (_AdminClientImpl):
         For create_acls the result value of each (successful) future is None.
         For delete_acls the result value of each (successful) future is the list of deleted AclBindings.
         """
-        import gc
         gc_was_enabled = gc.isenabled()
         gc.disable()
         try:
@@ -299,7 +294,6 @@ class AdminClient (_AdminClientImpl):
     @staticmethod
     def _make_futmap_result_from_list(f: concurrent.futures.Future,
                                       futmap: Dict[Any, concurrent.futures.Future]) -> None:
-        import gc
         gc_was_enabled = gc.isenabled()
         gc.disable()
         try:
@@ -326,7 +320,6 @@ class AdminClient (_AdminClientImpl):
 
     @staticmethod
     def _make_futmap_result(f: concurrent.futures.Future, futmap: Dict[str, concurrent.futures.Future]) -> None:
-        import gc
         gc_was_enabled = gc.isenabled()
         gc.disable()
         try:


### PR DESCRIPTION
<!--
Suggested PR template: Fill/delete/add sections as needed. Optionally delete any commented block.
-->
What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include implementation strategy.
-->

Bug:
- Some Admin module unit tests (e.g. `test_list_consumer_group_offsets_api`) finishes but after that the callback function (`_make_consumer_group_offsets_result`), running in the librdkafka's background, triggers garbage collection. When librdkafka detects that `rd_kafka_destroy` is invoked from its own thread (https://github.com/confluentinc/librdkafka/blob/616fb6e8074e82e0302f1c7d2896d7e577f8eb9b/src/rdkafka.c#L1115), it sends the ABORT signal

FIx:
- Disable GC via `gc.disable()` in tests that make fire-and-forget calls

Checklist
------------------
- [ ] Contains customer facing changes? Including API/behavior changes <!-- This can help identify if it has introduced any breaking changes -->
- [ ] Did you add sufficient unit test and/or integration test coverage for this PR?
  - If not, please explain why it is not required

References
----------
JIRA: https://confluentinc.atlassian.net/browse/NONJAVACLI-4105
<!--
Copy&paste links: to Jira ticket, other PRs, issues, Slack conversations...
For code bumps: link to PR, tag or GitHub `/compare/master...master`
-->

Test & Review
------------
<!--
Has it been tested? how?
Copy&paste any handy instructions, steps or requirements that can save time to the reviewer or any reader.
-->

Open questions / Follow-ups
--------------------------
<!--
Optional: anything open to discussion for the reviewer, out of scope, or follow-ups.
-->

<!--
Review stakeholders
------------------
<!--
Optional: mention stakeholders or if special context that is required to review.
-->
