### PR TITLE
Use ContextManager as workaround to mitigate GC issues in some Admin tests

### DIFF
--- a/tests/test_Admin.py
+++ b/tests/test_Admin.py
@@ -744,7 +744,7 @@ def test_list_consumer_group_offsets_api():
 
         with pytest.raises(ValueError):
             a.list_consumer_group_offsets([only_group_id_request],
-                                           request_timeout=-5)
+                                          request_timeout=-5)
 
         with pytest.raises(TypeError):
             a.list_consumer_group_offsets([ConsumerGroupTopicPartitions()])
@@ -842,7 +842,7 @@ def test_alter_consumer_group_offsets_api():
 
         with pytest.raises(ValueError):
             a.alter_consumer_group_offsets([request_with_group_and_topic_partition_offset1],
-                                            request_timeout=-5)
+                                           request_timeout=-5)
 
         with pytest.raises(TypeError):
             a.alter_consumer_group_offsets([ConsumerGroupTopicPartitions()])


### PR DESCRIPTION
<!--
Suggested PR template: Fill/delete/add sections as needed. Optionally delete any commented block.
-->
What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include implementation strategy.
-->

Some Admin module unit tests (e.g. test_list_consumer_group_offsets_api) finishes but after that the callback function (_make_consumer_group_offsets_result), running in the librdkafka's background, triggers garbage collection. When librdkafka detects that rd_kafka_destroy is invoked from its own thread (https://github.com/confluentinc/librdkafka/blob/616fb6e8074e82e0302f1c7d2896d7e577f8eb9b/src/rdkafka.c#L1115), it sends the ABORT signal

Using context manager as a workaround as it seems to help with cleaning up AdminClient object. To fix the root cause, we have to do a deeper investigation in librdkafka

Checklist
------------------
- [ ] Contains customer facing changes? Including API/behavior changes <!-- This can help identify if it has introduced any breaking changes -->
- [ ] Did you add sufficient unit test and/or integration test coverage for this PR?
  - If not, please explain why it is not required

References
----------
JIRA: https://confluentinc.atlassian.net/browse/NONJAVACLI-4105
<!--
Copy&paste links: to Jira ticket, other PRs, issues, Slack conversations...
For code bumps: link to PR, tag or GitHub `/compare/master...master`
-->

Test & Review
------------
<!--
Has it been tested? how?
Copy&paste any handy instructions, steps or requirements that can save time to the reviewer or any reader.
-->

Open questions / Follow-ups
--------------------------
<!--
Optional: anything open to discussion for the reviewer, out of scope, or follow-ups.
-->

<!--
Review stakeholders
------------------
<!--
Optional: mention stakeholders or if special context that is required to review.
-->
