### PR TITLE
Fix formatting issue of TopicPartition that causes SystemError on Windows

### DIFF
--- a/src/confluent_kafka/src/confluent_kafka.c
+++ b/src/confluent_kafka/src/confluent_kafka.c
@@ -1226,7 +1226,7 @@ static PyObject *TopicPartition_str0(TopicPartition *self) {
         }
 
         ret = cfl_PyUnistr(
-            _FromFormat("TopicPartition{topic=%s,partition=%" CFL_PRId32
+            _FromFormat("TopicPartition{topic=%s,partition=%d"
                         ",offset=%s,leader_epoch=%s,error=%s}",
                         self->topic, self->partition, offset_str,
                         leader_epoch_str, c_errstr ? c_errstr : "None"));


### PR DESCRIPTION
<!--
Suggested PR template: Fill/delete/add sections as needed. Optionally delete any commented block.
-->
What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include implementation strategy.
-->

Minor fix to address the formatting issue of TopicPartiton: `CFL_PRId32` macro expands to "I32d" on Windows (MSVC), which is not supported by Python's PyUnicode_FromFormat(). To fix it, we will replace `CFL_PRId32` with `%d`. This is safe as partition is already declared as int in the struct

Checklist
------------------
- [ ] Contains customer facing changes? Including API/behavior changes <!-- This can help identify if it has introduced any breaking changes -->
- [ ] Did you add sufficient unit test and/or integration test coverage for this PR?
  - If not, please explain why it is not required

References
----------
<!--
Copy&paste links: to Jira ticket, other PRs, issues, Slack conversations...
For code bumps: link to PR, tag or GitHub `/compare/master...master`
-->
Issue: https://github.com/confluentinc/confluent-kafka-python/issues/1715
Jira: https://confluentinc.atlassian.net/browse/NONJAVACLI-4144

Test & Review
------------
<!--
Has it been tested? how?
Copy&paste any handy instructions, steps or requirements that can save time to the reviewer or any reader.
-->

Open questions / Follow-ups
--------------------------
<!--
Optional: anything open to discussion for the reviewer, out of scope, or follow-ups.
-->

<!--
Review stakeholders
------------------
<!--
Optional: mention stakeholders or if special context that is required to review.
-->
