### PR TITLE
add Py_None check for msg and offset params in commit() and store_offsets()

### DIFF
--- a/src/confluent_kafka/src/Consumer.c
+++ b/src/confluent_kafka/src/Consumer.c
@@ -606,6 +606,9 @@ Consumer_store_offsets(Handle *self, PyObject *args, PyObject *kwargs) {
                                          &offsets))
                 return NULL;
 
+        msg = msg == Py_None ? NULL : msg;
+        offsets = offsets == Py_None ? NULL : offsets;
+
         if (msg && offsets) {
                 PyErr_SetString(PyExc_ValueError,
                                 "message and offsets are mutually exclusive");
@@ -636,7 +639,7 @@ Consumer_store_offsets(Handle *self, PyObject *args, PyObject *kwargs) {
 
                 m = (Message *)msg;
 
-                if (m->error != Py_None) {
+                if (m->error && m->error != Py_None) {
                         PyObject *error = Message_error(m, NULL);
                         PyObject *errstr =
                             PyObject_CallMethod(error, "str", NULL);


### PR DESCRIPTION
Overview
----
1. Fixes issue #1642 by ensuring message and offset params are treated as NULL in `commit()` and `store_offsets()` when their values are Py_None.
2. Added NULL check to avoid segmentation fault when a user-instantiated message object is passed in `commit()` and `store_offsets()`

Problem
-----
When calling `commit()` in any of the following ways,
```
consumer.commit(message=None)
consumer.commit(offsets=None)
consumer.commit(message=None, offsets=None)
```

An error occurs saying that `message and offsets are mutually exclusive`. 

This happens because our implementation of `commit()` (written in C) only checks for message and offsets values being NULL or non-NULL. When their values are `Py_None`, they are regarded as non-NULL which leads to the above error.

Checklist
------------------
- [x] Contains customer facing changes? Including API/behavior changes <!-- This can help identify if it has introduced any breaking changes -->
- [x] Did you add sufficient unit test and/or integration test coverage for this PR?


