### PR TITLE
Add deprecation warning for AvroProducer and AvroConsumer in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,19 @@ This client provides full integration with Schema Registry for schema management
 
 #### Synchronous Client & Serializers
 
+> **⚠️ Note on Legacy Classes**
+>
+> The `AvroProducer` and `AvroConsumer` classes are **deprecated** and will be removed in a future version.
+>
+> **Use instead:**
+> - `AvroSerializer` / `AvroDeserializer` with standard `Producer` / `Consumer` (shown below)
+> - `AsyncAvroSerializer` / `AsyncAvroDeserializer` with `AIOProducer` / `AIOConsumer` (see AsyncIO section)
+>
+> **Examples:**
+> - [`examples/avro_producer.py`](examples/avro_producer.py)
+> - [`examples/avro_consumer.py`](examples/avro_consumer.py)
+
+
 Use the synchronous `SchemaRegistryClient` with the standard `Producer` and `Consumer`.
 
 ```python


### PR DESCRIPTION
Fixes #910

## What?
Added a prominent deprecation warning in the Schema Registry Integration section of README.md for the legacy `AvroProducer` and `AvroConsumer` classes.

## Why?
These classes are marked as deprecated in the code but the README still prominently features them, which confuses new users (as noted in #910).

## Changes
- Added a clear warning box in the "Synchronous Client & Serializers" section
- Directs users to use modern `AvroSerializer`/`AvroDeserializer` with standard `Producer`/