### PR TITLE
Refine Consumer.commit type hints

### DIFF
--- a/src/confluent_kafka/cimpl.pyi
+++ b/src/confluent_kafka/cimpl.pyi
@@ -180,19 +180,51 @@ class Consumer:
     def assign(self, partitions: List[TopicPartition]) -> None: ...
     def unassign(self) -> None: ...
     def assignment(self) -> List[TopicPartition]: ...
+    # Message and offsets omitted, asynchronous.
     @overload
     def commit(
         self,
-        message: Optional['Message'] = None,
-        offsets: Optional[List[TopicPartition]] = None,
-        asynchronous: Literal[True] = True,
+        *,
+        asynchronous: Literal[True] = ...,
     ) -> None: ...
+    # Message and offsets omitted, synchronous.
     @overload
     def commit(
         self,
-        message: Optional['Message'] = None,
-        offsets: Optional[List[TopicPartition]] = None,
-        asynchronous: Literal[False] = False,
+        *,
+        asynchronous: Literal[False],
+    ) -> List[TopicPartition]: ...
+    # Message specified, asynchronous.
+    @overload
+    def commit(
+        self,
+        *,
+        message: Message,
+        asynchronous: Literal[True] = ...,
+    ) -> None: ...
+    # Message specified, synchronous.
+    @overload
+    def commit(
+        self,
+        *,
+        message: Message,
+        asynchronous: Literal[False],
+    ) -> List[TopicPartition]: ...
+    # Offsets specified, asynchronous.
+    @overload
+    def commit(
+        self,
+        *,
+        offsets: List[TopicPartition],
+        asynchronous: Literal[True] = ...,
+    ) -> None: ...
+    # Offsets specified, synchronous.
+    @overload
+    def commit(
+        self,
+        *,
+        offsets: List[TopicPartition],
+        asynchronous: Literal[False],
     ) -> List[TopicPartition]: ...
     def get_watermark_offsets(
         self, partition: TopicPartition, timeout: float = -1, cached: bool = False


### PR DESCRIPTION
The type hints for `Consumer.commit` allowed passing `None` for the `message` and `offsets` parameters, and allowed passing both these parameters. At runtime, passing `None` will give `TypeError`, and the documentation specifies that these parameters are mutually exclusive.

Together with the input-dependent return type, this gets a little complex, however having this properly encoded in the type signature allows finding elusive bugs earlier.

We previously added similar type hints [to stubs in Karapace](https://github.com/Aiven-Open/karapace/commit/f5d2b71a81373729f6607c83d515f38114ef8238) to fix exactly such a bug that was only discovered at application runtime.

<!--
Suggested PR template: Fill/delete/add sections as needed. Optionally delete any commented block.
-->
What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include implementation strategy.
-->

Checklist
------------------
- [ ] Contains customer facing changes? Including API/behavior changes <!-- This can help identify if it has introduced any breaking changes -->
- [ ] Did you add sufficient unit test and/or integration test coverage for this PR?
  - If not, please explain why it is not required

References
----------
JIRA: 
<!--
Copy&paste links: to Jira ticket, other PRs, issues, Slack conversations...
For code bumps: link to PR, tag or GitHub `/compare/master...master`
-->

Test & Review
------------
<!--
Has it been tested? how?
Copy&paste any handy instructions, steps or requirements that can save time to the reviewer or any reader.
-->

Open questions / Follow-ups
--------------------------
<!--
Optional: anything open to discussion for the reviewer, out of scope, or follow-ups.
-->

<!--
Review stakeholders
------------------
<!--
Optional: mention stakeholders or if special context that is required to review.
-->
