### PR TITLE
Implement async context manager protocol for AIO clients

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## v2.xx.x
 
+### Enhancements
+
+- Implement async context manager protocol for AIOProducer and AIOConsumer (#2180)
+
 ### Fixes
 
 - Ensure normalize.schemas config is passed during Protobuf ref lookup #2214

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,0 +1,1 @@
+typing-extensions; python_version < "3.11"

--- a/src/confluent_kafka/aio/_AIOConsumer.py
+++ b/src/confluent_kafka/aio/_AIOConsumer.py
@@ -16,6 +16,9 @@ import asyncio
 import concurrent.futures
 from typing import Any, Callable, Dict, Optional, Tuple
 
+# FIXME: import from typing once we depend on Python >= 3.11
+from typing_extensions import Self
+
 import confluent_kafka
 
 from . import _common as _common
@@ -45,6 +48,12 @@ class AIOConsumer:
         wrap_conf_callback(loop, consumer_conf, 'on_commit')
 
         self._consumer: confluent_kafka.Consumer = confluent_kafka.Consumer(consumer_conf)
+
+    async def __aenter__(self) -> Self:
+        return self
+
+    async def __aexit__(self, *_) -> None:
+        await self.close()
 
     async def _call(self, blocking_task: Callable[..., Any], *args: Any, **kwargs: Any) -> Any:
         return await _common.async_call(self.executor, blocking_task, *args, **kwargs)

--- a/src/confluent_kafka/aio/producer/_AIOProducer.py
+++ b/src/confluent_kafka/aio/producer/_AIOProducer.py
@@ -17,6 +17,9 @@ import concurrent.futures
 import logging
 from typing import Any, Callable, Dict, Optional
 
+# FIXME: import from typing once we depend on Python >= 3.11
+from typing_extensions import Self
+
 import confluent_kafka
 
 from .. import _common as _common
@@ -69,6 +72,12 @@ class AIOProducer:
         self._buffer_timeout_manager = BufferTimeoutManager(self._batch_processor, self._kafka_executor, buffer_timeout)
         if buffer_timeout > 0:
             self._buffer_timeout_manager.start_timeout_monitoring()
+
+    async def __aenter__(self) -> Self:
+        return self
+
+    async def __aexit__(self, *_) -> None:
+        await self.close()
 
     async def close(self) -> None:
         """Close the producer and cleanup resources

--- a/tests/test_AIOConsumer.py
+++ b/tests/test_AIOConsumer.py
@@ -165,3 +165,9 @@ class TestAIOConsumer:
             await consumer.poll(timeout=1.0)
 
         assert exc_info.value.args[0].code() == KafkaError._TRANSPORT
+
+    @pytest.mark.asyncio
+    async def test_async_context_manager(self, mock_consumer, mock_common, basic_config):
+        """Test AIOConsumer handles network errors gracefully."""
+        async with AIOConsumer(basic_config) as _:
+            pass

--- a/tests/test_AIOProducer.py
+++ b/tests/test_AIOProducer.py
@@ -81,6 +81,18 @@ class TestAIOProducer:
         assert producer2._is_closed is True
 
     @pytest.mark.asyncio
+    async def test_async_context_manager(self, mock_producer, mock_common, basic_config):
+        async with AIOProducer(basic_config) as producer:
+            assert producer._is_closed is False
+        assert producer._is_closed is True
+
+        async with AIOProducer(basic_config) as producer2:
+            assert producer2._is_closed is False
+            await producer2.close()
+        await producer2.close()
+        assert producer2._is_closed is True
+
+    @pytest.mark.asyncio
     async def test_call_method_executor_usage(self, mock_producer, mock_common, basic_config):
         producer = AIOProducer(basic_config)
 


### PR DESCRIPTION
When AIOProducer or AIOConsumer is used as the target of a `with:` statement, automatically close the connection at the end of the context.

<!--
Suggested PR template: Fill/delete/add sections as needed. Optionally delete any commented block.
-->
What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include implementation strategy.
-->

Checklist
------------------
- [ ] Contains customer facing changes? Including API/behavior changes <!-- This can help identify if it has introduced any breaking changes -->
- [ ] Did you add sufficient unit test and/or integration test coverage for this PR?
  - If not, please explain why it is not required

References
----------
JIRA: 
<!--
Copy&paste links: to Jira ticket, other PRs, issues, Slack conversations...
For code bumps: link to PR, tag or GitHub `/compare/master...master`
-->

Test & Review
------------
<!--
Has it been tested? how?
Copy&paste any handy instructions, steps or requirements that can save time to the reviewer or any reader.
-->

Open questions / Follow-ups
--------------------------
<!--
Optional: anything open to discussion for the reviewer, out of scope, or follow-ups.
-->

<!--
Review stakeholders
------------------
<!--
Optional: mention stakeholders or if special context that is required to review.
-->
