### PR TITLE
Remove resolver param passed to validate() in JSON schema 

### DIFF
--- a/src/confluent_kafka/schema_registry/common/json_schema.py
+++ b/src/confluent_kafka/schema_registry/common/json_schema.py
@@ -202,7 +202,7 @@ def _validate_subschemas(
                 ref = subschema.get("$ref")
                 if ref is not None:
                     subschema = resolver.lookup(ref).contents
-                validate(instance=message, schema=subschema, registry=registry, resolver=resolver)
+                validate(instance=message, schema=subschema, registry=registry)
                 return subschema
             except ValidationError:
                 pass


### PR DESCRIPTION
<!--
Suggested PR template: Fill/delete/add sections as needed. Optionally delete any commented block.
-->
What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include implementation strategy.
-->

RefResolver is deprecated as of 4.18.0 and we are using 4.24.0 of jsonschema library: https://github.com/python-jsonschema/jsonschema/blob/cbaf0f8fe9be1825477419f2ac02f835cc292198/jsonschema/validators.py#L471

What happens:
- When we pass resolver=<new Resolver> → it gets assigned to self._ref_resolver
- jsonschema checks if self._ref_resolver exists, and if so tries to call self._ref_resolver.resolving(ref) (https://github.com/python-jsonschema/jsonschema/blob/cbaf0f8fe9be1825477419f2ac02f835cc292198/jsonschema/validators.py#L471)
- However, the new Resolver from referencing library (what we pass from SR client) doesn't have a resolving() method
- `AttributeError: 'Resolver' object has no attribute 'resolving'`

Checklist
------------------
- [ ] Contains customer facing changes? Including API/behavior changes <!-- This can help identify if it has introduced any breaking changes -->
- [ ] Did you add sufficient unit test and/or integration test coverage for this PR?
  - If not, please explain why it is not required

References
----------
JIRA: https://confluentinc.atlassian.net/browse/INC-8778
<!--
Copy&paste links: to Jira ticket, other PRs, issues, Slack conversations...
For code bumps: link to PR, tag or GitHub `/compare/master...master`
-->

Test & Review
------------
<!--
Has it been tested? how?
Copy&paste any handy instructions, steps or requirements that can save time to the reviewer or any reader.
-->

Open questions / Follow-ups
--------------------------
<!--
Optional: anything open to discussion for the reviewer, out of scope, or follow-ups.
-->

<!--
Review stakeholders
------------------
<!--
Optional: mention stakeholders or if special context that is required to review.
-->
