### PR TITLE
Fix memory metric in ducktape tests and update max_memory_growth_mb threshold

### DIFF
--- a/tests/ducktape/producer_benchmark_bounds.json
+++ b/tests/ducktape/producer_benchmark_bounds.json
@@ -7,7 +7,7 @@
     "max_error_rate": 0.02,
     "min_success_rate": 0.98,
     "max_p99_latency_ms": 7000.0,
-    "max_memory_growth_mb": 3000.0,
+    "max_memory_growth_mb": 2000.0,
     "max_buffer_full_rate": 0.05,
     "min_messages_per_poll": 5.0
   },

--- a/tests/ducktape/test_producer.py
+++ b/tests/ducktape/test_producer.py
@@ -82,10 +82,6 @@ class SimpleProducerTest(Test):
         def message_formatter(msg_num):
             return f"Test message {msg_num}", f"key-{msg_num}"
 
-        # Containers for results
-        delivered_messages = []
-        failed_messages = []
-
         # Run the test
         start_time = time.time()
         messages_sent = strategy.produce_messages(
@@ -93,8 +89,6 @@ class SimpleProducerTest(Test):
             test_duration,
             start_time,
             message_formatter,
-            delivered_messages,
-            failed_messages,
         )
 
         # Finalize metrics collection
@@ -110,8 +104,7 @@ class SimpleProducerTest(Test):
 
         # Enhanced assertions using metrics
         assert messages_sent > 0, "No messages were sent"
-        assert len(delivered_messages) > 0, "No messages were delivered"
-        assert metrics_summary["messages_delivered"] > 0, "No messages were delivered (metrics)"
+        assert metrics_summary["messages_delivered"] > 0, "No messages were delivered"
         assert (
             metrics_summary["send_throughput_msg_per_sec"] > 10
         ), f"Send throughput too low: {metrics_summary['send_throughput_msg_per_sec']:.2f} msg/s"
@@ -161,10 +154,6 @@ class SimpleProducerTest(Test):
         def message_formatter(msg_num):
             return f"Test message {msg_num}", f"key-{msg_num}"
 
-        # Containers for results
-        delivered_messages = []
-        failed_messages = []
-
         # Run the test
         start_time = time.time()
         messages_sent = strategy.produce_messages(
@@ -172,8 +161,6 @@ class SimpleProducerTest(Test):
             test_duration,
             start_time,
             message_formatter,
-            delivered_messages,
-            failed_messages,
             use_transaction=True,
         )
 
@@ -190,8 +177,7 @@ class SimpleProducerTest(Test):
 
         # Enhanced assertions using metrics
         assert messages_sent > 0, "No messages were sent"
-        assert len(delivered_messages) > 0, "No messages were delivered"
-        assert metrics_summary["messages_delivered"] > 0, "No messages were delivered (metrics)"
+        assert metrics_summary["messages_delivered"] > 0, "No messages were delivered"
         assert (
             metrics_summary["send_throughput_msg_per_sec"] > 10
         ), f"Send throughput too low: {metrics_summary['send_throughput_msg_per_sec']:.2f} msg/s"
@@ -238,10 +224,6 @@ class SimpleProducerTest(Test):
         def message_formatter(msg_num):
             return f"Batch message {msg_num}", f"batch-key-{msg_num}"
 
-        # Containers for results
-        delivered_messages = []
-        failed_messages = []
-
         # Run the test
         start_time = time.time()
         messages_sent = strategy.produce_messages(
@@ -249,8 +231,6 @@ class SimpleProducerTest(Test):
             test_duration,
             start_time,
             message_formatter,
-            delivered_messages,
-            failed_messages,
         )
 
         # Finalize metrics collection
@@ -279,8 +259,7 @@ class SimpleProducerTest(Test):
 
         # Enhanced assertions using metrics
         assert messages_sent > 0, "No messages were sent"
-        assert len(delivered_messages) > 0, "No messages were delivered"
-        assert metrics_summary["messages_delivered"] > 0, "No messages were delivered (metrics)"
+        assert metrics_summary["messages_delivered"] > 0, "No messages were delivered"
         assert (
             metrics_summary["send_throughput_msg_per_sec"] > 10
         ), f"Send throughput too low: {metrics_summary['send_throughput_msg_per_sec']:.2f} msg/s"
@@ -362,10 +341,6 @@ class SimpleProducerTest(Test):
         def message_formatter(msg_num):
             return f"{large_message}-{msg_num}", f"comp-key-{msg_num}"
 
-        # Containers for results
-        delivered_messages = []
-        failed_messages = []
-
         # Run the test
         start_time = time.time()
         messages_sent = strategy.produce_messages(
@@ -373,8 +348,6 @@ class SimpleProducerTest(Test):
             test_duration,
             start_time,
             message_formatter,
-            delivered_messages,
-            failed_messages,
         )
 
         # Finalize metrics collection
@@ -403,8 +376,7 @@ class SimpleProducerTest(Test):
 
         # Enhanced assertions using metrics
         assert messages_sent > 0, "No messages were sent"
-        assert len(delivered_messages) > 0, "No messages were delivered"
-        assert metrics_summary["messages_delivered"] > 0, "No messages were delivered (metrics)"
+        assert metrics_summary["messages_delivered"] > 0, "No messages were delivered"
         assert metrics_summary["send_throughput_msg_per_sec"] > 5, (
             f"Send throughput too low for {compression_type}: "
             f"{metrics_summary['send_throughput_msg_per_sec']:.2f} msg/s"
@@ -516,17 +488,12 @@ class SimpleProducerTest(Test):
                 self.logger.error(f"Error creating message {i}: {e}")
                 return (f"Test message {i}", f"key-{i}")
 
-        delivered_messages = []
-        failed_messages = []
-
         start_time = time.time()
         messages_sent = strategy.produce_messages(
             topic_name,
             test_duration,
             start_time,
             message_formatter,
-            delivered_messages,
-            failed_messages,
             serialization_type,
         )
 
@@ -539,8 +506,7 @@ class SimpleProducerTest(Test):
         print_metrics_report(metrics_summary, is_valid, violations)
 
         assert messages_sent > 0, "No messages were sent"
-        assert len(delivered_messages) > 0, "No messages were delivered"
-        assert metrics_summary["messages_delivered"] > 0, "No messages were delivered (metrics)"
+        assert metrics_summary["messages_delivered"] > 0, "No messages were delivered"
         assert (
             metrics_summary["send_throughput_msg_per_sec"] > 10
         ), f"Send throughput too low: {metrics_summary['send_throughput_msg_per_sec']:.2f} msg/s"


### PR DESCRIPTION
<!--
Suggested PR template: Fill/delete/add sections as needed. Optionally delete any commented block.
-->
What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include implementation strategy.
-->

Current max_memory_growth_mb in CI is 1000, which makes the sync test_produce_with_compression perf test flaky as  the memory growth is around 1000MB. Increasing it to 1200 to better reflect the actual expected performance


`[ERROR - 2026-02-11 22:28:07,485 - test_producer - test_produce_with_compression - lineno:415]: Performance bounds validation failed for none compression: Memory growth too high: xxxMB (maximum: 1000.0MB)`
https://semaphore.ci.confluent.io/jobs/7d410d4f-a8bf-4655-a0ff-6658c86ca1de

Checklist
------------------
- [N] Contains customer facing changes? Including API/behavior changes <!-- This can help identify if it has introduced any breaking changes -->
- [N] Did you add sufficient unit test and/or integration test coverage for this PR?
  - Updating perf test threshold

References
----------
JIRA: 
<!--
Copy&paste links: to Jira ticket, other PRs, issues, Slack conversations...
For code bumps: link to PR, tag or GitHub `/compare/master...master`
-->

Test & Review
------------
<!--
Has it been tested? how?
Copy&paste any handy instructions, steps or requirements that can save time to the reviewer or any reader.
-->

Open questions / Follow-ups
--------------------------
<!--
Optional: anything open to discussion for the reviewer, out of scope, or follow-ups.
-->

<!--
Review stakeholders
------------------
<!--
Optional: mention stakeholders or if special context that is required to review.
-->
