### PR TITLE
Fix Windows wheel build: use python instead of python3

### DIFF
--- a/tools/wheels/build-wheels.bat
+++ b/tools/wheels/build-wheels.bat
@@ -25,7 +25,7 @@ set CIBW_REPAIR_WHEEL_COMMAND=python -m delvewheel repair --add-path %DLL_DIR% -
 
 set PATH=%PATH%;c:\Program Files\Git\bin\
 
-python3 -m cibuildwheel --output-dir %WHEELHOUSE% --platform windows || goto :error
+python -m cibuildwheel --output-dir %WHEELHOUSE% --platform windows || goto :error
 
 goto :eof
 


### PR DESCRIPTION
## Summary

- Replace `python3` with `python` in `build-wheels.bat` for the cibuildwheel invocation

## Context

`python3` is not a recognized command on Windows — the executable is just `python`. This causes the Windows wheel build to fail with:

```
'python3' is not recognized as an internal or external command,
operable program or batch file.
```

The rest of `build-wheels.bat` already uses `python` (for `CIBW_BEFORE_BUILD` and `CIBW_REPAIR_WHEEL_COMMAND`), so this was an inconsistency. The issue was previously masked because `sem-version python <version>` was crashing before reaching this point (fixed in https://github.com/confluentinc/ci-build-agent-infra/pull/2021), but now that `sem-version` works correctly on Windows, this is the next failure.

## Test plan

- [ ] Windows wheel build CI job passes