### PR TITLE
Avoid redundant lookup_schema call in _get_reader_schema when use_schema_id is set

### DIFF
--- a/src/confluent_kafka/schema_registry/_async/schema_registry_client.py
+++ b/src/confluent_kafka/schema_registry/_async/schema_registry_client.py
@@ -805,6 +805,8 @@ class AsyncSchemaRegistryClient(object):
         registered_schema = RegisteredSchema.from_dict(response)
 
         self._cache.set_schema(subject_name, schema_id, registered_schema.guid, registered_schema.schema)
+        if subject_name is not None:
+            self._cache.set_registered_schema(registered_schema.schema, registered_schema)
 
         return registered_schema.schema
 

--- a/src/confluent_kafka/schema_registry/_async/serde.py
+++ b/src/confluent_kafka/schema_registry/_async/serde.py
@@ -338,6 +338,9 @@ class AsyncBaseSerde(object):
     async def _get_reader_schema(self, subject: str, fmt: Optional[str] = None) -> Optional[RegisteredSchema]:
         if self._use_schema_id is not None:
             schema = await self._registry.get_schema(self._use_schema_id, subject, fmt)
+            registered_schema = self._registry._cache.get_registered_by_subject_id(subject, self._use_schema_id)
+            if registered_schema is not None:
+                return registered_schema
             return await self._registry.lookup_schema(subject, schema, normalize_schemas=False, deleted=True)
         if self._use_latest_with_metadata is not None:
             return await self._registry.get_latest_with_metadata(

--- a/src/confluent_kafka/schema_registry/_sync/schema_registry_client.py
+++ b/src/confluent_kafka/schema_registry/_sync/schema_registry_client.py
@@ -802,6 +802,8 @@ class SchemaRegistryClient(object):
         registered_schema = RegisteredSchema.from_dict(response)
 
         self._cache.set_schema(subject_name, schema_id, registered_schema.guid, registered_schema.schema)
+        if subject_name is not None:
+            self._cache.set_registered_schema(registered_schema.schema, registered_schema)
 
         return registered_schema.schema
 

--- a/src/confluent_kafka/schema_registry/_sync/serde.py
+++ b/src/confluent_kafka/schema_registry/_sync/serde.py
@@ -338,6 +338,9 @@ class BaseSerde(object):
     def _get_reader_schema(self, subject: str, fmt: Optional[str] = None) -> Optional[RegisteredSchema]:
         if self._use_schema_id is not None:
             schema = self._registry.get_schema(self._use_schema_id, subject, fmt)
+            registered_schema = self._registry._cache.get_registered_by_subject_id(subject, self._use_schema_id)
+            if registered_schema is not None:
+                return registered_schema
             return self._registry.lookup_schema(subject, schema, normalize_schemas=False, deleted=True)
         if self._use_latest_with_metadata is not None:
             return self._registry.get_latest_with_metadata(


### PR DESCRIPTION
Cache the full RegisteredSchema in get_schema when a subject is provided,
then use the cached RegisteredSchema in _get_reader_schema instead of
making a second HTTP round-trip via lookup_schema.