### PR TITLE
Fix uv venv picking up Python 3.14 on new Semaphore AMI

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -205,7 +205,7 @@ blocks:
             - sem-version python 3.11
             - pip install uv
             # use a virtualenv
-            - uv venv _venv && source _venv/bin/activate
+            - uv venv _venv --python "$(command -v python)" && source _venv/bin/activate
             - chmod u+r+x tools/source-package-verification.sh
             - tools/source-package-verification.sh
         - name: Build and Tests with 'consumer' group protocol
@@ -214,7 +214,7 @@ blocks:
             - sem-version java 17
             - pip install uv
             # use a virtualenv
-            - uv venv _venv && source _venv/bin/activate
+            - uv venv _venv --python "$(command -v python)" && source _venv/bin/activate
             - chmod u+r+x tools/source-package-verification.sh
             - export TEST_CONSUMER_GROUP_PROTOCOL=consumer
             - tools/source-package-verification.sh
@@ -223,7 +223,7 @@ blocks:
             - sem-version python 3.11
             - pip install uv
             # use a virtualenv
-            - uv venv _venv && source _venv/bin/activate
+            - uv venv _venv --python "$(command -v python)" && source _venv/bin/activate
             - chmod u+r+x tools/source-package-verification.sh
             - export RUN_COVERAGE=true
             - tools/source-package-verification.sh
@@ -247,7 +247,7 @@ blocks:
             - sem-version python 3.11
             - pip install uv
             # use a virtualenv
-            - uv venv _venv && source _venv/bin/activate
+            - uv venv _venv --python "$(command -v python)" && source _venv/bin/activate
             - chmod u+r+x tools/source-package-verification.sh
             - tools/source-package-verification.sh
   - name: "Source package verification with Python 3 (OSX x64) +docs"
@@ -266,7 +266,7 @@ blocks:
             - sem-version python 3.11
             - pip install uv
             # use a virtualenv
-            - uv venv _venv && source _venv/bin/activate
+            - uv venv _venv --python "$(command -v python)" && source _venv/bin/activate
             - chmod u+r+x tools/source-package-verification.sh
             - tools/source-package-verification.sh
   - name: "Source package verification with Python 3 (OSX arm64) +docs"
@@ -285,7 +285,7 @@ blocks:
             - sem-version python 3.11
             - pip install uv
             # use a virtualenv
-            - uv venv _venv && source _venv/bin/activate
+            - uv venv _venv --python "$(command -v python)" && source _venv/bin/activate
             - chmod u+r+x tools/source-package-verification.sh
             - tools/source-package-verification.sh
   - name: "Ducktape Performance Tests (Linux x64)"
@@ -311,7 +311,7 @@ blocks:
             - export ARCH=x64
             - sem-version python 3.11
             - pip install uv
-            - uv venv _venv && source _venv/bin/activate
+            - uv venv _venv --python "$(command -v python)" && source _venv/bin/activate
 
             # Install ducktape framework and additional dependencies
             - uv pip install ducktape psutil


### PR DESCRIPTION
## Root Cause
New Semaphore AMIs ship with Python 3.14 as the system default. Even though our pipeline calls `sem-version python 3.11` before `uv venv`, `uv` ignores this and auto-discovers 3.14. Since `google-re2` has no pre-built wheel for 3.14, pip/uv falls back to building from source, which fails because `absl/strings/string_view.h` is not installed on the agent.

## Fix
Pass `--python "$(command -v python)"` to all `uv venv` calls in `semaphore.yml` to ensure the pinned Python version is used
