### PR TITLE
Fix logger type in docs and add Consumer/Producer logger examples

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1074,8 +1074,10 @@ addition to the properties dictated by the underlying librdkafka C library:
   commit error, or None on success. *list(TopicPartition)* is the list of partitions with their committed
   offsets or per-partition errors.
 
-* ``logger=logging.Handler`` kwarg: forward logs from the Kafka client to the
-  provided ``logging.Handler`` instance.
+* ``logger=logging.Logger`` kwarg: forward logs from the Kafka client to the
+  provided ``logging.Logger`` instance.
+  Internally the client calls ``logger.log(level, msg, *args)``, so any object
+  with a compatible ``log()`` method will work (e.g., ``logging.LoggerAdapter``).
   To avoid spontaneous calls from non-Python threads the log messages
   will only be forwarded when ``client.poll()`` or ``producer.flush()`` are called.
   For example:

--- a/examples/consumer_logger.py
+++ b/examples/consumer_logger.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python
+#
+# Copyright 2024 Confluent Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import logging
+import sys
+
+from confluent_kafka import Consumer
+
+if len(sys.argv) != 2:
+    sys.stderr.write("Usage: %s <broker>\n" % sys.argv[0])
+    sys.exit(1)
+
+broker = sys.argv[1]
+
+# Custom logger
+logger = logging.getLogger('Consumer')
+logger.setLevel(logging.DEBUG)
+handler = logging.StreamHandler()
+handler.setFormatter(logging.Formatter('%(asctime)-15s %(levelname)-8s %(message)s'))
+logger.addHandler(handler)
+
+# Create Consumer with logger
+# The logger must be an object with a log(level, msg, *args) method,
+# such as logging.Logger or logging.LoggerAdapter.
+c = Consumer({'bootstrap.servers': broker,
+              'group.id': 'example-logger-group',
+              'debug': 'all'},
+             logger=logger)
+
+# Alternatively, pass the logger as a key in the config dict.
+# When passed as a kwarg, it overwrites the config key.
+#
+# c = Consumer({'bootstrap.servers': broker,
+#               'group.id': 'example-logger-group',
+#               'debug': 'all',
+#               'logger': logger})
+
+c.subscribe(['test'])
+
+# Log messages are forwarded when poll() is called
+for _ in range(10):
+    msg = c.poll(timeout=0.5)
+    if msg is not None and not msg.error():
+        print("Received: %s" % msg.value().decode('utf-8'))
+
+c.close()

--- a/examples/producer_logger.py
+++ b/examples/producer_logger.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python
+#
+# Copyright 2024 Confluent Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import logging
+import sys
+
+from confluent_kafka import Producer
+
+if len(sys.argv) != 2:
+    sys.stderr.write("Usage: %s <broker>\n" % sys.argv[0])
+    sys.exit(1)
+
+broker = sys.argv[1]
+
+# Custom logger
+logger = logging.getLogger('Producer')
+logger.setLevel(logging.DEBUG)
+handler = logging.StreamHandler()
+handler.setFormatter(logging.Formatter('%(asctime)-15s %(levelname)-8s %(message)s'))
+logger.addHandler(handler)
+
+# Create Producer with logger
+# The logger must be an object with a log(level, msg, *args) method,
+# such as logging.Logger or logging.LoggerAdapter.
+p = Producer({'bootstrap.servers': broker, 'debug': 'all'}, logger=logger)
+
+# Alternatively, pass the logger as a key in the config dict.
+# When passed as a kwarg, it overwrites the config key.
+#
+# p = Producer({'bootstrap.servers': broker,
+#               'debug': 'all',
+#               'logger': logger})
+
+# Log messages are forwarded when poll() or flush() is called
+p.poll(0)
+p.flush()


### PR DESCRIPTION
## Summary

The documentation incorrectly states `logger=logging.Handler` when the client actually calls `logger.log(level, msg, *args)`, which is a `logging.Logger` method (not `logging.Handler`). This PR fixes the type in the docs, clarifies that any object with a compatible `log()` method works, and adds dedicated Consumer and Producer logger examples.

Fixes #1668

## Changes

- **`docs/index.rst`** — Changed `logger=logging.Handler` to `logger=logging.Logger` and added a note that `logger.log(level, msg, *args)` is the required interface (so `logging.LoggerAdapter` also works).
- **`examples/consumer_logger.py`** — New example demonstrating Consumer with a custom `logging.Logger`, including the alternative config-dict approach.
- **`examples/producer_logger.py`** — New example demonstrating Producer with a custom `logging.Logger`, including the alternative config-dict approach.

## Verification Script

A verification script (`verify_example.sh`) validates the changes end-to-end. It creates its own virtual environment, installs `confluent-kafka`, and cleans up after itself.

### What it tests

Syntax checks on both new examples, import validation, runtime check that producer_logger.py emits log output via the custom logger against a dummy broker, and documentation checks that `logging.Logger` is used (not `logging.Handler`).

### Expected output

All 6 checks pass with `SUCCESS`.

### Actual output

```
=== Creating virtual environment ===
[notice] To update, run: pip install --upgrade pip
=== Syntax checks ===
  PASS: consumer_logger.py syntax
  PASS: producer_logger.py syntax

=== Import checks ===
  PASS: confluent_kafka importable

=== Producer logger runtime check ===
  PASS: producer_logger.py emits log output

=== Documentation check ===
  PASS: docs/index.rst uses logging.Logger
  PASS: docs/index.rst has no logging.Handler references

=== Results: 6 passed, 0 failed ===
SUCCESS
```

### Script

```bash
#!/usr/bin/env bash
set -euo pipefail

SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
VENV_DIR="${SCRIPT_DIR}/.venv"
PASS=0
FAIL=0

# Set up a virtual environment and install confluent-kafka
if [ ! -d "$VENV_DIR" ]; then
  echo "=== Creating virtual environment ==="
  python3 -m venv "$VENV_DIR"
fi
source "$VENV_DIR/bin/activate"
pip install -q confluent-kafka 2>&1 | tail -1

pass() { echo "  PASS: $1"; PASS=$((PASS + 1)); }
fail() { echo "  FAIL: $1"; FAIL=$((FAIL + 1)); }

echo "=== Syntax checks ==="
python3 -c "import ast; ast.parse(open('${SCRIPT_DIR}/consumer_logger.py').read())" \
  && pass "consumer_logger.py syntax" || fail "consumer_logger.py syntax"
python3 -c "import ast; ast.parse(open('${SCRIPT_DIR}/producer_logger.py').read())" \
  && pass "producer_logger.py syntax" || fail "producer_logger.py syntax"

echo ""
echo "=== Import checks ==="
python3 -c "import confluent_kafka" 2>/dev/null \
  && pass "confluent_kafka importable" || fail "confluent_kafka not installed"

echo ""
echo "=== Producer logger runtime check ==="
OUTPUT=$(python3 "${SCRIPT_DIR}/producer_logger.py" "localhost:19092" 2>&1 || true)
if echo "$OUTPUT" | grep -qi "Producer.*INIT\|Producer.*CONNECT\|Producer.*FAIL"; then
  pass "producer_logger.py emits log output"
else
  fail "producer_logger.py did not emit expected log output"
fi

echo ""
echo "=== Documentation check ==="
grep -q 'logger=logging\.Logger' "${REPO_ROOT}/docs/index.rst" \
  && pass "docs/index.rst uses logging.Logger" || fail "docs/index.rst still references logging.Handler"
grep -q 'logging\.Handler' "${REPO_ROOT}/docs/index.rst" \
  && fail "docs/index.rst still contains logging.Handler" || pass "docs/index.rst has no logging.Handler references"

echo ""
echo "=== Results: ${PASS} passed, ${FAIL} failed ==="
deactivate 2>/dev/null || true
rm -rf "$VENV_DIR"
[ "$FAIL" -gt 0 ] && echo "FAIL" && exit 1 || echo "SUCCESS"
```

## Test plan

- [x] Verification script passes (`./verify_example.sh`)
- [x] Both examples have valid syntax and follow existing repo conventions
- [x] Documentation correctly references `logging.Logger`

🤖 Generated with [Claude Code](https://claude.com/claude-code)