### PR TITLE
[KIP-932] : Implement acknowledgement callback for Share Consumer

### DIFF
--- a/.formatignore
+++ b/.formatignore
@@ -12,3 +12,7 @@ tests/integration/schema_registry/data/proto/TestProto_pb2.py
 tests/integration/schema_registry/data/proto/common_proto_pb2.py
 tests/integration/schema_registry/data/proto/exampleProtoCriteo_pb2.py
 tests/integration/schema_registry/data/proto/metadata_proto_pb2.py
+
+# Hand-maintained type stub. tools/style-format.sh runs clang-format on any
+# file that isn't .py, and that corrupts the stub. Keep it out.
+src/confluent_kafka/cimpl.pyi

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -11,7 +11,7 @@ global_job_config:
       value: v2.14.2
     # TODO KIP-932: Remove LIBRDKAFKA_BRANCH once LIBRDKAFKA_VERSION includes share consumer support
     - name: LIBRDKAFKA_BRANCH
-      value: dev_kip-932_queues-for-kafka_additional_api_python
+      value: dev_kip-932_queues-for-kafka
   prologue:
     commands:
       - checkout

--- a/src/confluent_kafka/_types.py
+++ b/src/confluent_kafka/_types.py
@@ -36,3 +36,4 @@ Deserializer = Callable[[Optional[bytes], Any], Any]  # (Optional[bytes], Serial
 # These are defined here to avoid circular imports
 DeliveryCallback = Callable[[Optional[Any], Any], None]  # (KafkaError, Message) -> None
 RebalanceCallback = Callable[[Any, List[Any]], None]  # (Consumer, List[TopicPartition]) -> None
+AcknowledgementCommitCallback = Callable[[Dict[Any, Any], Optional[Any]], None]  # (offsets, KafkaException) -> None

--- a/src/confluent_kafka/cimpl.pyi
+++ b/src/confluent_kafka/cimpl.pyi
@@ -1,49 +1,46 @@
-#Copyright 2025 Confluent Inc.
+# Copyright 2025 Confluent Inc.
 #
-#Licensed under the Apache License, Version 2.0(the "License");
-#you may not use this file except in compliance with the License.
-#You may obtain a copy of the License at
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
 #
-#http:  // www.apache.org/licenses/LICENSE-2.0
+# http://www.apache.org/licenses/LICENSE-2.0
 #
-#Unless required by applicable law or agreed to in writing, software
-#distributed under the License is distributed on an "AS IS" BASIS,
-#WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-#See the License for the specific language governing permissions and
-#limitations under the License.
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 """
 Type stubs for confluent_kafka.cimpl
 
-This combines automatic stubgen output (constants, functions)
-with manual class definitions based on runtime introspection and
-            domain knowledge.
+This combines automatic stubgen output (constants, functions) with
+manual class definitions based on runtime introspection and domain knowledge.
 
-⚠️ WARNING : MAINTENANCE REQUIRED ⚠️ This stub file must be kept in sync with the
-                 C extension source code in src /
-    : -src / Admin.c(AdminClientImpl methods) -
-    src / Producer.c(Producer class) - src / Consumer.c(Consumer class) -
-    src / AdminTypes.c(NewTopic, NewPartitions classes) -
-    src / confluent_kafka.c(KafkaError, Message, TopicPartition, Uuid classes)
+⚠️ WARNING: MAINTENANCE REQUIRED ⚠️
+This stub file must be kept in sync with the C extension source code in src/:
+- src/Admin.c (AdminClientImpl methods)
+- src/Producer.c (Producer class)
+- src/Consumer.c (Consumer class)
+- src/AdminTypes.c (NewTopic, NewPartitions classes)
+- src/confluent_kafka.c (KafkaError, Message, TopicPartition, Uuid classes)
 
-              When modifying C extension
-          interfaces(method signatures, parameters, defaults),
-    you MUST update the corresponding type definitions in this file
-        .Failure to do so will result in incorrect type hints and mypy errors
-        .
+When modifying C extension interfaces (method signatures, parameters, defaults),
+you MUST update the corresponding type definitions in this file.
+Failure to do so will result in incorrect type hints and mypy errors.
 
-    TODO : Consider migrating to Cython in the future to eliminate
-           this dual maintenance burden and get type hints directly from the
-           implementation
-        .""
-         "
+TODO: Consider migrating to Cython in the future to eliminate this dual
+maintenance burden and get type hints directly from the implementation.
+"""
 
-           import builtins from typing import Any,
-    Callable, Dict, FrozenSet, List, Literal, Optional, Tuple, Union,
-    overload
+import builtins
+from typing import Any, Callable, Dict, FrozenSet, List, Literal, Optional, Tuple, Union, overload
 
-    try : from typing import Self except ImportError:
-#FIXME : drop fallback once we require Python >= 3.11
+try:
+    from typing import Self
+except ImportError:
+    # FIXME: drop fallback once we require Python >= 3.11
     from typing_extensions import Self
 
 from confluent_kafka.admin._metadata import ClusterMetadata, GroupMetadata
@@ -51,17 +48,15 @@ from confluent_kafka.admin._metadata import ClusterMetadata, GroupMetadata
 from ._model import AcknowledgeType
 from ._types import HeadersType
 
-#Callback types with proper class references(                                  \
-    defined locally to avoid circular imports)
+# Callback types with proper class references (defined locally to avoid circular imports)
 DeliveryCallback = Callable[[Optional['KafkaError'], 'Message'], None]
 RebalanceCallback = Callable[['Consumer', List['TopicPartition']], None]
-#(offsets, exception) — note the order is offsets - first,                     \
-  opposite of on_commit.
+# (offsets, exception) — note the order is offsets-first, opposite of on_commit.
 AcknowledgementCommitCallback = Callable[
     [Dict['TopicPartition', FrozenSet[int]], Optional['KafkaException']], None
 ]
 
-#== == = CLASSES(Manual - stubgen missed these) == == =
+# ===== CLASSES (Manual - stubgen missed these) =====
 
 class KafkaError:
     BROKER_NOT_AVAILABLE: int
@@ -583,20 +578,18 @@ class ShareConsumer:
     def subscribe(self, topics: List[str]) -> None: ...
     def unsubscribe(self) -> None: ...
     def subscription(self) -> List[str]: ...
-#TODO KIP - 932 : poll() returns List[Message] today.Java returns a
-#dedicated container object(ConsumerRecords) instead of a list so it
-#can carry extra metadata alongside the records.Replace List[Message]
-#with a Messages container class once we have a clear use for that
-#metadata in Python.
+    # TODO KIP-932: poll() returns List[Message] today. Replace it with a
+    # Messages container class once we have a clear use for carrying extra
+    # metadata alongside the records.
     def poll(self, timeout: float = -1) -> List[Message]: ...
     def acknowledge(self, message: Message, ack_type: AcknowledgeType = ...) -> None: ...
     def acknowledge_offset(
         self, topic: str, partition: int, offset: int, ack_type: AcknowledgeType = ...
     ) -> None: ...
-#TODO KIP - 932 : Java's share-consumer commit returns a map keyed by
-#TopicIdPartition(topic name + topic UUID + partition).Python uses
-#the existing TopicPartition(no UUID) for now.Add a TopicIdPartition
-#class once the interface is finalized.
+    # TODO KIP-932: commit_sync() is keyed by the existing TopicPartition
+    # (no UUID) for now. A future TopicIdPartition (topic name + topic UUID
+    # + partition) would carry the UUID; add that class once the interface
+    # is finalized.
     def commit_sync(self, timeout: float = 60) -> Dict[TopicPartition, Optional[KafkaError]]: ...
     def commit_async(self) -> None: ...
     def set_acknowledgement_commit_callback(
@@ -762,7 +755,7 @@ class NewPartitions:
     def __gt__(self, other: 'NewPartitions') -> bool: ...
     def __ge__(self, other: 'NewPartitions') -> bool: ...
 
-#== == = MODULE FUNCTIONS(From stubgen) == == =
+# ===== MODULE FUNCTIONS (From stubgen) =====
 
 def libversion() -> Tuple[str, int]: ...
 def version() -> Tuple[str, int]: ...
@@ -770,7 +763,7 @@ def murmur2(key: bytes, partition_count: int) -> int: ...
 def consistent(key: bytes, partition_count: int) -> int: ...
 def fnv1a(key: bytes, partition_count: int) -> int: ...
 
-#== == = CONSTANTS(From stubgen) == == =
+# ===== CONSTANTS (From stubgen) =====
 
 ACL_OPERATION_ALL: int
 ACL_OPERATION_ALTER: int

--- a/src/confluent_kafka/cimpl.pyi
+++ b/src/confluent_kafka/cimpl.pyi
@@ -35,7 +35,7 @@ maintenance burden and get type hints directly from the implementation.
 """
 
 import builtins
-from typing import Any, Callable, Dict, List, Literal, Optional, Tuple, Union, overload
+from typing import Any, Callable, Dict, FrozenSet, List, Literal, Optional, Tuple, Union, overload
 
 try:
     from typing import Self
@@ -51,6 +51,11 @@ from ._types import HeadersType
 # Callback types with proper class references (defined locally to avoid circular imports)
 DeliveryCallback = Callable[[Optional['KafkaError'], 'Message'], None]
 RebalanceCallback = Callable[['Consumer', List['TopicPartition']], None]
+# Argument order mirrors Java AcknowledgementCommitCallback.onComplete:
+# (offsets, exception), not (err, parts) like on_commit.
+AcknowledgementCommitCallback = Callable[
+    [Dict['TopicPartition', FrozenSet[int]], Optional['KafkaException']], None
+]
 
 # ===== CLASSES (Manual - stubgen missed these) =====
 
@@ -590,6 +595,9 @@ class ShareConsumer:
     # class once the interface is finalized.
     def commit_sync(self, timeout: float = 60) -> Dict[TopicPartition, Optional[KafkaError]]: ...
     def commit_async(self) -> None: ...
+    def set_acknowledgement_commit_callback(
+        self, callback: Optional[AcknowledgementCommitCallback]
+    ) -> None: ...
     def close(self) -> None: ...
     def __enter__(self) -> "ShareConsumer": ...
     def __exit__(self, exc_type: Any, exc_value: Any, exc_traceback: Any) -> Optional[bool]: ...

--- a/src/confluent_kafka/cimpl.pyi
+++ b/src/confluent_kafka/cimpl.pyi
@@ -35,7 +35,7 @@ maintenance burden and get type hints directly from the implementation.
 """
 
 import builtins
-from typing import Any, Callable, Dict, FrozenSet, List, Literal, Optional, Tuple, Union, overload
+from typing import Any, Callable, Dict, List, Literal, Optional, Set, Tuple, Union, overload
 
 try:
     from typing import Self
@@ -53,7 +53,7 @@ DeliveryCallback = Callable[[Optional['KafkaError'], 'Message'], None]
 RebalanceCallback = Callable[['Consumer', List['TopicPartition']], None]
 # (offsets, exception) — note the order is offsets-first, opposite of on_commit.
 AcknowledgementCommitCallback = Callable[
-    [Dict['TopicPartition', FrozenSet[int]], Optional['KafkaException']], None
+    [Dict['TopicPartition', Set[int]], Optional['KafkaException']], None
 ]
 
 # ===== CLASSES (Manual - stubgen missed these) =====

--- a/src/confluent_kafka/cimpl.pyi
+++ b/src/confluent_kafka/cimpl.pyi
@@ -51,8 +51,7 @@ from ._types import HeadersType
 # Callback types with proper class references (defined locally to avoid circular imports)
 DeliveryCallback = Callable[[Optional['KafkaError'], 'Message'], None]
 RebalanceCallback = Callable[['Consumer', List['TopicPartition']], None]
-# Argument order mirrors Java AcknowledgementCommitCallback.onComplete:
-# (offsets, exception), not (err, parts) like on_commit.
+# (offsets, exception) — note the order is offsets-first, opposite of on_commit.
 AcknowledgementCommitCallback = Callable[
     [Dict['TopicPartition', FrozenSet[int]], Optional['KafkaException']], None
 ]

--- a/src/confluent_kafka/cimpl.pyi
+++ b/src/confluent_kafka/cimpl.pyi
@@ -1,46 +1,49 @@
-# Copyright 2025 Confluent Inc.
+#Copyright 2025 Confluent Inc.
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
+#Licensed under the Apache License, Version 2.0(the "License");
+#you may not use this file except in compliance with the License.
+#You may obtain a copy of the License at
 #
-# http://www.apache.org/licenses/LICENSE-2.0
+#http:  // www.apache.org/licenses/LICENSE-2.0
 #
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+#Unless required by applicable law or agreed to in writing, software
+#distributed under the License is distributed on an "AS IS" BASIS,
+#WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#See the License for the specific language governing permissions and
+#limitations under the License.
 
 """
 Type stubs for confluent_kafka.cimpl
 
-This combines automatic stubgen output (constants, functions) with
-manual class definitions based on runtime introspection and domain knowledge.
+This combines automatic stubgen output (constants, functions)
+with manual class definitions based on runtime introspection and
+            domain knowledge.
 
-⚠️ WARNING: MAINTENANCE REQUIRED ⚠️
-This stub file must be kept in sync with the C extension source code in src/:
-- src/Admin.c (AdminClientImpl methods)
-- src/Producer.c (Producer class)
-- src/Consumer.c (Consumer class)
-- src/AdminTypes.c (NewTopic, NewPartitions classes)
-- src/confluent_kafka.c (KafkaError, Message, TopicPartition, Uuid classes)
+⚠️ WARNING : MAINTENANCE REQUIRED ⚠️ This stub file must be kept in sync with the
+                 C extension source code in src /
+    : -src / Admin.c(AdminClientImpl methods) -
+    src / Producer.c(Producer class) - src / Consumer.c(Consumer class) -
+    src / AdminTypes.c(NewTopic, NewPartitions classes) -
+    src / confluent_kafka.c(KafkaError, Message, TopicPartition, Uuid classes)
 
-When modifying C extension interfaces (method signatures, parameters, defaults),
-you MUST update the corresponding type definitions in this file.
-Failure to do so will result in incorrect type hints and mypy errors.
+              When modifying C extension
+          interfaces(method signatures, parameters, defaults),
+    you MUST update the corresponding type definitions in this file
+        .Failure to do so will result in incorrect type hints and mypy errors
+        .
 
-TODO: Consider migrating to Cython in the future to eliminate this dual
-maintenance burden and get type hints directly from the implementation.
-"""
+    TODO : Consider migrating to Cython in the future to eliminate
+           this dual maintenance burden and get type hints directly from the
+           implementation
+        .""
+         "
 
-import builtins
-from typing import Any, Callable, Dict, FrozenSet, List, Literal, Optional, Tuple, Union, overload
+           import builtins from typing import Any,
+    Callable, Dict, FrozenSet, List, Literal, Optional, Tuple, Union,
+    overload
 
-try:
-    from typing import Self
-except ImportError:
-    # FIXME: drop fallback once we require Python >= 3.11
+    try : from typing import Self except ImportError:
+#FIXME : drop fallback once we require Python >= 3.11
     from typing_extensions import Self
 
 from confluent_kafka.admin._metadata import ClusterMetadata, GroupMetadata
@@ -48,15 +51,17 @@ from confluent_kafka.admin._metadata import ClusterMetadata, GroupMetadata
 from ._model import AcknowledgeType
 from ._types import HeadersType
 
-# Callback types with proper class references (defined locally to avoid circular imports)
+#Callback types with proper class references(                                  \
+    defined locally to avoid circular imports)
 DeliveryCallback = Callable[[Optional['KafkaError'], 'Message'], None]
 RebalanceCallback = Callable[['Consumer', List['TopicPartition']], None]
-# (offsets, exception) — note the order is offsets-first, opposite of on_commit.
+#(offsets, exception) — note the order is offsets - first,                     \
+  opposite of on_commit.
 AcknowledgementCommitCallback = Callable[
     [Dict['TopicPartition', FrozenSet[int]], Optional['KafkaException']], None
 ]
 
-# ===== CLASSES (Manual - stubgen missed these) =====
+#== == = CLASSES(Manual - stubgen missed these) == == =
 
 class KafkaError:
     BROKER_NOT_AVAILABLE: int
@@ -578,20 +583,20 @@ class ShareConsumer:
     def subscribe(self, topics: List[str]) -> None: ...
     def unsubscribe(self) -> None: ...
     def subscription(self) -> List[str]: ...
-    # TODO KIP-932: poll() returns List[Message] today. Java returns a
-    # dedicated container object (ConsumerRecords) instead of a list so it
-    # can carry extra metadata alongside the records. Replace List[Message]
-    # with a Messages container class once we have a clear use for that
-    # metadata in Python.
+#TODO KIP - 932 : poll() returns List[Message] today.Java returns a
+#dedicated container object(ConsumerRecords) instead of a list so it
+#can carry extra metadata alongside the records.Replace List[Message]
+#with a Messages container class once we have a clear use for that
+#metadata in Python.
     def poll(self, timeout: float = -1) -> List[Message]: ...
     def acknowledge(self, message: Message, ack_type: AcknowledgeType = ...) -> None: ...
     def acknowledge_offset(
         self, topic: str, partition: int, offset: int, ack_type: AcknowledgeType = ...
     ) -> None: ...
-    # TODO KIP-932: Java's share-consumer commit returns a map keyed by
-    # TopicIdPartition (topic name + topic UUID + partition). Python uses
-    # the existing TopicPartition (no UUID) for now. Add a TopicIdPartition
-    # class once the interface is finalized.
+#TODO KIP - 932 : Java's share-consumer commit returns a map keyed by
+#TopicIdPartition(topic name + topic UUID + partition).Python uses
+#the existing TopicPartition(no UUID) for now.Add a TopicIdPartition
+#class once the interface is finalized.
     def commit_sync(self, timeout: float = 60) -> Dict[TopicPartition, Optional[KafkaError]]: ...
     def commit_async(self) -> None: ...
     def set_acknowledgement_commit_callback(
@@ -757,7 +762,7 @@ class NewPartitions:
     def __gt__(self, other: 'NewPartitions') -> bool: ...
     def __ge__(self, other: 'NewPartitions') -> bool: ...
 
-# ===== MODULE FUNCTIONS (From stubgen) =====
+#== == = MODULE FUNCTIONS(From stubgen) == == =
 
 def libversion() -> Tuple[str, int]: ...
 def version() -> Tuple[str, int]: ...
@@ -765,7 +770,7 @@ def murmur2(key: bytes, partition_count: int) -> int: ...
 def consistent(key: bytes, partition_count: int) -> int: ...
 def fnv1a(key: bytes, partition_count: int) -> int: ...
 
-# ===== CONSTANTS (From stubgen) =====
+#== == = CONSTANTS(From stubgen) == == =
 
 ACL_OPERATION_ALL: int
 ACL_OPERATION_ALTER: int

--- a/src/confluent_kafka/src/ShareConsumer.c
+++ b/src/confluent_kafka/src/ShareConsumer.c
@@ -596,8 +596,9 @@ static void ShareConsumer_acknowledgement_commit_cb(
 
         cs = CallState_get(self);
 
-        offsets = partitions ? c_share_partition_offsets_list_to_py(partitions)
-                             : PyDict_New();
+        offsets = partitions
+                      ? c_share_partition_offsets_list_to_py_dict(partitions)
+                      : PyDict_New();
         if (!offsets)
                 goto crash;
 
@@ -630,6 +631,11 @@ static void ShareConsumer_acknowledgement_commit_cb(
 crash:
         CallState_fetch_exception(cs);
         CallState_crash(cs);
+        /* NULL is fine: rd_kafka_yield() only sets a thread-local flag and
+         * never reads the handle. We couldn't pass the real rk
+         * since rd_kafka_share_t keeps its rd_kafka_t private.
+         * TODO KIP-932: pass the real handle once a
+         * share -> rd_kafka_t accessor exists. */
         rd_kafka_yield(NULL);
 
 done:
@@ -932,8 +938,12 @@ static PyMethodDef ShareConsumer_methods[] = {
      METH_VARARGS | METH_KEYWORDS,
      ".. py:function:: set_acknowledgement_commit_callback(callback)\n"
      "\n"
-     "  Register a callback invoked once per acknowledgement-commit response\n"
-     "  from the broker. Fires on the thread that calls :py:func:`poll`.\n"
+     "  Register a callback invoked with the acknowledged offsets once the\n"
+     "  broker responds to an acknowledgement commit. It is always dispatched\n"
+     "  on the application thread, from within whichever consumer call is\n"
+     "  serving the response queue (:py:func:`poll`, :py:func:`commit_sync`,\n"
+     "  or :py:func:`close`), never from a background thread. Results of\n"
+     "  :py:func:`commit_async` are delivered on a subsequent such call.\n"
      "\n"
      "  :param callback: A callable\n"
      "      ``callback(offsets, exception)`` where ``offsets`` is a\n"
@@ -942,7 +952,9 @@ static PyMethodDef ShareConsumer_methods[] = {
      "      on failure or ``None`` on success. Pass ``None`` to clear the\n"
      "      currently registered callback.\n"
      "  :raises TypeError: if ``callback`` is neither callable nor None.\n"
-     "  :raises KafkaException: if called from inside the callback itself.\n"
+     "  :raises KafkaException: with ``_STATE`` if called from within the\n"
+     "      acknowledgement-commit callback. This applies to every\n"
+     "      ShareConsumer method.\n"
      "  :raises RuntimeError: if called on a closed share consumer.\n"
      "\n"},
 

--- a/src/confluent_kafka/src/ShareConsumer.c
+++ b/src/confluent_kafka/src/ShareConsumer.c
@@ -651,7 +651,7 @@ ShareConsumer_set_acknowledgement_commit_callback(ShareConsumerHandle *self,
                                                   PyObject *args,
                                                   PyObject *kwargs) {
         PyObject *callback = NULL;
-        rd_kafka_resp_err_t err;
+        rd_kafka_error_t *error;
         static char *kws[] = {"callback", NULL};
 
         if (!self->rkshare) {
@@ -669,15 +669,13 @@ ShareConsumer_set_acknowledgement_commit_callback(ShareConsumerHandle *self,
                 return NULL;
         }
 
-        err = rd_kafka_share_set_acknowledgement_cb(
+        error = rd_kafka_share_set_acknowledgement_commit_cb(
             self->rkshare,
             callback == Py_None ? NULL
                                 : ShareConsumer_acknowledgement_commit_cb,
             &self->base);
-        if (err) {
-                cfl_PyErr_Format(
-                    err, "Failed to set acknowledgement commit callback: %s",
-                    rd_kafka_err2str(err));
+        if (error) {
+                cfl_PyErr_from_error_destroy(error);
                 return NULL;
         }
 

--- a/src/confluent_kafka/src/ShareConsumer.c
+++ b/src/confluent_kafka/src/ShareConsumer.c
@@ -55,9 +55,11 @@ static void ShareConsumer_clear0(ShareConsumerHandle *self) {
          * time for share consumers (see
          * ShareConsumer_reject_incompatible_config), so nothing else needs
          * releasing here. */
-        if (self->base.u.Consumer.on_share_acknowledgement_commit) {
-                Py_DECREF(self->base.u.Consumer.on_share_acknowledgement_commit);
-                self->base.u.Consumer.on_share_acknowledgement_commit = NULL;
+        if (self->base.u.ShareConsumer.on_share_acknowledgement_commit) {
+                Py_DECREF(
+                    self->base.u.ShareConsumer.on_share_acknowledgement_commit);
+                self->base.u.ShareConsumer.on_share_acknowledgement_commit =
+                    NULL;
         }
 }
 
@@ -92,8 +94,9 @@ static void ShareConsumer_dealloc(ShareConsumerHandle *self) {
 
 static int
 ShareConsumer_traverse(ShareConsumerHandle *self, visitproc visit, void *arg) {
-        if (self->base.u.Consumer.on_share_acknowledgement_commit)
-                Py_VISIT(self->base.u.Consumer.on_share_acknowledgement_commit);
+        if (self->base.u.ShareConsumer.on_share_acknowledgement_commit)
+                Py_VISIT(
+                    self->base.u.ShareConsumer.on_share_acknowledgement_commit);
         return Handle_traverse(&self->base, visit, arg);
 }
 
@@ -574,18 +577,13 @@ static PyObject *ShareConsumer_commit_async(ShareConsumerHandle *self,
 /**
  * @brief Trampoline for the share-consumer acknowledgement-commit callback.
  *
- * Invoked by librdkafka from inside rd_kafka_share_consume_batch (i.e., from
- * within ShareConsumer_poll), once per acknowledgement-commit response. The
- * \p partitions list is owned by librdkafka and destroyed when this function
- * returns; do not free it.
+ * Called once per acknowledgement-commit response, from inside
+ * rd_kafka_share_consume_batch's rk_rep drain. The \p partitions list is
+ * owned by librdkafka — do not free it.
  *
- * Python signature (matches Java AcknowledgementCommitCallback.onComplete):
+ * Python signature:
  *     callback(offsets: Dict[TopicPartition, frozenset[int]],
  *              exception: KafkaException | None) -> None
- *
- * Note the (offsets, exception) order intentionally diverges from
- * Consumer on_commit's (err, parts) — Java parity wins here, per the
- * AcknowledgementCommitCallback.onComplete contract.
  */
 static void ShareConsumer_acknowledgement_commit_cb(
     rd_kafka_share_t *rkshare,
@@ -599,7 +597,7 @@ static void ShareConsumer_acknowledgement_commit_cb(
         PyObject *result  = NULL;
         CallState *cs;
 
-        if (!self->u.Consumer.on_share_acknowledgement_commit)
+        if (!self->u.ShareConsumer.on_share_acknowledgement_commit)
                 return;
 
         cs = CallState_get(self);
@@ -629,25 +627,13 @@ static void ShareConsumer_acknowledgement_commit_cb(
         }
 
         result = PyObject_CallObject(
-            self->u.Consumer.on_share_acknowledgement_commit, args);
+            self->u.ShareConsumer.on_share_acknowledgement_commit, args);
         if (!result)
                 goto crash;
 
         goto done;
 
 crash:
-        /* Stage the failure for the outer poll/commit_sync to surface, and
-         * short-circuit the current rk_rep drain.
-         *
-         * The fetched exception is restored by CallState_end.
-         * rd_kafka_yield's rk arg is unused — the impl only flips a TLS flag
-         * (rdkafka_queue.c:37-39) that rd_kafka_q_serve consults. The
-         * share-ack cb is dispatched by a q_serve drain inside
-         * rd_kafka_share_consume_batch (rdkafka.c:3844/3876), so the flag
-         * does short-circuit the current drain pass and stop subsequent cbs
-         * in this poll() from firing on a broken Python state. Passing NULL
-         * because rd_kafka_share_t exposes no public accessor to the
-         * underlying rd_kafka_t. */
         CallState_fetch_exception(cs);
         CallState_crash(cs);
         rd_kafka_yield(NULL);
@@ -664,9 +650,7 @@ done:
 /**
  * @brief Set or clear the acknowledgement-commit callback at runtime.
  *
- * Mirrors Java's ShareConsumer.setAcknowledgementCommitCallback(callback).
- * Pass None to clear. May be called any time except from within the callback
- * itself (librdkafka returns _STATE in that case).
+ * Pass None to clear.
  */
 static PyObject *ShareConsumer_set_acknowledgement_commit_callback(
     ShareConsumerHandle *self,
@@ -707,12 +691,12 @@ static PyObject *ShareConsumer_set_acknowledgement_commit_callback(
         /* Swap the stashed PyObject only after librdkafka accepts the
          * registration so a failed registration leaves the prior callback
          * intact. */
-        Py_XDECREF(self->base.u.Consumer.on_share_acknowledgement_commit);
+        Py_XDECREF(self->base.u.ShareConsumer.on_share_acknowledgement_commit);
         if (callback == Py_None) {
-                self->base.u.Consumer.on_share_acknowledgement_commit = NULL;
+                self->base.u.ShareConsumer.on_share_acknowledgement_commit = NULL;
         } else {
                 Py_INCREF(callback);
-                self->base.u.Consumer.on_share_acknowledgement_commit =
+                self->base.u.ShareConsumer.on_share_acknowledgement_commit =
                     callback;
         }
 
@@ -852,15 +836,13 @@ static PyMethodDef ShareConsumer_methods[] = {
      "\n"},
 
     /* TODO KIP-932: librdkafka error code → Python exception mapping is
-     * provisional. Today the share consumer translates every librdkafka
-     * error code into KafkaException via cfl_PyErr_Format(). Longer term we
-     * want each code to map to the Python exception a user porting from
-     * Java would expect, e.g.
-     *   _INVALID_ARG → ValueError    (matches Java IllegalArgumentException)
-     *   _STATE       → RuntimeError  (matches Java IllegalStateException)
+     * provisional. Today every librdkafka error code surfaces as
+     * KafkaException via cfl_PyErr_Format(). Longer term we want a finer
+     * mapping, e.g.
+     *   _INVALID_ARG → ValueError
+     *   _STATE       → RuntimeError
      * Open question: per-partition broker errors in commit_sync's result
-     * dict (mirrors Java's Map<TopicIdPartition, Optional<...>>) — keep as
-     * KafkaError, or translate as well?
+     * dict — keep as KafkaError, or translate as well?
      *
      * Revisit holistically once:
      *   - librdkafka's share-consumer error surface is stable (some codes
@@ -957,10 +939,7 @@ static PyMethodDef ShareConsumer_methods[] = {
      ".. py:function:: set_acknowledgement_commit_callback(callback)\n"
      "\n"
      "  Register a callback invoked once per acknowledgement-commit response\n"
-     "  from the broker. Mirrors Java\n"
-     "  ``ShareConsumer.setAcknowledgementCommitCallback``.\n"
-     "\n"
-     "  The callback is invoked on a thread calling :py:func:`poll`.\n"
+     "  from the broker. Fires on the thread that calls :py:func:`poll`.\n"
      "\n"
      "  :param callback: A callable\n"
      "      ``callback(offsets, exception)`` where ``offsets`` is a\n"

--- a/src/confluent_kafka/src/ShareConsumer.c
+++ b/src/confluent_kafka/src/ShareConsumer.c
@@ -589,17 +589,18 @@ static void ShareConsumer_acknowledgement_commit_cb(
         PyObject *exception = NULL;
         PyObject *args      = NULL;
         PyObject *result    = NULL;
-        PyObject *cb;
+        PyObject *cb        = NULL;
         CallState *cs;
 
         /* Own a ref to the callback for the whole call: the user callback (or
-         * a finalizer) can clear or replace the registration mid-flight. */
+         * a finalizer) can clear or replace the registration mid-flight.
+         * INCREF only after CallState_get reacquires the GIL. */
         cb = self->u.ShareConsumer.on_share_acknowledgement_commit;
         if (!cb)
                 return;
-        Py_INCREF(cb);
 
         cs = CallState_get(self);
+        Py_INCREF(cb);
 
         offsets = partitions
                       ? c_share_partition_offsets_list_to_py_dict(partitions)
@@ -608,6 +609,8 @@ static void ShareConsumer_acknowledgement_commit_cb(
                 goto crash;
 
         if (err) {
+                /* Passing NULL for the message makes KafkaError use err's
+                 * default string. */
                 PyObject *kafka_error = KafkaError_new_or_None(err, NULL);
                 exception = PyObject_CallFunctionObjArgs(KafkaException,
                                                          kafka_error, NULL);
@@ -643,7 +646,7 @@ crash:
         rd_kafka_yield(NULL);
 
 done:
-        Py_DECREF(cb);
+        Py_XDECREF(cb);
         Py_XDECREF(offsets);
         Py_XDECREF(exception);
         Py_XDECREF(args);
@@ -686,6 +689,7 @@ ShareConsumer_set_acknowledgement_commit_callback(ShareConsumerHandle *self,
             callback == Py_None ? NULL
                                 : ShareConsumer_acknowledgement_commit_cb,
             &self->base);
+
         if (error) {
                 cfl_PyErr_from_error_destroy(error);
                 return NULL;
@@ -956,7 +960,7 @@ static PyMethodDef ShareConsumer_methods[] = {
      "\n"
      "  :param callback: A callable\n"
      "      ``callback(offsets, exception)`` where ``offsets`` is a\n"
-     "      ``Dict[TopicPartition, frozenset[int]]`` of acknowledged offsets\n"
+     "      ``Dict[TopicPartition, set[int]]`` of acknowledged offsets\n"
      "      per partition and ``exception`` is a :py:class:`KafkaException`\n"
      "      on failure or ``None`` on success. Pass ``None`` to clear the\n"
      "      currently registered callback.\n"

--- a/src/confluent_kafka/src/ShareConsumer.c
+++ b/src/confluent_kafka/src/ShareConsumer.c
@@ -584,22 +584,22 @@ static void ShareConsumer_acknowledgement_commit_cb(
     rd_kafka_share_partition_offsets_list_t *partitions,
     rd_kafka_resp_err_t err,
     void *opaque) {
-        Handle *self        = opaque;
-        PyObject *offsets   = NULL;
-        PyObject *exception = NULL;
-        PyObject *args      = NULL;
-        PyObject *result    = NULL;
-        PyObject *cb        = NULL;
+        ShareConsumerHandle *self = opaque;
+        PyObject *offsets         = NULL;
+        PyObject *exception       = NULL;
+        PyObject *args            = NULL;
+        PyObject *result          = NULL;
+        PyObject *cb              = NULL;
         CallState *cs;
 
         /* Own a ref to the callback for the whole call: the user callback (or
          * a finalizer) can clear or replace the registration mid-flight.
          * INCREF only after CallState_get reacquires the GIL. */
-        cb = self->u.ShareConsumer.on_share_acknowledgement_commit;
+        cb = self->base.u.ShareConsumer.on_share_acknowledgement_commit;
         if (!cb)
                 return;
 
-        cs = CallState_get(self);
+        cs = CallState_get(&self->base);
         Py_INCREF(cb);
 
         offsets = partitions
@@ -688,7 +688,7 @@ ShareConsumer_set_acknowledgement_commit_callback(ShareConsumerHandle *self,
             self->rkshare,
             callback == Py_None ? NULL
                                 : ShareConsumer_acknowledgement_commit_cb,
-            &self->base);
+            self);
 
         if (error) {
                 cfl_PyErr_from_error_destroy(error);

--- a/src/confluent_kafka/src/ShareConsumer.c
+++ b/src/confluent_kafka/src/ShareConsumer.c
@@ -48,13 +48,29 @@ typedef struct {
 } ShareConsumerHandle;
 
 
+static void ShareConsumer_clear0(ShareConsumerHandle *self) {
+        /* Release the acknowledgement-commit callback registered at runtime
+         * via ShareConsumer.set_acknowledgement_commit_callback(). Other
+         * consumer-only callbacks (on_commit, stats_cb) are rejected at config
+         * time for share consumers (see
+         * ShareConsumer_reject_incompatible_config), so nothing else needs
+         * releasing here. */
+        if (self->base.u.Consumer.on_share_acknowledgement_commit) {
+                Py_DECREF(self->base.u.Consumer.on_share_acknowledgement_commit);
+                self->base.u.Consumer.on_share_acknowledgement_commit = NULL;
+        }
+}
+
 static int ShareConsumer_clear(ShareConsumerHandle *self) {
+        ShareConsumer_clear0(self);
         Handle_clear(&self->base);
         return 0;
 }
 
 static void ShareConsumer_dealloc(ShareConsumerHandle *self) {
         PyObject_GC_UnTrack(self);
+
+        ShareConsumer_clear0(self);
 
         if (self->rkshare) {
                 CallState cs;
@@ -76,6 +92,8 @@ static void ShareConsumer_dealloc(ShareConsumerHandle *self) {
 
 static int
 ShareConsumer_traverse(ShareConsumerHandle *self, visitproc visit, void *arg) {
+        if (self->base.u.Consumer.on_share_acknowledgement_commit)
+                Py_VISIT(self->base.u.Consumer.on_share_acknowledgement_commit);
         return Handle_traverse(&self->base, visit, arg);
 }
 
@@ -554,6 +572,155 @@ static PyObject *ShareConsumer_commit_async(ShareConsumerHandle *self,
 
 
 /**
+ * @brief Trampoline for the share-consumer acknowledgement-commit callback.
+ *
+ * Invoked by librdkafka from inside rd_kafka_share_consume_batch (i.e., from
+ * within ShareConsumer_poll), once per acknowledgement-commit response. The
+ * \p partitions list is owned by librdkafka and destroyed when this function
+ * returns; do not free it.
+ *
+ * Python signature (matches Java AcknowledgementCommitCallback.onComplete):
+ *     callback(offsets: Dict[TopicPartition, frozenset[int]],
+ *              exception: KafkaException | None) -> None
+ *
+ * Note the (offsets, exception) order intentionally diverges from
+ * Consumer on_commit's (err, parts) — Java parity wins here, per the
+ * AcknowledgementCommitCallback.onComplete contract.
+ */
+static void ShareConsumer_acknowledgement_commit_cb(
+    rd_kafka_share_t *rkshare,
+    rd_kafka_share_partition_offsets_list_t *partitions,
+    rd_kafka_resp_err_t err,
+    void *opaque) {
+        Handle *self      = opaque;
+        PyObject *offsets = NULL;
+        PyObject *exc     = NULL;
+        PyObject *args    = NULL;
+        PyObject *result  = NULL;
+        CallState *cs;
+
+        if (!self->u.Consumer.on_share_acknowledgement_commit)
+                return;
+
+        cs = CallState_get(self);
+
+        offsets = partitions
+                      ? c_share_partition_offsets_list_to_py(partitions)
+                      : PyDict_New();
+        if (!offsets)
+                goto crash;
+
+        if (err) {
+                PyObject *kerr = KafkaError_new_or_None(err, NULL);
+                exc = PyObject_CallFunctionObjArgs(KafkaException, kerr, NULL);
+                Py_DECREF(kerr);
+                if (!exc)
+                        goto crash;
+        } else {
+                Py_INCREF(Py_None);
+                exc = Py_None;
+        }
+
+        args = Py_BuildValue("(OO)", offsets, exc);
+        if (!args) {
+                cfl_PyErr_Format(RD_KAFKA_RESP_ERR__FAIL,
+                                 "Unable to build callback args");
+                goto crash;
+        }
+
+        result = PyObject_CallObject(
+            self->u.Consumer.on_share_acknowledgement_commit, args);
+        if (!result)
+                goto crash;
+
+        goto done;
+
+crash:
+        /* Stage the failure for the outer poll/commit_sync to surface, and
+         * short-circuit the current rk_rep drain.
+         *
+         * The fetched exception is restored by CallState_end.
+         * rd_kafka_yield's rk arg is unused — the impl only flips a TLS flag
+         * (rdkafka_queue.c:37-39) that rd_kafka_q_serve consults. The
+         * share-ack cb is dispatched by a q_serve drain inside
+         * rd_kafka_share_consume_batch (rdkafka.c:3844/3876), so the flag
+         * does short-circuit the current drain pass and stop subsequent cbs
+         * in this poll() from firing on a broken Python state. Passing NULL
+         * because rd_kafka_share_t exposes no public accessor to the
+         * underlying rd_kafka_t. */
+        CallState_fetch_exception(cs);
+        CallState_crash(cs);
+        rd_kafka_yield(NULL);
+
+done:
+        Py_XDECREF(offsets);
+        Py_XDECREF(exc);
+        Py_XDECREF(args);
+        Py_XDECREF(result);
+        CallState_resume(cs);
+}
+
+
+/**
+ * @brief Set or clear the acknowledgement-commit callback at runtime.
+ *
+ * Mirrors Java's ShareConsumer.setAcknowledgementCommitCallback(callback).
+ * Pass None to clear. May be called any time except from within the callback
+ * itself (librdkafka returns _STATE in that case).
+ */
+static PyObject *ShareConsumer_set_acknowledgement_commit_callback(
+    ShareConsumerHandle *self,
+    PyObject *args,
+    PyObject *kwargs) {
+        PyObject *callback = NULL;
+        rd_kafka_resp_err_t err;
+        static char *kws[] = {"callback", NULL};
+
+        if (!self->rkshare) {
+                PyErr_SetString(PyExc_RuntimeError,
+                                ERR_MSG_SHARE_CONSUMER_CLOSED);
+                return NULL;
+        }
+
+        if (!PyArg_ParseTupleAndKeywords(args, kwargs, "O", kws, &callback))
+                return NULL;
+
+        if (callback != Py_None && !PyCallable_Check(callback)) {
+                PyErr_SetString(PyExc_TypeError,
+                                "callback must be callable or None");
+                return NULL;
+        }
+
+        err = rd_kafka_share_set_acknowledgement_cb(
+            self->rkshare,
+            callback == Py_None ? NULL
+                                : ShareConsumer_acknowledgement_commit_cb,
+            &self->base);
+        if (err) {
+                cfl_PyErr_Format(
+                    err,
+                    "Failed to set acknowledgement commit callback: %s",
+                    rd_kafka_err2str(err));
+                return NULL;
+        }
+
+        /* Swap the stashed PyObject only after librdkafka accepts the
+         * registration so a failed registration leaves the prior callback
+         * intact. */
+        Py_XDECREF(self->base.u.Consumer.on_share_acknowledgement_commit);
+        if (callback == Py_None) {
+                self->base.u.Consumer.on_share_acknowledgement_commit = NULL;
+        } else {
+                Py_INCREF(callback);
+                self->base.u.Consumer.on_share_acknowledgement_commit =
+                    callback;
+        }
+
+        Py_RETURN_NONE;
+}
+
+
+/**
  * @brief Close the share consumer.
  */
 static PyObject *ShareConsumer_close(ShareConsumerHandle *self,
@@ -775,13 +942,35 @@ static PyMethodDef ShareConsumer_methods[] = {
      ".. py:function:: commit_async()\n"
      "\n"
      "  Asynchronously commit pending acknowledgements. Returns immediately;\n"
-     "  broker results are delivered via the configured\n"
-     "  ``share_acknowledgement_commit_cb`` callback.\n"
+     "  broker results are delivered to the callback registered via\n"
+     "  :py:func:`set_acknowledgement_commit_callback`, if any.\n"
      "\n"
      "  :returns: None\n"
      "  :raises KafkaException: on error\n"
      "  :raises RuntimeError: if called on a closed share consumer\n"
      "  :raises TypeError: if any arguments are passed\n"
+     "\n"},
+
+    {"set_acknowledgement_commit_callback",
+     (PyCFunction)ShareConsumer_set_acknowledgement_commit_callback,
+     METH_VARARGS | METH_KEYWORDS,
+     ".. py:function:: set_acknowledgement_commit_callback(callback)\n"
+     "\n"
+     "  Register a callback invoked once per acknowledgement-commit response\n"
+     "  from the broker. Mirrors Java\n"
+     "  ``ShareConsumer.setAcknowledgementCommitCallback``.\n"
+     "\n"
+     "  The callback is invoked on a thread calling :py:func:`poll`.\n"
+     "\n"
+     "  :param callback: A callable\n"
+     "      ``callback(offsets, exception)`` where ``offsets`` is a\n"
+     "      ``Dict[TopicPartition, frozenset[int]]`` of acknowledged offsets\n"
+     "      per partition and ``exception`` is a :py:class:`KafkaException`\n"
+     "      on failure or ``None`` on success. Pass ``None`` to clear the\n"
+     "      currently registered callback.\n"
+     "  :raises TypeError: if ``callback`` is neither callable nor None.\n"
+     "  :raises KafkaException: if called from inside the callback itself.\n"
+     "  :raises RuntimeError: if called on a closed share consumer.\n"
      "\n"},
 
     {"close", (PyCFunction)ShareConsumer_close, METH_NOARGS,

--- a/src/confluent_kafka/src/ShareConsumer.c
+++ b/src/confluent_kafka/src/ShareConsumer.c
@@ -589,10 +589,15 @@ static void ShareConsumer_acknowledgement_commit_cb(
         PyObject *exception = NULL;
         PyObject *args      = NULL;
         PyObject *result    = NULL;
+        PyObject *cb;
         CallState *cs;
 
-        if (!self->u.ShareConsumer.on_share_acknowledgement_commit)
+        /* Own a ref to the callback for the whole call: the user callback (or
+         * a finalizer) can clear or replace the registration mid-flight. */
+        cb = self->u.ShareConsumer.on_share_acknowledgement_commit;
+        if (!cb)
                 return;
+        Py_INCREF(cb);
 
         cs = CallState_get(self);
 
@@ -621,8 +626,7 @@ static void ShareConsumer_acknowledgement_commit_cb(
                 goto crash;
         }
 
-        result = PyObject_CallObject(
-            self->u.ShareConsumer.on_share_acknowledgement_commit, args);
+        result = PyObject_CallObject(cb, args);
         if (!result)
                 goto crash;
 
@@ -639,6 +643,7 @@ crash:
         rd_kafka_yield(NULL);
 
 done:
+        Py_DECREF(cb);
         Py_XDECREF(offsets);
         Py_XDECREF(exception);
         Py_XDECREF(args);
@@ -657,6 +662,7 @@ ShareConsumer_set_acknowledgement_commit_callback(ShareConsumerHandle *self,
                                                   PyObject *args,
                                                   PyObject *kwargs) {
         PyObject *callback = NULL;
+        PyObject *old;
         rd_kafka_error_t *error;
         static char *kws[] = {"callback", NULL};
 
@@ -687,8 +693,10 @@ ShareConsumer_set_acknowledgement_commit_callback(ShareConsumerHandle *self,
 
         /* Swap the stashed PyObject only after librdkafka accepts the
          * registration so a failed registration leaves the prior callback
-         * intact. */
-        Py_XDECREF(self->base.u.ShareConsumer.on_share_acknowledgement_commit);
+         * intact. Store the new value before dropping the old ref: releasing
+         * the old callback may run a finalizer, and GC traverse must not see
+         * the field pointing at a freed object. */
+        old = self->base.u.ShareConsumer.on_share_acknowledgement_commit;
         if (callback == Py_None) {
                 self->base.u.ShareConsumer.on_share_acknowledgement_commit =
                     NULL;
@@ -697,6 +705,7 @@ ShareConsumer_set_acknowledgement_commit_callback(ShareConsumerHandle *self,
                 self->base.u.ShareConsumer.on_share_acknowledgement_commit =
                     callback;
         }
+        Py_XDECREF(old);
 
         Py_RETURN_NONE;
 }

--- a/src/confluent_kafka/src/ShareConsumer.c
+++ b/src/confluent_kafka/src/ShareConsumer.c
@@ -87,6 +87,8 @@ static void ShareConsumer_dealloc(ShareConsumerHandle *self) {
                 CallState_end(&self->base, &cs);
         }
 
+        /* TODO KIP-932: once ShareConsumer_clear0 is gone, drop the manual
+         * pair above and just call ShareConsumer_clear(self) here. */
         Handle_clear(&self->base);
 
         Py_TYPE(self)->tp_free((PyObject *)self);
@@ -576,25 +578,17 @@ static PyObject *ShareConsumer_commit_async(ShareConsumerHandle *self,
 
 /**
  * @brief Trampoline for the share-consumer acknowledgement-commit callback.
- *
- * Called once per acknowledgement-commit response, from inside
- * rd_kafka_share_consume_batch's rk_rep drain. The \p partitions list is
- * owned by librdkafka — do not free it.
- *
- * Python signature:
- *     callback(offsets: Dict[TopicPartition, frozenset[int]],
- *              exception: KafkaException | None) -> None
  */
 static void ShareConsumer_acknowledgement_commit_cb(
     rd_kafka_share_t *rkshare,
     rd_kafka_share_partition_offsets_list_t *partitions,
     rd_kafka_resp_err_t err,
     void *opaque) {
-        Handle *self      = opaque;
-        PyObject *offsets = NULL;
-        PyObject *exc     = NULL;
-        PyObject *args    = NULL;
-        PyObject *result  = NULL;
+        Handle *self        = opaque;
+        PyObject *offsets   = NULL;
+        PyObject *exception = NULL;
+        PyObject *args      = NULL;
+        PyObject *result    = NULL;
         CallState *cs;
 
         if (!self->u.ShareConsumer.on_share_acknowledgement_commit)
@@ -602,24 +596,24 @@ static void ShareConsumer_acknowledgement_commit_cb(
 
         cs = CallState_get(self);
 
-        offsets = partitions
-                      ? c_share_partition_offsets_list_to_py(partitions)
-                      : PyDict_New();
+        offsets = partitions ? c_share_partition_offsets_list_to_py(partitions)
+                             : PyDict_New();
         if (!offsets)
                 goto crash;
 
         if (err) {
-                PyObject *kerr = KafkaError_new_or_None(err, NULL);
-                exc = PyObject_CallFunctionObjArgs(KafkaException, kerr, NULL);
-                Py_DECREF(kerr);
-                if (!exc)
+                PyObject *kafka_error = KafkaError_new_or_None(err, NULL);
+                exception = PyObject_CallFunctionObjArgs(KafkaException,
+                                                         kafka_error, NULL);
+                Py_DECREF(kafka_error);
+                if (!exception)
                         goto crash;
         } else {
                 Py_INCREF(Py_None);
-                exc = Py_None;
+                exception = Py_None;
         }
 
-        args = Py_BuildValue("(OO)", offsets, exc);
+        args = Py_BuildValue("(OO)", offsets, exception);
         if (!args) {
                 cfl_PyErr_Format(RD_KAFKA_RESP_ERR__FAIL,
                                  "Unable to build callback args");
@@ -640,7 +634,7 @@ crash:
 
 done:
         Py_XDECREF(offsets);
-        Py_XDECREF(exc);
+        Py_XDECREF(exception);
         Py_XDECREF(args);
         Py_XDECREF(result);
         CallState_resume(cs);
@@ -652,10 +646,10 @@ done:
  *
  * Pass None to clear.
  */
-static PyObject *ShareConsumer_set_acknowledgement_commit_callback(
-    ShareConsumerHandle *self,
-    PyObject *args,
-    PyObject *kwargs) {
+static PyObject *
+ShareConsumer_set_acknowledgement_commit_callback(ShareConsumerHandle *self,
+                                                  PyObject *args,
+                                                  PyObject *kwargs) {
         PyObject *callback = NULL;
         rd_kafka_resp_err_t err;
         static char *kws[] = {"callback", NULL};
@@ -682,8 +676,7 @@ static PyObject *ShareConsumer_set_acknowledgement_commit_callback(
             &self->base);
         if (err) {
                 cfl_PyErr_Format(
-                    err,
-                    "Failed to set acknowledgement commit callback: %s",
+                    err, "Failed to set acknowledgement commit callback: %s",
                     rd_kafka_err2str(err));
                 return NULL;
         }
@@ -693,7 +686,8 @@ static PyObject *ShareConsumer_set_acknowledgement_commit_callback(
          * intact. */
         Py_XDECREF(self->base.u.ShareConsumer.on_share_acknowledgement_commit);
         if (callback == Py_None) {
-                self->base.u.ShareConsumer.on_share_acknowledgement_commit = NULL;
+                self->base.u.ShareConsumer.on_share_acknowledgement_commit =
+                    NULL;
         } else {
                 Py_INCREF(callback);
                 self->base.u.ShareConsumer.on_share_acknowledgement_commit =
@@ -836,13 +830,15 @@ static PyMethodDef ShareConsumer_methods[] = {
      "\n"},
 
     /* TODO KIP-932: librdkafka error code → Python exception mapping is
-     * provisional. Today every librdkafka error code surfaces as
-     * KafkaException via cfl_PyErr_Format(). Longer term we want a finer
-     * mapping, e.g.
-     *   _INVALID_ARG → ValueError
-     *   _STATE       → RuntimeError
+     * provisional. Today the share consumer translates every librdkafka
+     * error code into KafkaException via cfl_PyErr_Format(). Longer term we
+     * want each code to map to the Python exception a user porting from
+     * Java would expect, e.g.
+     *   _INVALID_ARG → ValueError    (matches Java IllegalArgumentException)
+     *   _STATE       → RuntimeError  (matches Java IllegalStateException)
      * Open question: per-partition broker errors in commit_sync's result
-     * dict — keep as KafkaError, or translate as well?
+     * dict (mirrors Java's Map<TopicIdPartition, Optional<...>>) — keep as
+     * KafkaError, or translate as well?
      *
      * Revisit holistically once:
      *   - librdkafka's share-consumer error surface is stable (some codes

--- a/src/confluent_kafka/src/confluent_kafka.c
+++ b/src/confluent_kafka/src/confluent_kafka.c
@@ -1642,7 +1642,7 @@ err:
  *          exception set.
  */
 PyObject *c_share_partition_offsets_list_to_py_dict(
-    const rd_kafka_share_partition_offsets_list_t *list) {
+    const rd_kafka_share_partition_offsets_list_t *partition_offsets_list) {
         PyObject *result        = NULL;
         PyObject *partition_key = NULL;
         PyObject *offset_set    = NULL;
@@ -1655,15 +1655,16 @@ PyObject *c_share_partition_offsets_list_to_py_dict(
 
         /* The only caller already rules out a NULL list, but don't rely on
          * that here: just hand back the empty dict. */
-        if (!list)
+        if (!partition_offsets_list)
                 return result;
 
-        partition_count = rd_kafka_share_partition_offsets_list_count(list);
+        partition_count =
+            rd_kafka_share_partition_offsets_list_count(partition_offsets_list);
         for (partition_index = 0; partition_index < partition_count;
              partition_index++) {
-                const rd_kafka_share_partition_offsets_t *entry =
-                    rd_kafka_share_partition_offsets_list_get(list,
-                                                              partition_index);
+                const rd_kafka_share_partition_offsets_t *partition_offsets =
+                    rd_kafka_share_partition_offsets_list_get(
+                        partition_offsets_list, partition_index);
                 const rd_kafka_topic_partition_t *rktpar;
                 const int64_t *offsets;
                 size_t offsets_count;
@@ -1672,16 +1673,18 @@ PyObject *c_share_partition_offsets_list_to_py_dict(
                 /* The accessors below and c_part_to_py() both deref their
                  * argument without a NULL check, so skip a bad entry
                  * instead of segfaulting on it. */
-                if (!entry)
+                if (!partition_offsets)
                         continue;
 
-                rktpar = rd_kafka_share_partition_offsets_partition(entry);
+                rktpar = rd_kafka_share_partition_offsets_partition(
+                    partition_offsets);
                 if (!rktpar)
                         continue;
 
-                offsets = rd_kafka_share_partition_offsets_offsets(entry);
-                offsets_count =
-                    rd_kafka_share_partition_offsets_offsets_cnt(entry);
+                offsets =
+                    rd_kafka_share_partition_offsets_offsets(partition_offsets);
+                offsets_count = rd_kafka_share_partition_offsets_offsets_cnt(
+                    partition_offsets);
                 /* A NULL offsets array with a non-zero count would be a bug;
                  * clamp to 0 so we never deref it below. */
                 if (!offsets)

--- a/src/confluent_kafka/src/confluent_kafka.c
+++ b/src/confluent_kafka/src/confluent_kafka.c
@@ -1635,6 +1635,80 @@ err:
 }
 
 /**
+ * @brief Convert a share-consumer per-partition acknowledged-offsets list into
+ *        a Python dict(TopicPartition -> frozenset(int)).
+ *
+ * Mirrors Java AcknowledgementCommitCallback.onComplete's
+ * Map<TopicIdPartition, Set<Long>>. TopicPartition is used in place of
+ * TopicIdPartition until the latter is added Python-wide
+ * (see TODO in cimpl.pyi).
+ *
+ * @returns The new Python dict, or NULL on allocation failure with an
+ *          exception set.
+ */
+PyObject *c_share_partition_offsets_list_to_py(
+    const rd_kafka_share_partition_offsets_list_t *list) {
+        PyObject *result    = NULL;
+        PyObject *key       = NULL;
+        PyObject *offsetset = NULL;
+        size_t count;
+        size_t i;
+
+        result = PyDict_New();
+        if (!result)
+                goto err;
+
+        count = rd_kafka_share_partition_offsets_list_count(list);
+        for (i = 0; i < count; i++) {
+                const rd_kafka_share_partition_offsets_t *entry =
+                    rd_kafka_share_partition_offsets_list_get(list, i);
+                const rd_kafka_topic_partition_t *rktpar =
+                    rd_kafka_share_partition_offsets_partition(entry);
+                const int64_t *offsets =
+                    rd_kafka_share_partition_offsets_offsets(entry);
+                size_t offsets_cnt =
+                    rd_kafka_share_partition_offsets_offsets_cnt(entry);
+                size_t j;
+
+                key = c_part_to_py(rktpar);
+                if (!key)
+                        goto err;
+
+                offsetset = PyFrozenSet_New(NULL);
+                if (!offsetset)
+                        goto err;
+
+                for (j = 0; j < offsets_cnt; j++) {
+                        PyObject *off = PyLong_FromLongLong(
+                            (long long)offsets[j]);
+                        if (!off)
+                                goto err;
+                        if (PySet_Add(offsetset, off) == -1) {
+                                Py_DECREF(off);
+                                goto err;
+                        }
+                        Py_DECREF(off);
+                }
+
+                if (PyDict_SetItem(result, key, offsetset) == -1)
+                        goto err;
+
+                Py_DECREF(key);
+                Py_DECREF(offsetset);
+                key       = NULL;
+                offsetset = NULL;
+        }
+
+        return result;
+
+err:
+        Py_XDECREF(key);
+        Py_XDECREF(offsetset);
+        Py_XDECREF(result);
+        return NULL;
+}
+
+/**
  * @brief Convert Python list(TopicPartition) to C
  * rd_kafka_topic_partition_list_t.
  *

--- a/src/confluent_kafka/src/confluent_kafka.c
+++ b/src/confluent_kafka/src/confluent_kafka.c
@@ -1638,11 +1638,6 @@ err:
  * @brief Convert a share-consumer per-partition acknowledged-offsets list into
  *        a Python dict(TopicPartition -> frozenset(int)).
  *
- * Mirrors Java AcknowledgementCommitCallback.onComplete's
- * Map<TopicIdPartition, Set<Long>>. TopicPartition is used in place of
- * TopicIdPartition until the latter is added Python-wide
- * (see TODO in cimpl.pyi).
- *
  * @returns The new Python dict, or NULL on allocation failure with an
  *          exception set.
  */

--- a/src/confluent_kafka/src/confluent_kafka.c
+++ b/src/confluent_kafka/src/confluent_kafka.c
@@ -1643,62 +1643,65 @@ err:
  */
 PyObject *c_share_partition_offsets_list_to_py(
     const rd_kafka_share_partition_offsets_list_t *list) {
-        PyObject *result    = NULL;
-        PyObject *key       = NULL;
-        PyObject *offsetset = NULL;
-        size_t count;
-        size_t i;
+        PyObject *result        = NULL;
+        PyObject *partition_key = NULL;
+        PyObject *offset_set    = NULL;
+        size_t partition_count;
+        size_t partition_index;
 
         result = PyDict_New();
         if (!result)
                 goto err;
 
-        count = rd_kafka_share_partition_offsets_list_count(list);
-        for (i = 0; i < count; i++) {
+        partition_count = rd_kafka_share_partition_offsets_list_count(list);
+        for (partition_index = 0; partition_index < partition_count;
+             partition_index++) {
                 const rd_kafka_share_partition_offsets_t *entry =
-                    rd_kafka_share_partition_offsets_list_get(list, i);
+                    rd_kafka_share_partition_offsets_list_get(list,
+                                                              partition_index);
                 const rd_kafka_topic_partition_t *rktpar =
                     rd_kafka_share_partition_offsets_partition(entry);
                 const int64_t *offsets =
                     rd_kafka_share_partition_offsets_offsets(entry);
-                size_t offsets_cnt =
+                size_t offsets_count =
                     rd_kafka_share_partition_offsets_offsets_cnt(entry);
-                size_t j;
+                size_t offset_index;
 
-                key = c_part_to_py(rktpar);
-                if (!key)
+                partition_key = c_part_to_py(rktpar);
+                if (!partition_key)
                         goto err;
 
-                offsetset = PyFrozenSet_New(NULL);
-                if (!offsetset)
+                offset_set = PyFrozenSet_New(NULL);
+                if (!offset_set)
                         goto err;
 
-                for (j = 0; j < offsets_cnt; j++) {
-                        PyObject *off = PyLong_FromLongLong(
-                            (long long)offsets[j]);
-                        if (!off)
+                for (offset_index = 0; offset_index < offsets_count;
+                     offset_index++) {
+                        PyObject *offset = PyLong_FromLongLong(
+                            (long long)offsets[offset_index]);
+                        if (!offset)
                                 goto err;
-                        if (PySet_Add(offsetset, off) == -1) {
-                                Py_DECREF(off);
+                        if (PySet_Add(offset_set, offset) == -1) {
+                                Py_DECREF(offset);
                                 goto err;
                         }
-                        Py_DECREF(off);
+                        Py_DECREF(offset);
                 }
 
-                if (PyDict_SetItem(result, key, offsetset) == -1)
+                if (PyDict_SetItem(result, partition_key, offset_set) == -1)
                         goto err;
 
-                Py_DECREF(key);
-                Py_DECREF(offsetset);
-                key       = NULL;
-                offsetset = NULL;
+                Py_DECREF(partition_key);
+                Py_DECREF(offset_set);
+                partition_key = NULL;
+                offset_set    = NULL;
         }
 
         return result;
 
 err:
-        Py_XDECREF(key);
-        Py_XDECREF(offsetset);
+        Py_XDECREF(partition_key);
+        Py_XDECREF(offset_set);
         Py_XDECREF(result);
         return NULL;
 }

--- a/src/confluent_kafka/src/confluent_kafka.c
+++ b/src/confluent_kafka/src/confluent_kafka.c
@@ -1636,7 +1636,7 @@ err:
 
 /**
  * @brief Convert a share-consumer per-partition acknowledged-offsets list into
- *        a Python dict(TopicPartition -> frozenset(int)).
+ *        a Python dict(TopicPartition -> set(int)).
  *
  * @returns The new Python dict, or NULL on allocation failure with an
  *          exception set.
@@ -1694,7 +1694,7 @@ PyObject *c_share_partition_offsets_list_to_py_dict(
                 if (!partition_key)
                         goto err;
 
-                offset_set = PyFrozenSet_New(NULL);
+                offset_set = PySet_New(NULL);
                 if (!offset_set)
                         goto err;
 

--- a/src/confluent_kafka/src/confluent_kafka.c
+++ b/src/confluent_kafka/src/confluent_kafka.c
@@ -1641,7 +1641,7 @@ err:
  * @returns The new Python dict, or NULL on allocation failure with an
  *          exception set.
  */
-PyObject *c_share_partition_offsets_list_to_py(
+PyObject *c_share_partition_offsets_list_to_py_dict(
     const rd_kafka_share_partition_offsets_list_t *list) {
         PyObject *result        = NULL;
         PyObject *partition_key = NULL;
@@ -1653,19 +1653,39 @@ PyObject *c_share_partition_offsets_list_to_py(
         if (!result)
                 goto err;
 
+        /* The only caller already rules out a NULL list, but don't rely on
+         * that here: just hand back the empty dict. */
+        if (!list)
+                return result;
+
         partition_count = rd_kafka_share_partition_offsets_list_count(list);
         for (partition_index = 0; partition_index < partition_count;
              partition_index++) {
                 const rd_kafka_share_partition_offsets_t *entry =
                     rd_kafka_share_partition_offsets_list_get(list,
                                                               partition_index);
-                const rd_kafka_topic_partition_t *rktpar =
-                    rd_kafka_share_partition_offsets_partition(entry);
-                const int64_t *offsets =
-                    rd_kafka_share_partition_offsets_offsets(entry);
-                size_t offsets_count =
-                    rd_kafka_share_partition_offsets_offsets_cnt(entry);
+                const rd_kafka_topic_partition_t *rktpar;
+                const int64_t *offsets;
+                size_t offsets_count;
                 size_t offset_index;
+
+                /* The accessors below and c_part_to_py() both deref their
+                 * argument without a NULL check, so skip a bad entry
+                 * instead of segfaulting on it. */
+                if (!entry)
+                        continue;
+
+                rktpar = rd_kafka_share_partition_offsets_partition(entry);
+                if (!rktpar)
+                        continue;
+
+                offsets = rd_kafka_share_partition_offsets_offsets(entry);
+                offsets_count =
+                    rd_kafka_share_partition_offsets_offsets_cnt(entry);
+                /* A NULL offsets array with a non-zero count would be a bug;
+                 * clamp to 0 so we never deref it below. */
+                if (!offsets)
+                        offsets_count = 0;
 
                 partition_key = c_part_to_py(rktpar);
                 if (!partition_key)

--- a/src/confluent_kafka/src/confluent_kafka.h
+++ b/src/confluent_kafka/src/confluent_kafka.h
@@ -275,6 +275,7 @@ typedef struct {
                 } Consumer;
 
                 struct {
+                        /* cb(offsets, exc) */
                         PyObject *on_share_acknowledgement_commit;
                 } ShareConsumer;
         } u;
@@ -465,7 +466,7 @@ PyObject *c_parts_to_py(const rd_kafka_topic_partition_list_t *c_parts);
 PyObject *c_parts_to_dict_topic_partition_to_error(
     const rd_kafka_topic_partition_list_t *c_parts);
 PyObject *c_share_partition_offsets_list_to_py_dict(
-    const rd_kafka_share_partition_offsets_list_t *list);
+    const rd_kafka_share_partition_offsets_list_t *partition_offsets_list);
 PyObject *c_Node_to_py(const rd_kafka_Node_t *c_node);
 PyObject *c_Uuid_to_py(const rd_kafka_Uuid_t *c_uuid);
 rd_kafka_topic_partition_list_t *py_to_c_parts(PyObject *plist);

--- a/src/confluent_kafka/src/confluent_kafka.h
+++ b/src/confluent_kafka/src/confluent_kafka.h
@@ -215,7 +215,7 @@ PyObject *KafkaError_new_from_error_destroy(rd_kafka_error_t *error);
 /****************************************************************************
  *
  *
- * Common instance handle for Producer, Consumer, and ShareConsumer
+ * Common instance handle for Producer, Consumer and ShareConsumer
  *
  *
  *
@@ -464,7 +464,7 @@ PyObject *c_part_to_py(const rd_kafka_topic_partition_t *c_part);
 PyObject *c_parts_to_py(const rd_kafka_topic_partition_list_t *c_parts);
 PyObject *c_parts_to_dict_topic_partition_to_error(
     const rd_kafka_topic_partition_list_t *c_parts);
-PyObject *c_share_partition_offsets_list_to_py(
+PyObject *c_share_partition_offsets_list_to_py_dict(
     const rd_kafka_share_partition_offsets_list_t *list);
 PyObject *c_Node_to_py(const rd_kafka_Node_t *c_node);
 PyObject *c_Uuid_to_py(const rd_kafka_Uuid_t *c_uuid);

--- a/src/confluent_kafka/src/confluent_kafka.h
+++ b/src/confluent_kafka/src/confluent_kafka.h
@@ -270,6 +270,14 @@ typedef struct {
                         PyObject *on_revoke; /* Rebalance: on_revoke callback */
                         PyObject *on_lost;   /* Rebalance: on_lost callback */
                         PyObject *on_commit; /* Commit callback */
+                        /* Share-consumer per-ack-commit callback (KIP-932),
+                         * registered at runtime via
+                         * ShareConsumer.set_acknowledgement_commit_callback().
+                         * Sits inside the Consumer union member because
+                         * ShareConsumer_init currently routes through
+                         * RD_KAFKA_CONSUMER (see ShareConsumer_init TODO);
+                         * move once share gets a dedicated union member. */
+                        PyObject *on_share_acknowledgement_commit;
                         rd_kafka_queue_t *rkqu; /* Consumer queue */
 
                 } Consumer;
@@ -460,6 +468,8 @@ PyObject *c_part_to_py(const rd_kafka_topic_partition_t *c_part);
 PyObject *c_parts_to_py(const rd_kafka_topic_partition_list_t *c_parts);
 PyObject *c_parts_to_dict_topic_partition_to_error(
     const rd_kafka_topic_partition_list_t *c_parts);
+PyObject *c_share_partition_offsets_list_to_py(
+    const rd_kafka_share_partition_offsets_list_t *list);
 PyObject *c_Node_to_py(const rd_kafka_Node_t *c_node);
 PyObject *c_Uuid_to_py(const rd_kafka_Uuid_t *c_uuid);
 rd_kafka_topic_partition_list_t *py_to_c_parts(PyObject *plist);

--- a/src/confluent_kafka/src/confluent_kafka.h
+++ b/src/confluent_kafka/src/confluent_kafka.h
@@ -215,7 +215,7 @@ PyObject *KafkaError_new_from_error_destroy(rd_kafka_error_t *error);
 /****************************************************************************
  *
  *
- * Common instance handle for both Producer and Consumer
+ * Common instance handle for Producer, Consumer, and ShareConsumer
  *
  *
  *
@@ -270,17 +270,18 @@ typedef struct {
                         PyObject *on_revoke; /* Rebalance: on_revoke callback */
                         PyObject *on_lost;   /* Rebalance: on_lost callback */
                         PyObject *on_commit; /* Commit callback */
-                        /* Share-consumer per-ack-commit callback (KIP-932),
-                         * registered at runtime via
-                         * ShareConsumer.set_acknowledgement_commit_callback().
-                         * Sits inside the Consumer union member because
-                         * ShareConsumer_init currently routes through
-                         * RD_KAFKA_CONSUMER (see ShareConsumer_init TODO);
-                         * move once share gets a dedicated union member. */
-                        PyObject *on_share_acknowledgement_commit;
                         rd_kafka_queue_t *rkqu; /* Consumer queue */
 
                 } Consumer;
+
+                /**
+                 * ShareConsumer (KIP-932)
+                 */
+                struct {
+                        /* Set via
+                         * ShareConsumer.set_acknowledgement_commit_callback() */
+                        PyObject *on_share_acknowledgement_commit;
+                } ShareConsumer;
         } u;
 } Handle;
 

--- a/src/confluent_kafka/src/confluent_kafka.h
+++ b/src/confluent_kafka/src/confluent_kafka.h
@@ -274,12 +274,7 @@ typedef struct {
 
                 } Consumer;
 
-                /**
-                 * ShareConsumer (KIP-932)
-                 */
                 struct {
-                        /* Set via
-                         * ShareConsumer.set_acknowledgement_commit_callback() */
                         PyObject *on_share_acknowledgement_commit;
                 } ShareConsumer;
         } u;

--- a/tests/integration/share_consumer/test_share_consumer_ack.py
+++ b/tests/integration/share_consumer/test_share_consumer_ack.py
@@ -17,7 +17,9 @@
 
 """Integration tests for ShareConsumer acknowledgement (KIP-932)."""
 
+import gc
 import time
+import weakref
 
 import pytest
 
@@ -774,15 +776,13 @@ def test_set_callback_after_close_raises(kafka_cluster):
 def test_callback_fires_on_explicit_commit_async(kafka_cluster):
     """ack → commit_async → poll fires the cb with exception=None and
     a dict containing the acknowledged offsets."""
-    topic = kafka_cluster.create_topic_and_wait_propogation(
-        'test-share-consumer-cb-explicit')
+    topic = kafka_cluster.create_topic_and_wait_propogation('test-share-consumer-cb-explicit')
     num_messages = 3
 
     sc = kafka_cluster.share_consumer({'share.acknowledgement.mode': 'explicit'})
     try:
         invocations = []
-        sc.set_acknowledgement_commit_callback(
-            lambda offsets, exc: invocations.append((offsets, exc)))
+        sc.set_acknowledgement_commit_callback(lambda offsets, exc: invocations.append((offsets, exc)))
 
         sc.subscribe([topic])
 
@@ -818,24 +818,21 @@ def test_callback_fires_on_explicit_commit_async(kafka_cluster):
             assert tp.topic == topic
             assert isinstance(offsets[tp], frozenset)
             cb_offsets |= offsets[tp]
-        assert cb_offsets == acked_offsets, (
-            f'cb saw {cb_offsets}, acked {acked_offsets}'
-        )
+        assert cb_offsets == acked_offsets, f'cb saw {cb_offsets}, acked {acked_offsets}'
     finally:
         sc.close()
 
 
 def test_callback_fires_on_implicit_mode(kafka_cluster):
-    """Implicit mode: next poll auto-acks prior batch and fires the cb."""
-    topic = kafka_cluster.create_topic_and_wait_propogation(
-        'test-share-consumer-cb-implicit')
+    """Implicit mode: next poll auto-acks prior batch and fires the cb with
+    the offsets that were just auto-acked."""
+    topic = kafka_cluster.create_topic_and_wait_propogation('test-share-consumer-cb-implicit')
     num_messages = 3
 
     sc = kafka_cluster.share_consumer({'share.acknowledgement.mode': 'implicit'})
     try:
         invocations = []
-        sc.set_acknowledgement_commit_callback(
-            lambda offsets, exc: invocations.append((offsets, exc)))
+        sc.set_acknowledgement_commit_callback(lambda offsets, exc: invocations.append((offsets, exc)))
 
         sc.subscribe([topic])
 
@@ -845,25 +842,40 @@ def test_callback_fires_on_implicit_mode(kafka_cluster):
         producer.flush(timeout=10.0)
 
         # Drain all records — each subsequent poll() implicit-acks the prior
-        # batch, which fires the cb.
-        drain_share_consumers([sc], num_messages, timeout_s=20.0)
+        # batch, which fires the cb. Capture the offsets actually consumed so
+        # we can verify the cb reported the same set.
+        batches = drain_share_consumers([sc], num_messages, timeout_s=20.0)
+        consumed_offsets = {m.offset() for m in batches[0]}
+        assert (
+            len(consumed_offsets) == num_messages
+        ), f'consumed {len(consumed_offsets)} unique offsets, expected {num_messages}'
 
-        # Final commit_async to flush the tail batch, plus polls to drain.
+        # Final commit_async to flush the tail batch's implicit-ack.
         sc.commit_async()
-        _wait_for_callback(sc, invocations, 1, timeout_s=10.0)
+
+        # The cb fires once per (batch x partition); poll until every consumed
+        # offset has been reported by the cb, or timeout.
+        deadline = time.time() + 10.0
+        cb_offsets = set()
+        while time.time() < deadline and cb_offsets != consumed_offsets:
+            sc.poll(timeout=0.5)
+            cb_offsets = set()
+            for offsets, _ in invocations:
+                for tp_offsets in offsets.values():
+                    cb_offsets |= tp_offsets
 
         assert invocations, 'callback never fired'
         for offsets, exc in invocations:
             assert exc is None, f'unexpected exception in cb: {exc!r}'
             assert len(offsets) == 1
+        assert cb_offsets == consumed_offsets, f'cb reported {cb_offsets}, consumed {consumed_offsets}'
     finally:
         sc.close()
 
 
 def test_callback_replacement_only_new_fires(kafka_cluster):
     """Re-registering replaces the prior callback — old one stops firing."""
-    topic = kafka_cluster.create_topic_and_wait_propogation(
-        'test-share-consumer-cb-replace')
+    topic = kafka_cluster.create_topic_and_wait_propogation('test-share-consumer-cb-replace')
 
     sc = kafka_cluster.share_consumer({'share.acknowledgement.mode': 'explicit'})
     try:
@@ -871,8 +883,7 @@ def test_callback_replacement_only_new_fires(kafka_cluster):
         cb2_calls = []
 
         # First cycle: cb1 active.
-        sc.set_acknowledgement_commit_callback(
-            lambda offsets, exc: cb1_calls.append((offsets, exc)))
+        sc.set_acknowledgement_commit_callback(lambda offsets, exc: cb1_calls.append((offsets, exc)))
         sc.subscribe([topic])
         producer = kafka_cluster.cimpl_producer()
         producer.produce(topic, value=b'msg-cb1')
@@ -888,8 +899,7 @@ def test_callback_replacement_only_new_fires(kafka_cluster):
         cb1_count_after_first_cycle = len(cb1_calls)
 
         # Swap to cb2.
-        sc.set_acknowledgement_commit_callback(
-            lambda offsets, exc: cb2_calls.append((offsets, exc)))
+        sc.set_acknowledgement_commit_callback(lambda offsets, exc: cb2_calls.append((offsets, exc)))
 
         producer.produce(topic, value=b'msg-cb2')
         producer.flush(timeout=10.0)
@@ -901,23 +911,21 @@ def test_callback_replacement_only_new_fires(kafka_cluster):
         _wait_for_callback(sc, cb2_calls, 1, timeout_s=10.0)
 
         assert cb2_calls, 'cb2 never fired after replacement'
-        assert len(cb1_calls) == cb1_count_after_first_cycle, (
-            f'cb1 fired again after replacement: {cb1_calls[cb1_count_after_first_cycle:]}'
-        )
+        assert (
+            len(cb1_calls) == cb1_count_after_first_cycle
+        ), f'cb1 fired again after replacement: {cb1_calls[cb1_count_after_first_cycle:]}'
     finally:
         sc.close()
 
 
 def test_callback_clear_with_none_disables(kafka_cluster):
     """After clearing with None the cb must not fire on subsequent commits."""
-    topic = kafka_cluster.create_topic_and_wait_propogation(
-        'test-share-consumer-cb-clear')
+    topic = kafka_cluster.create_topic_and_wait_propogation('test-share-consumer-cb-clear')
 
     sc = kafka_cluster.share_consumer({'share.acknowledgement.mode': 'explicit'})
     try:
         invocations = []
-        sc.set_acknowledgement_commit_callback(
-            lambda offsets, exc: invocations.append((offsets, exc)))
+        sc.set_acknowledgement_commit_callback(lambda offsets, exc: invocations.append((offsets, exc)))
         sc.subscribe([topic])
 
         producer = kafka_cluster.cimpl_producer()
@@ -948,33 +956,40 @@ def test_callback_clear_with_none_disables(kafka_cluster):
         while time.time() < deadline:
             sc.poll(timeout=0.5)
 
-        assert len(invocations) == count_before_clear, (
-            f'cb fired {len(invocations) - count_before_clear} times after clear'
-        )
+        assert (
+            len(invocations) == count_before_clear
+        ), f'cb fired {len(invocations) - count_before_clear} times after clear'
     finally:
         sc.close()
 
 
 def test_callback_fires_on_commit_sync(kafka_cluster):
-    """cb fires inside commit_sync itself — no extra poll needed."""
-    topic = kafka_cluster.create_topic_and_wait_propogation(
-        'test-share-consumer-cb-commit-sync')
+    """cb fires inside commit_sync itself — no extra poll needed — and the
+    cb payload contains the offsets that were acked."""
+    topic = kafka_cluster.create_topic_and_wait_propogation('test-share-consumer-cb-commit-sync')
+    num_messages = 3
 
     sc = kafka_cluster.share_consumer({'share.acknowledgement.mode': 'explicit'})
     try:
         invocations = []
-        sc.set_acknowledgement_commit_callback(
-            lambda offsets, exc: invocations.append((offsets, exc)))
+        sc.set_acknowledgement_commit_callback(lambda offsets, exc: invocations.append((offsets, exc)))
         sc.subscribe([topic])
 
         producer = kafka_cluster.cimpl_producer()
-        producer.produce(topic, value=b'msg-0')
+        for i in range(num_messages):
+            producer.produce(topic, value=f'msg-{i}'.encode())
         producer.flush(timeout=10.0)
 
-        msgs = poll_first_batch(sc)
-        assert msgs
-        for m in msgs:
-            sc.acknowledge(m, AcknowledgeType.ACCEPT)
+        acked_offsets = set()
+        batch = []
+        deadline = time.time() + 20.0
+        while time.time() < deadline and len(batch) < num_messages:
+            for m in sc.poll(timeout=0.5):
+                if m.error() is None:
+                    batch.append(m)
+                    sc.acknowledge(m, AcknowledgeType.ACCEPT)
+                    acked_offsets.add(m.offset())
+        assert len(batch) == num_messages, f'received {len(batch)} of {num_messages}'
 
         # commit_sync blocks until broker responds, and per-partition results
         # are also delivered to the cb via the post-commit rk_rep drain.
@@ -983,34 +998,45 @@ def test_callback_fires_on_commit_sync(kafka_cluster):
 
         # The cb should have fired before commit_sync returned; no poll().
         assert invocations, 'cb did not fire during commit_sync'
+        cb_offsets = set()
         for offsets, exc in invocations:
             assert exc is None, f'unexpected exception in cb: {exc!r}'
-            assert len(offsets) == 1
+            assert len(offsets) == 1, f'expected 1 partition key, got {list(offsets)}'
+            tp = next(iter(offsets))
+            assert tp.topic == topic
+            cb_offsets |= offsets[tp]
+        assert cb_offsets == acked_offsets, f'cb saw {cb_offsets}, acked {acked_offsets}'
     finally:
         sc.close()
 
 
 def test_callback_fires_during_close(kafka_cluster):
     """close() drains pending share-ack ops, so unacked-at-close work still
-    surfaces through the cb."""
-    topic = kafka_cluster.create_topic_and_wait_propogation(
-        'test-share-consumer-cb-close')
+    surfaces through the cb with the offsets that were acked."""
+    topic = kafka_cluster.create_topic_and_wait_propogation('test-share-consumer-cb-close')
+    num_messages = 3
 
     sc = kafka_cluster.share_consumer({'share.acknowledgement.mode': 'explicit'})
     invocations = []
+    acked_offsets = set()
     try:
-        sc.set_acknowledgement_commit_callback(
-            lambda offsets, exc: invocations.append((offsets, exc)))
+        sc.set_acknowledgement_commit_callback(lambda offsets, exc: invocations.append((offsets, exc)))
         sc.subscribe([topic])
 
         producer = kafka_cluster.cimpl_producer()
-        producer.produce(topic, value=b'msg-0')
+        for i in range(num_messages):
+            producer.produce(topic, value=f'msg-{i}'.encode())
         producer.flush(timeout=10.0)
 
-        msgs = poll_first_batch(sc)
-        assert msgs
-        for m in msgs:
-            sc.acknowledge(m, AcknowledgeType.ACCEPT)
+        batch = []
+        deadline = time.time() + 20.0
+        while time.time() < deadline and len(batch) < num_messages:
+            for m in sc.poll(timeout=0.5):
+                if m.error() is None:
+                    batch.append(m)
+                    sc.acknowledge(m, AcknowledgeType.ACCEPT)
+                    acked_offsets.add(m.offset())
+        assert len(batch) == num_messages, f'received {len(batch)} of {num_messages}'
 
         # Trigger the send but DO NOT poll — let close() drain the response.
         sc.commit_async()
@@ -1018,49 +1044,52 @@ def test_callback_fires_during_close(kafka_cluster):
         sc.close()
 
     assert invocations, 'cb did not fire during close()'
+    cb_offsets = set()
     for offsets, exc in invocations:
         assert exc is None, f'unexpected exception in cb: {exc!r}'
-        assert len(offsets) == 1
+        assert len(offsets) == 1, f'expected 1 partition key, got {list(offsets)}'
+        tp = next(iter(offsets))
+        assert tp.topic == topic
+        cb_offsets |= offsets[tp]
+    assert cb_offsets == acked_offsets, f'cb saw {cb_offsets}, acked {acked_offsets}'
 
 
 def test_callback_cardinality_multipartition(kafka_cluster):
     """With N partitions and records spread across them, the cb should fire
-    N times, each with exactly one TopicPartition key."""
+    N times, each with exactly one TopicPartition key carrying the offsets
+    acked for that partition."""
     num_partitions = 3
     num_messages_per_partition = 2
     topic = kafka_cluster.create_topic_and_wait_propogation(
-        'test-share-consumer-cb-multipart',
-        {'num_partitions': num_partitions})
+        'test-share-consumer-cb-multipart', {'num_partitions': num_partitions}
+    )
 
     sc = kafka_cluster.share_consumer({'share.acknowledgement.mode': 'explicit'})
     try:
         invocations = []
-        sc.set_acknowledgement_commit_callback(
-            lambda offsets, exc: invocations.append((offsets, exc)))
+        sc.set_acknowledgement_commit_callback(lambda offsets, exc: invocations.append((offsets, exc)))
         sc.subscribe([topic])
 
         producer = kafka_cluster.cimpl_producer()
         # Produce to specific partitions so all N see records.
         for partition in range(num_partitions):
             for i in range(num_messages_per_partition):
-                producer.produce(
-                    topic, value=f'p{partition}-msg-{i}'.encode(),
-                    partition=partition)
+                producer.produce(topic, value=f'p{partition}-msg-{i}'.encode(), partition=partition)
         producer.flush(timeout=10.0)
 
         total_messages = num_partitions * num_messages_per_partition
-        partitions_seen_in_acks = set()
+        acked_by_partition = {}  # partition -> set of offsets acked
         deadline = time.time() + 30.0
         received = 0
         while time.time() < deadline and received < total_messages:
             for m in sc.poll(timeout=0.5):
                 if m.error() is None:
                     sc.acknowledge(m, AcknowledgeType.ACCEPT)
-                    partitions_seen_in_acks.add(m.partition())
+                    acked_by_partition.setdefault(m.partition(), set()).add(m.offset())
                     received += 1
-        assert partitions_seen_in_acks == set(range(num_partitions)), (
-            f'expected acks on partitions {set(range(num_partitions))}, '
-            f'got {partitions_seen_in_acks}')
+        assert set(acked_by_partition.keys()) == set(range(num_partitions)), (
+            f'expected acks on partitions {set(range(num_partitions))}, ' f'got {set(acked_by_partition.keys())}'
+        )
 
         sc.commit_async()
         deadline = time.time() + 10.0
@@ -1070,18 +1099,15 @@ def test_callback_cardinality_multipartition(kafka_cluster):
         # Every invocation: exactly one partition key.
         for offsets, exc in invocations:
             assert exc is None
-            assert len(offsets) == 1, (
-                f'cb invocation carried {len(offsets)} partitions; expected 1')
+            assert len(offsets) == 1, f'cb invocation carried {len(offsets)} partitions; expected 1'
 
-        # Aggregate: every partition we acked must show up across the
-        # invocations.
-        partitions_seen_in_cb = set()
+        # Aggregate per-partition offsets the cb reported, then compare to
+        # what we acked.
+        cb_by_partition = {}
         for offsets, _ in invocations:
             tp = next(iter(offsets))
-            partitions_seen_in_cb.add(tp.partition)
-        assert partitions_seen_in_cb == partitions_seen_in_acks, (
-            f'cb saw partitions {partitions_seen_in_cb}, '
-            f'expected {partitions_seen_in_acks}')
+            cb_by_partition.setdefault(tp.partition, set()).update(offsets[tp])
+        assert cb_by_partition == acked_by_partition, f'cb reported {cb_by_partition}, acked {acked_by_partition}'
     finally:
         sc.close()
 
@@ -1089,14 +1115,12 @@ def test_callback_cardinality_multipartition(kafka_cluster):
 def test_callback_not_invoked_on_empty_commit(kafka_cluster):
     """commit_async/commit_sync with no pending acks short-circuits without
     a broker request — the cb must not fire."""
-    topic = kafka_cluster.create_topic_and_wait_propogation(
-        'test-share-consumer-cb-empty-commit')
+    topic = kafka_cluster.create_topic_and_wait_propogation('test-share-consumer-cb-empty-commit')
 
     sc = kafka_cluster.share_consumer({'share.acknowledgement.mode': 'explicit'})
     try:
         invocations = []
-        sc.set_acknowledgement_commit_callback(
-            lambda offsets, exc: invocations.append((offsets, exc)))
+        sc.set_acknowledgement_commit_callback(lambda offsets, exc: invocations.append((offsets, exc)))
         sc.subscribe([topic])
 
         # Empty commits — no records consumed, nothing to ack.
@@ -1109,9 +1133,7 @@ def test_callback_not_invoked_on_empty_commit(kafka_cluster):
         while time.time() < deadline:
             sc.poll(timeout=0.5)
 
-        assert invocations == [], (
-            f'cb fired on empty commit: {invocations!r}'
-        )
+        assert invocations == [], f'cb fired on empty commit: {invocations!r}'
     finally:
         sc.close()
 
@@ -1119,8 +1141,7 @@ def test_callback_not_invoked_on_empty_commit(kafka_cluster):
 def test_callback_reentrancy_guard(kafka_cluster):
     """Calling share-consumer APIs from inside the cb fails with _STATE —
     librdkafka guards every entry point against reentrancy."""
-    topic = kafka_cluster.create_topic_and_wait_propogation(
-        'test-share-consumer-cb-reentrancy')
+    topic = kafka_cluster.create_topic_and_wait_propogation('test-share-consumer-cb-reentrancy')
 
     sc = kafka_cluster.share_consumer({'share.acknowledgement.mode': 'explicit'})
     try:
@@ -1131,8 +1152,7 @@ def test_callback_reentrancy_guard(kafka_cluster):
 
         def reentrant_cb(offsets, exc):
             try:
-                sc.set_acknowledgement_commit_callback(
-                    lambda o, e: None)
+                sc.set_acknowledgement_commit_callback(lambda o, e: None)
             except KafkaException as ex:
                 captured_setter_err.append(ex)
             try:
@@ -1173,8 +1193,7 @@ def test_callback_reentrancy_guard(kafka_cluster):
 
 def test_callback_exception_propagates_from_poll(kafka_cluster):
     """An exception raised inside the cb surfaces from the next poll() call."""
-    topic = kafka_cluster.create_topic_and_wait_propogation(
-        'test-share-consumer-cb-exception')
+    topic = kafka_cluster.create_topic_and_wait_propogation('test-share-consumer-cb-exception')
 
     sentinel = ValueError('sentinel from cb')
 
@@ -1213,4 +1232,49 @@ def test_callback_exception_propagates_from_poll(kafka_cluster):
             sc.set_acknowledgement_commit_callback(None)
         except Exception:
             pass
+        sc.close()
+
+
+class _CounterCallback:
+    """Picklable, weakref-able callable used by the rebind refcount test.
+    Plain functions/lambdas don't support weakref so we can't use them
+    directly."""
+
+    def __init__(self):
+        self.calls = 0
+
+    def __call__(self, offsets, exc):
+        self.calls += 1
+
+
+def test_rebind_releases_previous_callback(kafka_cluster):
+    """Registering a new cb must release the previously stashed PyObject so
+    the prior callable can be garbage-collected once external refs go away.
+    Regression test for a refcount leak in
+    set_acknowledgement_commit_callback's swap path."""
+    sc = kafka_cluster.share_consumer({'share.acknowledgement.mode': 'explicit'})
+    try:
+        first = _CounterCallback()
+        first_ref = weakref.ref(first)
+        sc.set_acknowledgement_commit_callback(first)
+
+        # Drop the only external reference; the share consumer's internal
+        # stash should still be holding `first` alive.
+        del first
+        gc.collect()
+        assert first_ref() is not None, 'first cb collected while still registered'
+
+        # Rebind to a different callable: the stash must release `first`.
+        second = _CounterCallback()
+        sc.set_acknowledgement_commit_callback(second)
+        gc.collect()
+        assert first_ref() is None, 'first cb still alive after rebind — stash leaked'
+
+        # Clearing with None must release `second` too.
+        second_ref = weakref.ref(second)
+        del second
+        sc.set_acknowledgement_commit_callback(None)
+        gc.collect()
+        assert second_ref() is None, 'second cb still alive after clear — stash leaked'
+    finally:
         sc.close()

--- a/tests/integration/share_consumer/test_share_consumer_ack.py
+++ b/tests/integration/share_consumer/test_share_consumer_ack.py
@@ -1405,7 +1405,7 @@ def test_callback_reports_invalid_record_state_on_commit_async(kafka_cluster):
             tp = next(iter(offsets))
             assert isinstance(tp, TopicPartition)
             assert tp.topic == topic
-            assert isinstance(offsets[tp], frozenset)
+            assert isinstance(offsets[tp], set)
             cb_offsets |= offsets[tp]
         assert cb_offsets == acked_offsets, f'cb error saw {cb_offsets}, acked {acked_offsets}'
     finally:

--- a/tests/integration/share_consumer/test_share_consumer_ack.py
+++ b/tests/integration/share_consumer/test_share_consumer_ack.py
@@ -818,7 +818,7 @@ def test_callback_fires_on_explicit_commit_async(kafka_cluster):
             tp = next(iter(offsets))
             assert isinstance(tp, TopicPartition)
             assert tp.topic == topic
-            assert isinstance(offsets[tp], frozenset)
+            assert isinstance(offsets[tp], set)
             cb_offsets |= offsets[tp]
         assert cb_offsets == acked_offsets, f'cb saw {cb_offsets}, acked {acked_offsets}'
     finally:

--- a/tests/integration/share_consumer/test_share_consumer_ack.py
+++ b/tests/integration/share_consumer/test_share_consumer_ack.py
@@ -724,13 +724,9 @@ def test_partial_ack_still_blocks_next_poll(kafka_cluster):
 
 # --- acknowledgement-commit callback --------------------------------------
 #
-# librdkafka fires the callback once per partition (rdkafka_share_acknowledgement.h:
-# "enqueues one callback operation per partition"), so each invocation's
-# offsets dict contains exactly one TopicPartition key. The cb is dispatched
-# by the rk_rep drain inside rd_kafka_share_consume_batch (rdkafka.c:3844/3876),
-# i.e. on the thread that calls poll(). Tests that expect a cb invocation
-# must therefore poll() at least once after commit_async / commit_sync to
-# give the drain a chance to fire it.
+# The cb fires once per partition, dispatched on the thread that calls poll().
+# Tests that expect a cb invocation must poll() at least once after
+# commit_async / commit_sync so the dispatch has a chance to run.
 
 
 def _wait_for_callback(sc, invocations, expected_count, timeout_s=10.0):
@@ -755,14 +751,12 @@ def test_set_callback_rejects_non_callable(kafka_cluster):
 
 def test_set_callback_accepts_none(kafka_cluster):
     """None clears the callback; setting/clearing repeatedly is safe.
-    Both positional and ``callback=`` keyword forms accepted (Java parity:
-    the Java parameter is named ``callback``)."""
+    Both positional and ``callback=`` keyword forms work."""
     sc = kafka_cluster.share_consumer({'share.acknowledgement.mode': 'explicit'})
     try:
         sc.set_acknowledgement_commit_callback(None)
         sc.set_acknowledgement_commit_callback(lambda offsets, exc: None)
         sc.set_acknowledgement_commit_callback(None)
-        # Keyword form (matches Java's setAcknowledgementCommitCallback param).
         sc.set_acknowledgement_commit_callback(callback=lambda offsets, exc: None)
         sc.set_acknowledgement_commit_callback(callback=None)
     finally:
@@ -962,8 +956,7 @@ def test_callback_clear_with_none_disables(kafka_cluster):
 
 
 def test_callback_fires_on_commit_sync(kafka_cluster):
-    """commit_sync drains rk_rep before returning (rdkafka.c:4353), so the
-    cb fires inside commit_sync itself — no extra poll needed."""
+    """cb fires inside commit_sync itself — no extra poll needed."""
     topic = kafka_cluster.create_topic_and_wait_propogation(
         'test-share-consumer-cb-commit-sync')
 
@@ -998,9 +991,8 @@ def test_callback_fires_on_commit_sync(kafka_cluster):
 
 
 def test_callback_fires_during_close(kafka_cluster):
-    """close() drains pending share-ack ops via rd_kafka_consumer_close0
-    (rdkafka.c:5137-5153 → rd_kafka_poll_cb → SHARE_ACK_COMMIT_CB_EXECUTE),
-    so unacked-at-close work still surfaces through the cb."""
+    """close() drains pending share-ack ops, so unacked-at-close work still
+    surfaces through the cb."""
     topic = kafka_cluster.create_topic_and_wait_propogation(
         'test-share-consumer-cb-close')
 
@@ -1032,10 +1024,8 @@ def test_callback_fires_during_close(kafka_cluster):
 
 
 def test_callback_cardinality_multipartition(kafka_cluster):
-    """librdkafka fires the cb once per partition
-    (rdkafka_share_acknowledgement.h:307-318). With N partitions and records
-    spread across them, the cb should fire N times, each with exactly one
-    TopicPartition key."""
+    """With N partitions and records spread across them, the cb should fire
+    N times, each with exactly one TopicPartition key."""
     num_partitions = 3
     num_messages_per_partition = 2
     topic = kafka_cluster.create_topic_and_wait_propogation(
@@ -1081,8 +1071,7 @@ def test_callback_cardinality_multipartition(kafka_cluster):
         for offsets, exc in invocations:
             assert exc is None
             assert len(offsets) == 1, (
-                f'cb invocation carried {len(offsets)} partitions; expected 1 '
-                f'(librdkafka fires once per partition)')
+                f'cb invocation carried {len(offsets)} partitions; expected 1')
 
         # Aggregate: every partition we acked must show up across the
         # invocations.
@@ -1098,9 +1087,8 @@ def test_callback_cardinality_multipartition(kafka_cluster):
 
 
 def test_callback_not_invoked_on_empty_commit(kafka_cluster):
-    """commit_async/commit_sync with no pending acks short-circuit in
-    librdkafka (rdkafka.c:4232-4236, 4309-4313) and never enqueue a broker
-    request — the cb must not fire."""
+    """commit_async/commit_sync with no pending acks short-circuits without
+    a broker request — the cb must not fire."""
     topic = kafka_cluster.create_topic_and_wait_propogation(
         'test-share-consumer-cb-empty-commit')
 
@@ -1129,16 +1117,15 @@ def test_callback_not_invoked_on_empty_commit(kafka_cluster):
 
 
 def test_callback_reentrancy_guard(kafka_cluster):
-    """Calling share-consumer APIs from inside the cb fails with _STATE
-    (rdkafka.c:3084-3092: every entry acquires the share handle; acquire
-    rejects when in_callback is true)."""
+    """Calling share-consumer APIs from inside the cb fails with _STATE —
+    librdkafka guards every entry point against reentrancy."""
     topic = kafka_cluster.create_topic_and_wait_propogation(
         'test-share-consumer-cb-reentrancy')
 
     sc = kafka_cluster.share_consumer({'share.acknowledgement.mode': 'explicit'})
     try:
-        # Two separate guard checks — one documented (set_…cb itself, per
-        # rdkafka.h:2272), one broader (commit_async, via share_acquire).
+        # Two separate guard checks: set_…cb itself, and a generic share-API
+        # call (commit_async) that goes through the same reentrancy guard.
         captured_setter_err = []
         captured_commit_err = []
 

--- a/tests/integration/share_consumer/test_share_consumer_ack.py
+++ b/tests/integration/share_consumer/test_share_consumer_ack.py
@@ -1013,8 +1013,8 @@ def test_callback_fires_on_commit_sync(kafka_cluster):
 
 
 def test_callback_fires_during_close(kafka_cluster):
-    """close() drains pending share-ack ops, so unacked-at-close work still
-    surfaces through the cb with the offsets that were acked."""
+    """close() drains the inflight ack-commit, so the cb fires for the acked
+    offsets even though we never poll() after commit_async()."""
     topic = kafka_cluster.create_topic_and_wait_propogation('test-share-consumer-cb-close')
     num_messages = 3
 
@@ -1186,10 +1186,7 @@ def test_callback_reentrancy_guard(kafka_cluster):
     finally:
         # Replace the reentrant cb before close so close()'s drain doesn't
         # re-trip the guards.
-        try:
-            sc.set_acknowledgement_commit_callback(None)
-        except Exception:
-            pass
+        sc.set_acknowledgement_commit_callback(None)
         sc.close()
 
 
@@ -1279,10 +1276,7 @@ def test_callback_exception_propagates_from_poll(kafka_cluster):
         assert raised is sentinel, f'expected sentinel ValueError, got {raised!r}'
     finally:
         # Replace the raising cb before close so close() doesn't fire it.
-        try:
-            sc.set_acknowledgement_commit_callback(None)
-        except Exception:
-            pass
+        sc.set_acknowledgement_commit_callback(None)
         sc.close()
 
 

--- a/tests/integration/share_consumer/test_share_consumer_ack.py
+++ b/tests/integration/share_consumer/test_share_consumer_ack.py
@@ -18,6 +18,7 @@
 """Integration tests for ShareConsumer acknowledgement (KIP-932)."""
 
 import gc
+import threading
 import time
 import weakref
 
@@ -726,9 +727,10 @@ def test_partial_ack_still_blocks_next_poll(kafka_cluster):
 
 # --- acknowledgement-commit callback --------------------------------------
 #
-# The cb fires once per partition, dispatched on the thread that calls poll().
-# Tests that expect a cb invocation must poll() at least once after
-# commit_async / commit_sync so the dispatch has a chance to run.
+# The cb fires once per partition, on the application thread. It runs from
+# whatever consumer call drains the response queue: poll(), commit_sync(), or
+# close(). commit_sync() and close() dispatch inline, so after a commit_async()
+# a test has to make one of those calls before the cb will fire.
 
 
 def _wait_for_callback(sc, invocations, expected_count, timeout_s=10.0):
@@ -1188,6 +1190,55 @@ def test_callback_reentrancy_guard(kafka_cluster):
             sc.set_acknowledgement_commit_callback(None)
         except Exception:
             pass
+        sc.close()
+
+
+def test_share_consumer_methods_rejected_from_other_thread(kafka_cluster):
+    """A ShareConsumer is single-threaded. While one thread is parked in a
+    consumer call (here poll(), which holds the access gate the whole time),
+    a call from another thread is rejected with _CONFLICT."""
+    topic = kafka_cluster.create_topic_and_wait_propogation('test-share-consumer-cross-thread')
+
+    sc = kafka_cluster.share_consumer({'share.acknowledgement.mode': 'explicit'})
+    started = threading.Event()
+    stop = threading.Event()
+    try:
+        sc.subscribe([topic])
+
+        def gate_holder():
+            # Poll an empty topic in a tight loop so this thread holds the gate
+            # almost the whole time. Ignore anything that goes wrong here; all
+            # that matters is the other thread seeing the conflict.
+            started.set()
+            while not stop.is_set():
+                try:
+                    sc.poll(timeout=0.5)
+                except Exception:
+                    pass
+
+        holder = threading.Thread(target=gate_holder, name='gate-holder')
+        holder.start()
+        try:
+            assert started.wait(timeout=5.0), 'gate-holder thread did not start'
+
+            # While the holder is parked in poll(), commit_async() from this
+            # thread should come back as concurrent access. Retry for a bit so
+            # the call lands during a poll() and not in the gap between two.
+            conflict = None
+            deadline = time.time() + 10.0
+            while conflict is None and time.time() < deadline:
+                try:
+                    sc.commit_async()
+                except KafkaException as ex:
+                    if ex.args[0].code() == KafkaError._CONFLICT:
+                        conflict = ex
+                time.sleep(0.02)
+
+            assert conflict is not None, 'expected _CONFLICT from cross-thread commit_async(), got none'
+        finally:
+            stop.set()
+            holder.join(timeout=5.0)
+    finally:
         sc.close()
 
 

--- a/tests/integration/share_consumer/test_share_consumer_ack.py
+++ b/tests/integration/share_consumer/test_share_consumer_ack.py
@@ -1323,3 +1323,165 @@ def test_rebind_releases_previous_callback(kafka_cluster):
         assert second_ref() is None, 'second cb still alive after clear — stash leaked'
     finally:
         sc.close()
+
+
+# --- acknowledgement-commit callback: error delivery ----------------------
+#
+# The cb tests above all check the happy path (exc is None). These check the
+# other half: when the broker rejects an ack, the cb's second arg is a
+# KafkaException instead, still carrying the offsets it applies to.
+#
+# Lock-expiry INVALID_RECORD_STATE is the only rejection we can force without a
+# mock cluster: ack a record, let its lock lapse (1s, from tests/common
+# broker_conf), then commit the now-stale ack.
+
+
+def _ack_then_let_lock_expire(sc, num_messages, lock_sleep_s=2.0, timeout_s=20.0):
+    """Consume num_messages, ACCEPT each, then sleep past the broker's 1s lock
+    so the acks go stale. Returns the acked offsets. We ack inside the loop
+    rather than after it, else the next poll() trips _STATE on the unacked
+    batch."""
+    acked_offsets = set()
+    batch = []
+    deadline = time.time() + timeout_s
+    while time.time() < deadline and len(batch) < num_messages:
+        for m in sc.poll(timeout=0.5):
+            if m.error() is None:
+                batch.append(m)
+                sc.acknowledge(m, AcknowledgeType.ACCEPT)
+                acked_offsets.add(m.offset())
+    assert len(batch) == num_messages, f'received {len(batch)} of {num_messages}'
+    time.sleep(lock_sleep_s)
+    return acked_offsets
+
+
+def test_callback_reports_invalid_record_state_on_commit_async(kafka_cluster):
+    """Stale ack + commit_async: the rejection comes back through the cb as a
+    KafkaException carrying INVALID_RECORD_STATE, offsets attached."""
+    topic = kafka_cluster.create_topic_and_wait_propogation('test-share-consumer-cb-err-async')
+    num_messages = 3
+
+    sc = kafka_cluster.share_consumer({'share.acknowledgement.mode': 'explicit'})
+    try:
+        invocations = []
+        sc.set_acknowledgement_commit_callback(lambda offsets, exc: invocations.append((offsets, exc)))
+        sc.subscribe([topic])
+
+        producer = kafka_cluster.cimpl_producer()
+        for i in range(num_messages):
+            producer.produce(topic, value=f'msg-{i}'.encode())
+        producer.flush(timeout=10.0)
+
+        acked_offsets = _ack_then_let_lock_expire(sc, num_messages)
+
+        sc.commit_async()
+
+        # Poll until the rejection lands. The expired records get redelivered
+        # and, unacked, would block the next poll with _STATE — don't care,
+        # we're just here to drain the response queue. Swallow it, keep going.
+        deadline = time.time() + 15.0
+        while time.time() < deadline and not any(exc is not None for _, exc in invocations):
+            try:
+                sc.poll(timeout=0.5)
+            except KafkaException:
+                pass
+
+        errored = [(offsets, exc) for offsets, exc in invocations if exc is not None]
+        assert errored, f'cb never reported an error; invocations={invocations!r}'
+
+        cb_offsets = set()
+        for offsets, exc in errored:
+            assert isinstance(exc, KafkaException), f'exc is not a KafkaException: {exc!r}'
+            err = exc.args[0]
+            assert err.code() == KafkaError.INVALID_RECORD_STATE
+            assert err.name() == 'INVALID_RECORD_STATE'
+            # retriable()/fatal() are always False here — the error is built
+            # from a bare code with no per-instance flags, so branch on code(),
+            # not the flags. See docs/share_consumer_error_mapping.md.
+            assert err.retriable() is False
+            assert err.fatal() is False
+            # The error doesn't replace the offsets — they come through too.
+            assert len(offsets) == 1, f'expected 1 partition key, got {list(offsets)}'
+            tp = next(iter(offsets))
+            assert isinstance(tp, TopicPartition)
+            assert tp.topic == topic
+            assert isinstance(offsets[tp], frozenset)
+            cb_offsets |= offsets[tp]
+        assert cb_offsets == acked_offsets, f'cb error saw {cb_offsets}, acked {acked_offsets}'
+    finally:
+        sc.set_acknowledgement_commit_callback(None)
+        sc.close()
+
+
+def test_callback_reports_invalid_record_state_on_commit_sync(kafka_cluster):
+    """commit_sync reports the rejection twice — in its result dict and to the
+    cb — and the two had better agree. The cb fires inline, so no poll()."""
+    topic = kafka_cluster.create_topic_and_wait_propogation('test-share-consumer-cb-err-sync')
+    num_messages = 3
+
+    sc = kafka_cluster.share_consumer({'share.acknowledgement.mode': 'explicit'})
+    try:
+        invocations = []
+        sc.set_acknowledgement_commit_callback(lambda offsets, exc: invocations.append((offsets, exc)))
+        sc.subscribe([topic])
+
+        producer = kafka_cluster.cimpl_producer()
+        for i in range(num_messages):
+            producer.produce(topic, value=f'msg-{i}'.encode())
+        producer.flush(timeout=10.0)
+
+        _ack_then_let_lock_expire(sc, num_messages)
+
+        result = sc.commit_sync(timeout=10.0)
+
+        # First place it shows up: the per-partition result dict.
+        assert any(
+            err is not None and err.code() == KafkaError.INVALID_RECORD_STATE for err in result.values()
+        ), f'expected INVALID_RECORD_STATE in commit_sync result {result}'
+
+        # And again via the cb, which already fired inline before commit_sync
+        # returned — no poll in between.
+        errored = [(offsets, exc) for offsets, exc in invocations if exc is not None]
+        assert errored, f'cb never reported an error during commit_sync; invocations={invocations!r}'
+        for _, exc in errored:
+            assert isinstance(exc, KafkaException)
+            assert exc.args[0].code() == KafkaError.INVALID_RECORD_STATE
+    finally:
+        sc.set_acknowledgement_commit_callback(None)
+        sc.close()
+
+
+def test_callback_reports_error_during_close(kafka_cluster):
+    """No poll() after commit_async, so close() is what drains the response and
+    fires the cb — rejection included. Error-path twin of
+    test_callback_fires_during_close."""
+    topic = kafka_cluster.create_topic_and_wait_propogation('test-share-consumer-cb-err-close')
+    num_messages = 3
+
+    sc = kafka_cluster.share_consumer({'share.acknowledgement.mode': 'explicit'})
+    invocations = []
+    try:
+        sc.set_acknowledgement_commit_callback(lambda offsets, exc: invocations.append((offsets, exc)))
+        sc.subscribe([topic])
+
+        producer = kafka_cluster.cimpl_producer()
+        for i in range(num_messages):
+            producer.produce(topic, value=f'msg-{i}'.encode())
+        producer.flush(timeout=10.0)
+
+        _ack_then_let_lock_expire(sc, num_messages)
+
+        # Fire the send but don't poll — let close() drain the response.
+        sc.commit_async()
+    finally:
+        sc.close()
+
+    errored = [(offsets, exc) for offsets, exc in invocations if exc is not None]
+    assert errored, f'cb did not report an error during close(); invocations={invocations!r}'
+    for offsets, exc in errored:
+        assert isinstance(exc, KafkaException)
+        assert exc.args[0].code() == KafkaError.INVALID_RECORD_STATE
+        # Failed offsets still ride along on the close-drained error.
+        assert len(offsets) == 1, f'expected 1 partition key, got {list(offsets)}'
+        tp = next(iter(offsets))
+        assert tp.topic == topic

--- a/tests/integration/share_consumer/test_share_consumer_ack.py
+++ b/tests/integration/share_consumer/test_share_consumer_ack.py
@@ -21,14 +21,8 @@ import time
 
 import pytest
 
-from confluent_kafka import AcknowledgeType, KafkaError, KafkaException
+from confluent_kafka import AcknowledgeType, KafkaError, KafkaException, TopicPartition
 from tests.common import drain_share_consumers, poll_first_batch, unique_id
-
-# TODO KIP-932: these tests verify ack success indirectly — by opening a
-# second consumer in the same share group and asserting no redelivery.
-# Once the per-record acknowledgement callback is exposed through the
-# Python binding add direct success/failure assertions on the callback instead of relying
-# on the no-redelivery side-channel.
 
 # TODO KIP-932: add unit tests (alongside integration tests) that exercise
 # type and value validation of acknowledge() / acknowledge_offset() input
@@ -265,9 +259,6 @@ def test_unacked_records_block_next_poll(kafka_cluster):
 
 
 # --- delivery limit, atomicity, transactions ------------------------------
-
-# TODO KIP-932: Add a test once the per-record ack callback is exposed
-# through the Python binding.
 
 
 def test_delivery_attempt_limit_archives_record(kafka_cluster):
@@ -728,4 +719,511 @@ def test_partial_ack_still_blocks_next_poll(kafka_cluster):
             sc.acknowledge(m, AcknowledgeType.ACCEPT)
         sc.poll(timeout=2.0)
     finally:
+        sc.close()
+
+
+# --- acknowledgement-commit callback --------------------------------------
+#
+# librdkafka fires the callback once per partition (rdkafka_share_acknowledgement.h:
+# "enqueues one callback operation per partition"), so each invocation's
+# offsets dict contains exactly one TopicPartition key. The cb is dispatched
+# by the rk_rep drain inside rd_kafka_share_consume_batch (rdkafka.c:3844/3876),
+# i.e. on the thread that calls poll(). Tests that expect a cb invocation
+# must therefore poll() at least once after commit_async / commit_sync to
+# give the drain a chance to fire it.
+
+
+def _wait_for_callback(sc, invocations, expected_count, timeout_s=10.0):
+    """Poll until at least expected_count cb invocations have been recorded
+    or timeout_s elapses. Returns the (possibly partial) invocations list."""
+    deadline = time.time() + timeout_s
+    while len(invocations) < expected_count and time.time() < deadline:
+        sc.poll(timeout=0.5)
+    return invocations
+
+
+def test_set_callback_rejects_non_callable(kafka_cluster):
+    """Non-callable raises TypeError at the binding."""
+    sc = kafka_cluster.share_consumer({'share.acknowledgement.mode': 'explicit'})
+    try:
+        for bad in (42, 'not-a-callable', object()):
+            with pytest.raises(TypeError):
+                sc.set_acknowledgement_commit_callback(bad)
+    finally:
+        sc.close()
+
+
+def test_set_callback_accepts_none(kafka_cluster):
+    """None clears the callback; setting/clearing repeatedly is safe.
+    Both positional and ``callback=`` keyword forms accepted (Java parity:
+    the Java parameter is named ``callback``)."""
+    sc = kafka_cluster.share_consumer({'share.acknowledgement.mode': 'explicit'})
+    try:
+        sc.set_acknowledgement_commit_callback(None)
+        sc.set_acknowledgement_commit_callback(lambda offsets, exc: None)
+        sc.set_acknowledgement_commit_callback(None)
+        # Keyword form (matches Java's setAcknowledgementCommitCallback param).
+        sc.set_acknowledgement_commit_callback(callback=lambda offsets, exc: None)
+        sc.set_acknowledgement_commit_callback(callback=None)
+    finally:
+        sc.close()
+
+
+def test_set_callback_after_close_raises(kafka_cluster):
+    """Calling the setter on a closed consumer raises RuntimeError."""
+    sc = kafka_cluster.share_consumer({'share.acknowledgement.mode': 'explicit'})
+    sc.close()
+    with pytest.raises(RuntimeError):
+        sc.set_acknowledgement_commit_callback(lambda offsets, exc: None)
+
+
+def test_callback_fires_on_explicit_commit_async(kafka_cluster):
+    """ack → commit_async → poll fires the cb with exception=None and
+    a dict containing the acknowledged offsets."""
+    topic = kafka_cluster.create_topic_and_wait_propogation(
+        'test-share-consumer-cb-explicit')
+    num_messages = 3
+
+    sc = kafka_cluster.share_consumer({'share.acknowledgement.mode': 'explicit'})
+    try:
+        invocations = []
+        sc.set_acknowledgement_commit_callback(
+            lambda offsets, exc: invocations.append((offsets, exc)))
+
+        sc.subscribe([topic])
+
+        producer = kafka_cluster.cimpl_producer()
+        produced = [f'msg-{i}'.encode() for i in range(num_messages)]
+        for value in produced:
+            producer.produce(topic, value=value)
+        producer.flush(timeout=10.0)
+
+        acked_offsets = set()
+        batch = []
+        deadline = time.time() + 20.0
+        while time.time() < deadline and len(batch) < num_messages:
+            for m in sc.poll(timeout=0.5):
+                if m.error() is None:
+                    batch.append(m)
+                    sc.acknowledge(m, AcknowledgeType.ACCEPT)
+                    acked_offsets.add(m.offset())
+        assert len(batch) == num_messages, f'received {len(batch)} of {num_messages}'
+
+        sc.commit_async()
+        _wait_for_callback(sc, invocations, 1, timeout_s=10.0)
+
+        assert invocations, 'callback never fired'
+        cb_offsets = set()
+        for offsets, exc in invocations:
+            assert exc is None, f'unexpected exception in cb: {exc!r}'
+            # librdkafka fires the cb once per partition; with a single
+            # default-partition-count topic the dict has exactly one key.
+            assert len(offsets) == 1, f'expected 1 partition key, got {list(offsets)}'
+            tp = next(iter(offsets))
+            assert isinstance(tp, TopicPartition)
+            assert tp.topic == topic
+            assert isinstance(offsets[tp], frozenset)
+            cb_offsets |= offsets[tp]
+        assert cb_offsets == acked_offsets, (
+            f'cb saw {cb_offsets}, acked {acked_offsets}'
+        )
+    finally:
+        sc.close()
+
+
+def test_callback_fires_on_implicit_mode(kafka_cluster):
+    """Implicit mode: next poll auto-acks prior batch and fires the cb."""
+    topic = kafka_cluster.create_topic_and_wait_propogation(
+        'test-share-consumer-cb-implicit')
+    num_messages = 3
+
+    sc = kafka_cluster.share_consumer({'share.acknowledgement.mode': 'implicit'})
+    try:
+        invocations = []
+        sc.set_acknowledgement_commit_callback(
+            lambda offsets, exc: invocations.append((offsets, exc)))
+
+        sc.subscribe([topic])
+
+        producer = kafka_cluster.cimpl_producer()
+        for i in range(num_messages):
+            producer.produce(topic, value=f'msg-{i}'.encode())
+        producer.flush(timeout=10.0)
+
+        # Drain all records — each subsequent poll() implicit-acks the prior
+        # batch, which fires the cb.
+        drain_share_consumers([sc], num_messages, timeout_s=20.0)
+
+        # Final commit_async to flush the tail batch, plus polls to drain.
+        sc.commit_async()
+        _wait_for_callback(sc, invocations, 1, timeout_s=10.0)
+
+        assert invocations, 'callback never fired'
+        for offsets, exc in invocations:
+            assert exc is None, f'unexpected exception in cb: {exc!r}'
+            assert len(offsets) == 1
+    finally:
+        sc.close()
+
+
+def test_callback_replacement_only_new_fires(kafka_cluster):
+    """Re-registering replaces the prior callback — old one stops firing."""
+    topic = kafka_cluster.create_topic_and_wait_propogation(
+        'test-share-consumer-cb-replace')
+
+    sc = kafka_cluster.share_consumer({'share.acknowledgement.mode': 'explicit'})
+    try:
+        cb1_calls = []
+        cb2_calls = []
+
+        # First cycle: cb1 active.
+        sc.set_acknowledgement_commit_callback(
+            lambda offsets, exc: cb1_calls.append((offsets, exc)))
+        sc.subscribe([topic])
+        producer = kafka_cluster.cimpl_producer()
+        producer.produce(topic, value=b'msg-cb1')
+        producer.flush(timeout=10.0)
+
+        msgs = poll_first_batch(sc)
+        assert msgs, 'cb1 cycle: no message received'
+        for m in msgs:
+            sc.acknowledge(m, AcknowledgeType.ACCEPT)
+        sc.commit_async()
+        _wait_for_callback(sc, cb1_calls, 1, timeout_s=10.0)
+        assert cb1_calls, 'cb1 never fired'
+        cb1_count_after_first_cycle = len(cb1_calls)
+
+        # Swap to cb2.
+        sc.set_acknowledgement_commit_callback(
+            lambda offsets, exc: cb2_calls.append((offsets, exc)))
+
+        producer.produce(topic, value=b'msg-cb2')
+        producer.flush(timeout=10.0)
+        msgs = poll_first_batch(sc)
+        assert msgs, 'cb2 cycle: no message received'
+        for m in msgs:
+            sc.acknowledge(m, AcknowledgeType.ACCEPT)
+        sc.commit_async()
+        _wait_for_callback(sc, cb2_calls, 1, timeout_s=10.0)
+
+        assert cb2_calls, 'cb2 never fired after replacement'
+        assert len(cb1_calls) == cb1_count_after_first_cycle, (
+            f'cb1 fired again after replacement: {cb1_calls[cb1_count_after_first_cycle:]}'
+        )
+    finally:
+        sc.close()
+
+
+def test_callback_clear_with_none_disables(kafka_cluster):
+    """After clearing with None the cb must not fire on subsequent commits."""
+    topic = kafka_cluster.create_topic_and_wait_propogation(
+        'test-share-consumer-cb-clear')
+
+    sc = kafka_cluster.share_consumer({'share.acknowledgement.mode': 'explicit'})
+    try:
+        invocations = []
+        sc.set_acknowledgement_commit_callback(
+            lambda offsets, exc: invocations.append((offsets, exc)))
+        sc.subscribe([topic])
+
+        producer = kafka_cluster.cimpl_producer()
+        producer.produce(topic, value=b'msg-pre-clear')
+        producer.flush(timeout=10.0)
+
+        msgs = poll_first_batch(sc)
+        assert msgs
+        for m in msgs:
+            sc.acknowledge(m, AcknowledgeType.ACCEPT)
+        sc.commit_async()
+        _wait_for_callback(sc, invocations, 1, timeout_s=10.0)
+        assert invocations, 'cb did not fire before clear'
+        count_before_clear = len(invocations)
+
+        # Clear and do another cycle.
+        sc.set_acknowledgement_commit_callback(None)
+        producer.produce(topic, value=b'msg-post-clear')
+        producer.flush(timeout=10.0)
+        msgs = poll_first_batch(sc)
+        assert msgs
+        for m in msgs:
+            sc.acknowledge(m, AcknowledgeType.ACCEPT)
+        sc.commit_async()
+
+        # Drain rk_rep so any (unwanted) cb dispatches get a chance.
+        deadline = time.time() + 5.0
+        while time.time() < deadline:
+            sc.poll(timeout=0.5)
+
+        assert len(invocations) == count_before_clear, (
+            f'cb fired {len(invocations) - count_before_clear} times after clear'
+        )
+    finally:
+        sc.close()
+
+
+def test_callback_fires_on_commit_sync(kafka_cluster):
+    """commit_sync drains rk_rep before returning (rdkafka.c:4353), so the
+    cb fires inside commit_sync itself — no extra poll needed."""
+    topic = kafka_cluster.create_topic_and_wait_propogation(
+        'test-share-consumer-cb-commit-sync')
+
+    sc = kafka_cluster.share_consumer({'share.acknowledgement.mode': 'explicit'})
+    try:
+        invocations = []
+        sc.set_acknowledgement_commit_callback(
+            lambda offsets, exc: invocations.append((offsets, exc)))
+        sc.subscribe([topic])
+
+        producer = kafka_cluster.cimpl_producer()
+        producer.produce(topic, value=b'msg-0')
+        producer.flush(timeout=10.0)
+
+        msgs = poll_first_batch(sc)
+        assert msgs
+        for m in msgs:
+            sc.acknowledge(m, AcknowledgeType.ACCEPT)
+
+        # commit_sync blocks until broker responds, and per-partition results
+        # are also delivered to the cb via the post-commit rk_rep drain.
+        result = sc.commit_sync(timeout=10.0)
+        assert result, 'commit_sync returned no per-partition results'
+
+        # The cb should have fired before commit_sync returned; no poll().
+        assert invocations, 'cb did not fire during commit_sync'
+        for offsets, exc in invocations:
+            assert exc is None, f'unexpected exception in cb: {exc!r}'
+            assert len(offsets) == 1
+    finally:
+        sc.close()
+
+
+def test_callback_fires_during_close(kafka_cluster):
+    """close() drains pending share-ack ops via rd_kafka_consumer_close0
+    (rdkafka.c:5137-5153 → rd_kafka_poll_cb → SHARE_ACK_COMMIT_CB_EXECUTE),
+    so unacked-at-close work still surfaces through the cb."""
+    topic = kafka_cluster.create_topic_and_wait_propogation(
+        'test-share-consumer-cb-close')
+
+    sc = kafka_cluster.share_consumer({'share.acknowledgement.mode': 'explicit'})
+    invocations = []
+    try:
+        sc.set_acknowledgement_commit_callback(
+            lambda offsets, exc: invocations.append((offsets, exc)))
+        sc.subscribe([topic])
+
+        producer = kafka_cluster.cimpl_producer()
+        producer.produce(topic, value=b'msg-0')
+        producer.flush(timeout=10.0)
+
+        msgs = poll_first_batch(sc)
+        assert msgs
+        for m in msgs:
+            sc.acknowledge(m, AcknowledgeType.ACCEPT)
+
+        # Trigger the send but DO NOT poll — let close() drain the response.
+        sc.commit_async()
+    finally:
+        sc.close()
+
+    assert invocations, 'cb did not fire during close()'
+    for offsets, exc in invocations:
+        assert exc is None, f'unexpected exception in cb: {exc!r}'
+        assert len(offsets) == 1
+
+
+def test_callback_cardinality_multipartition(kafka_cluster):
+    """librdkafka fires the cb once per partition
+    (rdkafka_share_acknowledgement.h:307-318). With N partitions and records
+    spread across them, the cb should fire N times, each with exactly one
+    TopicPartition key."""
+    num_partitions = 3
+    num_messages_per_partition = 2
+    topic = kafka_cluster.create_topic_and_wait_propogation(
+        'test-share-consumer-cb-multipart',
+        {'num_partitions': num_partitions})
+
+    sc = kafka_cluster.share_consumer({'share.acknowledgement.mode': 'explicit'})
+    try:
+        invocations = []
+        sc.set_acknowledgement_commit_callback(
+            lambda offsets, exc: invocations.append((offsets, exc)))
+        sc.subscribe([topic])
+
+        producer = kafka_cluster.cimpl_producer()
+        # Produce to specific partitions so all N see records.
+        for partition in range(num_partitions):
+            for i in range(num_messages_per_partition):
+                producer.produce(
+                    topic, value=f'p{partition}-msg-{i}'.encode(),
+                    partition=partition)
+        producer.flush(timeout=10.0)
+
+        total_messages = num_partitions * num_messages_per_partition
+        partitions_seen_in_acks = set()
+        deadline = time.time() + 30.0
+        received = 0
+        while time.time() < deadline and received < total_messages:
+            for m in sc.poll(timeout=0.5):
+                if m.error() is None:
+                    sc.acknowledge(m, AcknowledgeType.ACCEPT)
+                    partitions_seen_in_acks.add(m.partition())
+                    received += 1
+        assert partitions_seen_in_acks == set(range(num_partitions)), (
+            f'expected acks on partitions {set(range(num_partitions))}, '
+            f'got {partitions_seen_in_acks}')
+
+        sc.commit_async()
+        deadline = time.time() + 10.0
+        while time.time() < deadline and len(invocations) < num_partitions:
+            sc.poll(timeout=0.5)
+
+        # Every invocation: exactly one partition key.
+        for offsets, exc in invocations:
+            assert exc is None
+            assert len(offsets) == 1, (
+                f'cb invocation carried {len(offsets)} partitions; expected 1 '
+                f'(librdkafka fires once per partition)')
+
+        # Aggregate: every partition we acked must show up across the
+        # invocations.
+        partitions_seen_in_cb = set()
+        for offsets, _ in invocations:
+            tp = next(iter(offsets))
+            partitions_seen_in_cb.add(tp.partition)
+        assert partitions_seen_in_cb == partitions_seen_in_acks, (
+            f'cb saw partitions {partitions_seen_in_cb}, '
+            f'expected {partitions_seen_in_acks}')
+    finally:
+        sc.close()
+
+
+def test_callback_not_invoked_on_empty_commit(kafka_cluster):
+    """commit_async/commit_sync with no pending acks short-circuit in
+    librdkafka (rdkafka.c:4232-4236, 4309-4313) and never enqueue a broker
+    request — the cb must not fire."""
+    topic = kafka_cluster.create_topic_and_wait_propogation(
+        'test-share-consumer-cb-empty-commit')
+
+    sc = kafka_cluster.share_consumer({'share.acknowledgement.mode': 'explicit'})
+    try:
+        invocations = []
+        sc.set_acknowledgement_commit_callback(
+            lambda offsets, exc: invocations.append((offsets, exc)))
+        sc.subscribe([topic])
+
+        # Empty commits — no records consumed, nothing to ack.
+        sc.commit_async()
+        result = sc.commit_sync(timeout=2.0)
+        assert result == {}, f'expected empty result dict, got {result!r}'
+
+        # Give librdkafka a chance to fire any (unwanted) cb dispatches.
+        deadline = time.time() + 3.0
+        while time.time() < deadline:
+            sc.poll(timeout=0.5)
+
+        assert invocations == [], (
+            f'cb fired on empty commit: {invocations!r}'
+        )
+    finally:
+        sc.close()
+
+
+def test_callback_reentrancy_guard(kafka_cluster):
+    """Calling share-consumer APIs from inside the cb fails with _STATE
+    (rdkafka.c:3084-3092: every entry acquires the share handle; acquire
+    rejects when in_callback is true)."""
+    topic = kafka_cluster.create_topic_and_wait_propogation(
+        'test-share-consumer-cb-reentrancy')
+
+    sc = kafka_cluster.share_consumer({'share.acknowledgement.mode': 'explicit'})
+    try:
+        # Two separate guard checks — one documented (set_…cb itself, per
+        # rdkafka.h:2272), one broader (commit_async, via share_acquire).
+        captured_setter_err = []
+        captured_commit_err = []
+
+        def reentrant_cb(offsets, exc):
+            try:
+                sc.set_acknowledgement_commit_callback(
+                    lambda o, e: None)
+            except KafkaException as ex:
+                captured_setter_err.append(ex)
+            try:
+                sc.commit_async()
+            except KafkaException as ex:
+                captured_commit_err.append(ex)
+
+        sc.set_acknowledgement_commit_callback(reentrant_cb)
+        sc.subscribe([topic])
+
+        producer = kafka_cluster.cimpl_producer()
+        producer.produce(topic, value=b'msg-0')
+        producer.flush(timeout=10.0)
+
+        msgs = poll_first_batch(sc)
+        assert msgs
+        for m in msgs:
+            sc.acknowledge(m, AcknowledgeType.ACCEPT)
+
+        sc.commit_async()
+        deadline = time.time() + 10.0
+        while time.time() < deadline and not captured_setter_err:
+            sc.poll(timeout=0.5)
+
+        assert captured_setter_err, 'cb did not raise on nested setter call'
+        assert captured_setter_err[0].args[0].code() == KafkaError._STATE
+        assert captured_commit_err, 'cb did not raise on nested commit_async'
+        assert captured_commit_err[0].args[0].code() == KafkaError._STATE
+    finally:
+        # Replace the reentrant cb before close so close()'s drain doesn't
+        # re-trip the guards.
+        try:
+            sc.set_acknowledgement_commit_callback(None)
+        except Exception:
+            pass
+        sc.close()
+
+
+def test_callback_exception_propagates_from_poll(kafka_cluster):
+    """An exception raised inside the cb surfaces from the next poll() call."""
+    topic = kafka_cluster.create_topic_and_wait_propogation(
+        'test-share-consumer-cb-exception')
+
+    sentinel = ValueError('sentinel from cb')
+
+    def raising_cb(offsets, exc):
+        raise sentinel
+
+    sc = kafka_cluster.share_consumer({'share.acknowledgement.mode': 'explicit'})
+    try:
+        sc.set_acknowledgement_commit_callback(raising_cb)
+        sc.subscribe([topic])
+
+        producer = kafka_cluster.cimpl_producer()
+        producer.produce(topic, value=b'msg-0')
+        producer.flush(timeout=10.0)
+
+        msgs = poll_first_batch(sc)
+        assert msgs
+        for m in msgs:
+            sc.acknowledge(m, AcknowledgeType.ACCEPT)
+        sc.commit_async()
+
+        # The cb is dispatched on the next poll's rk_rep drain; that's when
+        # the ValueError should resurface in this thread.
+        deadline = time.time() + 10.0
+        raised = None
+        while time.time() < deadline and raised is None:
+            try:
+                sc.poll(timeout=0.5)
+            except ValueError as e:
+                raised = e
+                break
+        assert raised is sentinel, f'expected sentinel ValueError, got {raised!r}'
+    finally:
+        # Replace the raising cb before close so close() doesn't fire it.
+        try:
+            sc.set_acknowledgement_commit_callback(None)
+        except Exception:
+            pass
         sc.close()

--- a/tests/integration/share_consumer_oauth/test_oauth_integration.py
+++ b/tests/integration/share_consumer_oauth/test_oauth_integration.py
@@ -114,10 +114,7 @@ def test_share_consumer_oauth_refresh_through_reauth(oauth_share_consumer_conf):
 #
 # TODO KIP-932: fix the OAuth construction path so it surfaces a KafkaException
 # instead of a SystemError, then re-enable this test.
-@pytest.mark.skip(
-    reason="Latent OAuth bug: failed construction raises SystemError instead of "
-    "KafkaException."
-)
+@pytest.mark.skip(reason="Latent OAuth bug: failed construction raises SystemError instead of " "KafkaException.")
 def test_share_consumer_oauth_expired_token_surfaces_error_cb(oauth_share_consumer_conf):
     """Expired token is rejected by the broker; error_cb fires from the poll drain.
 

--- a/tests/integration/share_consumer_oauth/test_oauth_integration.py
+++ b/tests/integration/share_consumer_oauth/test_oauth_integration.py
@@ -100,6 +100,24 @@ def test_share_consumer_oauth_refresh_through_reauth(oauth_share_consumer_conf):
         sc.close()
 
 
+# Skipping for now: this hits a latent bug in the OAuth path where a failed
+# construction comes back as a SystemError instead of a KafkaException.
+#
+# What happens: when the initial token doesn't arrive in time,
+# wait_for_oauth_token_set sets a KafkaException and we then tear the half-built
+# client down. That teardown drains whatever is still queued on rk_rep, and a
+# broker "auth failed" event is sitting there waiting to fire error_cb. So
+# error_cb (errors.append(...)) ends up being called while the KafkaException is
+# still pending, which CPython won't allow: you can't call into Python with an
+# exception already set. The result is a SystemError that hides the real
+# KafkaException the caller was meant to catch.
+#
+# TODO KIP-932: fix the OAuth construction path so it surfaces a KafkaException
+# instead of a SystemError, then re-enable this test.
+@pytest.mark.skip(
+    reason="Latent OAuth bug: failed construction raises SystemError instead of "
+    "KafkaException."
+)
 def test_share_consumer_oauth_expired_token_surfaces_error_cb(oauth_share_consumer_conf):
     """Expired token is rejected by the broker; error_cb fires from the poll drain.
 

--- a/tests/test_ShareConsumer.py
+++ b/tests/test_ShareConsumer.py
@@ -268,11 +268,14 @@ def test_subscribe_with_non_list_raises(share_consumer):
         share_consumer.subscribe(None)
 
 
-def test_subscribe_with_empty_list_raises(share_consumer):
-    """librdkafka rejects an empty subscription with _INVALID_ARG."""
-    with pytest.raises(KafkaException) as exc_info:
-        share_consumer.subscribe([])
-    assert exc_info.value.args[0].code() == KafkaError._INVALID_ARG
+def test_subscribe_with_empty_list_unsubscribes(share_consumer):
+    """subscribe([]) is equivalent to unsubscribe(): an empty topic list
+    clears the current subscription instead of raising."""
+    share_consumer.subscribe(['test-topic'])
+    assert share_consumer.subscription() == ['test-topic']
+
+    share_consumer.subscribe([])  # no exception
+    assert share_consumer.subscription() == []
 
 
 def test_poll_with_non_numeric_timeout_raises(share_consumer):


### PR DESCRIPTION
**Summary**
- Adds a runtime-registered acknowledgement-commit callback for ShareConsumer. 
- New Python method ShareConsumer.set_acknowledgement_commit_callback(callback) which accepts a callable `(offsets, exception) -> None` or `None` to clear.
- New C trampoline `ShareConsumer_acknowledgement_commit_cb` plus helper `c_share_partition_offsets_list_to_py()` that converts librdkafka's `rd_kafka_share_partition_offsets_list_t `into `Dict[TopicPartition, frozenset[int]]`.
- Carves out a dedicated ShareConsumer arm in the Handle union so the share-consumer state no
  longer piggybacks on the Consumer fields. GC traverse/clear updated accordingly.
- Adds integration tests in t`ests/integration/share_consumer/test_share_consumer_ack.py `covering success, error,
  clear-callback, and lifecycle paths.