### PR TITLE
Fix tag-release CI: Linux wheel verify + Windows wheel build

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -179,7 +179,7 @@ blocks:
             - name: MSYSTEM
               value: UCRT64
           commands:
-            - sem-version python 3.11.15
+            - sem-version python 3.11
             - bash tools/mingw-w64/semaphore_commands.sh
             - bash tools/wheels/install-librdkafka.sh $env:LIBRDKAFKA_VERSION.TrimStart("v") dest
             - tools/wheels/build-wheels.bat x64 win_amd64 dest wheelhouse
@@ -509,7 +509,7 @@ blocks:
       jobs:
         - name: Verify
           commands:
-            - sem-version python 3.11.15
+            - sem-version python 3.11
             - python -m pip install --upgrade pip pytest
             - python -m pip install -r requirements/requirements-tests-install.txt
             - artifact pull workflow artifacts

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -179,7 +179,7 @@ blocks:
             - name: MSYSTEM
               value: UCRT64
           commands:
-            - sem-version python 3.11.9
+            - sem-version python 3.11.15
             - bash tools/mingw-w64/semaphore_commands.sh
             - bash tools/wheels/install-librdkafka.sh $env:LIBRDKAFKA_VERSION.TrimStart("v") dest
             - tools/wheels/build-wheels.bat x64 win_amd64 dest wheelhouse
@@ -509,7 +509,7 @@ blocks:
       jobs:
         - name: Verify
           commands:
-            - sem-version python 3.11.9
+            - sem-version python 3.11.15
             - python -m pip install --upgrade pip pytest
             - python -m pip install -r requirements/requirements-tests-install.txt
             - artifact pull workflow artifacts

--- a/tools/test-manylinux.sh
+++ b/tools/test-manylinux.sh
@@ -62,7 +62,7 @@ function run_single_in_docker {
     fi
 
     # Install pip and uv for package management
-    curl https://bootstrap.pypa.io/get-pip.py | python3.9
+    curl https://bootstrap.pypa.io/pip/3.9/get-pip.py | python3.9
     pip install uv
 
     /io/tools/smoketest.sh "$wheelhouse"


### PR DESCRIPTION
Linux x64/arm64 "Wheel Verification" failed because tools/test-manylinux.sh downloaded bootstrap.pypa.io/get-pip.py and ran it against Python 3.9. Upstream pypa dropped Py3.9 support from the unversioned endpoint; the error itself recommends the versioned URL https://bootstrap.pypa.io/pip/3.9/get-pip.py.

Windows "Wheels" + "Wheel Verification" failed because sem-version python 3.11.9 reported "No GitHub artifact attestations found". mise (used by Semaphore's Windows AMI) requires GitHub artifact attestations on python-build-standalone artifacts. Attestation support was added to python-build-standalone in PR #517 (2025-02-11); Py3.11.9 was packaged before that. Bump to 3.11.15, which is shipped by every recent attested release.

CI validation : https://semaphore.ci.confluent.io/workflows/fa36311e-c7e7-468c-9318-9d9f0ed23c0a?pipeline_id=63c64c70-738c-441a-ba1e-812770e01f77