### PR TITLE
v2.14.2rc4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Confluent Python Client for Apache Kafka - CHANGELOG
 
-## v2.14.2rc3
+## v2.14.2rc4
 
 ### Fixes
 
@@ -11,7 +11,7 @@
 - Fix Encryption fails when referencing self defined types (#2254)
 
 
-confluent-kafka-python v2.14.2rc3 is based on librdkafka v2.14.2-RC3, see the
+confluent-kafka-python v2.14.2rc4 is based on librdkafka v2.14.2-RC3, see the
 [librdkafka release notes](https://github.com/confluentinc/librdkafka/releases/tag/v2.14.2-RC3)
 for a complete list of changes, enhancements, fixes and upgrade considerations.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "confluent-kafka"
-version = "2.14.2rc3"
+version = "2.14.2rc4"
 description = "Confluent's Python client for Apache Kafka"
 classifiers = [
     "Development Status :: 5 - Production/Stable",

--- a/src/confluent_kafka/src/confluent_kafka.h
+++ b/src/confluent_kafka/src/confluent_kafka.h
@@ -38,7 +38,7 @@
 /**
  * @brief confluent-kafka-python version, must match that of pyproject.toml.
  */
-#define CFL_VERSION_STR "2.14.2rc3"
+#define CFL_VERSION_STR "2.14.2rc4"
 
 /**
  * Minimum required librdkafka version. This is checked both during

--- a/tests/soak/setup_all_versions.py
+++ b/tests/soak/setup_all_versions.py
@@ -22,7 +22,7 @@ LIBRDKAFKA_VERSIONS = [
 ]
 
 PYTHON_VERSIONS = [
-    '2.14.2rc3',
+    '2.14.2rc4',
     '2.13.2',
     '2.13.0',
     '2.12.1',


### PR DESCRIPTION
Bumps version strings from rc3 → rc4 in pyproject.toml, confluent_kafka.h, and CHANGELOG.md.

rc4 carries the same fix set as rc3, retagged on top of master to pick up
the tag-release CI fix (#2258). librdkafka pin unchanged (v2.14.2-RC3).