### PR TITLE
v2.14.2

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -8,7 +8,7 @@ execution_time_limit:
 global_job_config:
   env_vars:
     - name: LIBRDKAFKA_VERSION
-      value: v2.14.2-RC3
+      value: v2.14.2
   prologue:
     commands:
       - checkout

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Confluent Python Client for Apache Kafka - CHANGELOG
 
-## v2.14.2 - 2026-06-01
+## v2.14.2 - 2026-06-03
 
 v2.14.2 is a maintenance release with the following fixes and enhancements:
 
@@ -16,6 +16,12 @@ v2.14.2 is a maintenance release with the following fixes and enhancements:
 confluent-kafka-python v2.14.2 is based on librdkafka v2.14.2, see the
 [librdkafka release notes](https://github.com/confluentinc/librdkafka/releases/tag/v2.14.2)
 for a complete list of changes, enhancements, fixes and upgrade considerations.
+
+
+
+## v2.14.1
+
+There was no 2.14.1 release of the Python Client.
 
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Confluent Python Client for Apache Kafka - CHANGELOG
 
-## v2.14.2rc4
+## v2.14.2 - 2026-06-01
+
+v2.14.2 is a maintenance release with the following fixes and enhancements:
 
 ### Fixes
 
@@ -11,8 +13,8 @@
 - Fix Encryption fails when referencing self defined types (#2254)
 
 
-confluent-kafka-python v2.14.2rc4 is based on librdkafka v2.14.2-RC3, see the
-[librdkafka release notes](https://github.com/confluentinc/librdkafka/releases/tag/v2.14.2-RC3)
+confluent-kafka-python v2.14.2 is based on librdkafka v2.14.2, see the
+[librdkafka release notes](https://github.com/confluentinc/librdkafka/releases/tag/v2.14.2)
 for a complete list of changes, enhancements, fixes and upgrade considerations.
 
 

--- a/examples/docker/Dockerfile.alpine
+++ b/examples/docker/Dockerfile.alpine
@@ -30,7 +30,7 @@ FROM alpine:3.12
 
 COPY . /usr/src/confluent-kafka-python
 
-ENV LIBRDKAFKA_VERSION="v2.14.2-RC3"
+ENV LIBRDKAFKA_VERSION="v2.14.2"
 ENV KCAT_VERSION="master"
 ENV CKP_VERSION="master"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "confluent-kafka"
-version = "2.14.2rc4"
+version = "2.14.2"
 description = "Confluent's Python client for Apache Kafka"
 classifiers = [
     "Development Status :: 5 - Production/Stable",

--- a/src/confluent_kafka/src/confluent_kafka.h
+++ b/src/confluent_kafka/src/confluent_kafka.h
@@ -38,7 +38,7 @@
 /**
  * @brief confluent-kafka-python version, must match that of pyproject.toml.
  */
-#define CFL_VERSION_STR "2.14.2rc4"
+#define CFL_VERSION_STR "2.14.2"
 
 /**
  * Minimum required librdkafka version. This is checked both during

--- a/tests/soak/setup_all_versions.py
+++ b/tests/soak/setup_all_versions.py
@@ -5,7 +5,7 @@ import subprocess
 PYTHON_SOAK_TEST_BRANCH = 'master'
 
 LIBRDKAFKA_VERSIONS = [
-    '2.14.2-RC3',
+    '2.14.2',
     '2.13.2',
     '2.13.0',
     '2.12.1',
@@ -22,7 +22,7 @@ LIBRDKAFKA_VERSIONS = [
 ]
 
 PYTHON_VERSIONS = [
-    '2.14.2rc4',
+    '2.14.2',
     '2.13.2',
     '2.13.0',
     '2.12.1',


### PR DESCRIPTION
Bumps version strings from `2.14.2rc4` → `2.14.2` final and flips the librdkafka pin from `v2.14.2-RC3` → `v2.14.2` (now live on NuGet as of 2026-06-01).
rc4 was validated end-to-end against prod pypi.org + a local broker (produce/consume round-trip via `examples/producer.py` and `examples/consumer.py`). Pre-release validation script passes locally (0 warnings).