### PR TITLE
Pin protobuf<7.0.0 to avoid upb FieldDescriptor.label breakage

### DIFF
--- a/requirements/requirements-examples.txt
+++ b/requirements/requirements-examples.txt
@@ -19,7 +19,7 @@ jsonschema >= 4.18.0
 orjson >= 3.10
 
 googleapis-common-protos
-protobuf
+protobuf<7.0.0
 
 azure-identity
 azure-keyvault-keys

--- a/requirements/requirements-protobuf.txt
+++ b/requirements/requirements-protobuf.txt
@@ -1,2 +1,2 @@
 googleapis-common-protos
-protobuf
+protobuf<7.0.0


### PR DESCRIPTION
## Issue
`requirements/requirements-protobuf.txt` and `requirements/requirements-examples.txt` have unpinned `protobuf`. Google released `protobuf==7.35.0` to PyPI between May 29 and Jun 1, 2026. v7 removed `.label` from the upb `FieldDescriptor`, which is accessed at 7 runtime call sites in the schema-registry protobuf module:

- `src/confluent_kafka/schema_registry/common/protobuf.py:263`
- `src/confluent_kafka/schema_registry/rules/cel/constraints.py` (6 sites)

Master CI on May 29 (last green run) resolved `protobuf==6.33.6`. Any CI run from Jun 1 onward resolves `protobuf==7.35.0` and fails.

## Fix
Pin `protobuf<7.0.0` in the two requirements files that carry the unpinned dep. Minimal ceiling-only constraint to keep the existing no-lower-bound style.