### PR TITLE
Fix Encryption fails when expanded union types have two references to the same record (#2262)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Confluent Python Client for Apache Kafka - CHANGELOG
 
+## v2.xx.x
+
+### Fixes
+
+- Fix Encryption fails when expanded union types have two references to the same record (#2262)
+
 ## v2.14.2 - 2026-06-03
 
 v2.14.2 is a maintenance release with the following fixes and enhancements:
@@ -11,7 +17,6 @@ v2.14.2 is a maintenance release with the following fixes and enhancements:
 - Fix redefining a named Avro type in a diamond dependency pattern (#2238)
 - Fix typing_extensions import errors on Python 3.12 (#2232)
 - Fix Encryption fails when referencing self defined types (#2254)
-- Fix Encryption fails when expanded union types have two references to the same record (#2262)
 
 
 confluent-kafka-python v2.14.2 is based on librdkafka v2.14.2, see the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ v2.14.2 is a maintenance release with the following fixes and enhancements:
 - Fix redefining a named Avro type in a diamond dependency pattern (#2238)
 - Fix typing_extensions import errors on Python 3.12 (#2232)
 - Fix Encryption fails when referencing self defined types (#2254)
+- Fix Encryption fails when expanded union types have two references to the same record (#2262)
 
 
 confluent-kafka-python v2.14.2 is based on librdkafka v2.14.2, see the

--- a/src/confluent_kafka/schema_registry/common/avro.py
+++ b/src/confluent_kafka/schema_registry/common/avro.py
@@ -267,7 +267,7 @@ def _collapse_schema(schema: AvroSchema, encountered_references=None) -> AvroSch
         elif schema_type == "record":
             name = schema.get("name")
             namespace = schema.get("namespace")
-            full_name = name if namespace is None or '.' in name else f"{namespace}.{name}"
+            full_name = name if namespace is None or (name is not None and '.' in name) else f"{namespace}.{name}"
             if full_name in encountered_references:
                 return schema["name"]
             encountered_references.append(full_name)

--- a/src/confluent_kafka/schema_registry/common/avro.py
+++ b/src/confluent_kafka/schema_registry/common/avro.py
@@ -5,7 +5,7 @@ import re
 from collections import defaultdict
 from copy import deepcopy
 from io import BytesIO
-from typing import Dict, Optional, Set, Tuple, Union, cast, List
+from typing import Dict, Optional, Set, Tuple, Union, cast
 
 from fastavro import repository, validate
 from fastavro.schema import load_schema
@@ -236,19 +236,20 @@ def _resolve_union(schema: AvroSchema, message: AvroMessage) -> Tuple[Optional[A
             continue
     return (None, message)
 
+
 def _collapse_schema(schema: AvroSchema, encountered_references=None) -> AvroSchema:
     """
-        Collapses a schema to conform to the Avro specification if it has been previously expanded.
-        Recursively replaces any record, fixed, or enum definitions with their name if they have already been encountered in the schema.
-        Mutates the incoming schema
+    Collapses a schema to conform to the Avro specification if it has been previously expanded.
+    Recursively replaces record, fixed, or enum definitions with their name when they have been already defined.
+    Mutates the incoming schema.
 
-        Args:
-            schema: An (expanded) Avro schema
-            encountered_references: A list of encountered references (used in the recursion)
+    Args:
+        schema: An (expanded) Avro schema
+        encountered_references: A list of encountered references (used in the recursion)
 
-        Returns:
-            AvroSchema: A collapsed Avro schema.
-        """
+    Returns:
+        AvroSchema: A collapsed Avro schema.
+    """
     if encountered_references is None:
         encountered_references = []
     if isinstance(schema, str):
@@ -287,6 +288,7 @@ def _collapse_schema(schema: AvroSchema, encountered_references=None) -> AvroSch
         schema["type"] = _collapse_schema(schema["type"], encountered_references)
         return schema
     return schema
+
 
 def get_inline_tags(schema: AvroSchema) -> Dict[str, Set[str]]:
     inline_tags: Dict[str, Set[str]] = defaultdict(set)

--- a/src/confluent_kafka/schema_registry/common/avro.py
+++ b/src/confluent_kafka/schema_registry/common/avro.py
@@ -230,13 +230,27 @@ def _resolve_union(schema: AvroSchema, message: AvroMessage) -> Tuple[Optional[A
                     if dict_schema["name"] == dict_message['-type']:
                         return (dict_schema, dict_message)
             else:
-                validate(message, _collapse_schema(deepcopy(subschema), []))
+                validate(message, _collapse_schema(deepcopy(subschema)))
                 return (subschema, message)
         except:  # noqa: E722
             continue
     return (None, message)
 
-def _collapse_schema(schema: AvroSchema, encountered_references: List[str]) -> AvroSchema:
+def _collapse_schema(schema: AvroSchema, encountered_references=None) -> AvroSchema:
+    """
+        Collapses a schema to conform to the Avro specification if it has been previously expanded.
+        Recursively replaces any record, fixed, or enum definitions with their name if they have already been encountered in the schema.
+        Mutates the incoming schema
+
+        Args:
+            schema: An (expanded) Avro schema
+            encountered_references: A list of encountered references (used in the recursion)
+
+        Returns:
+            AvroSchema: A collapsed Avro schema.
+        """
+    if encountered_references is None:
+        encountered_references = []
     if isinstance(schema, str):
         return schema
     elif isinstance(schema, list):
@@ -250,16 +264,20 @@ def _collapse_schema(schema: AvroSchema, encountered_references: List[str]) -> A
             schema["values"] = _collapse_schema(schema["values"], encountered_references)
             return schema
         elif schema_type == "record":
-            if schema["name"] in encountered_references :
+            name = schema.get("name")
+            namespace = schema.get("namespace")
+            full_name = name if namespace is None or '.' in name else f"{namespace}.{name}"
+            if full_name in encountered_references:
                 return schema["name"]
-            encountered_references.append(schema["name"])
+            encountered_references.append(full_name)
             if schema.get("aliases") is not None:
                 for alias in schema["aliases"]:
-                    encountered_references.append(alias)
+                    full_alias = alias if namespace is None or '.' in alias else f"{namespace}.{alias}"
+                    encountered_references.append(full_alias)
             schema["fields"] = _collapse_schema(schema["fields"], encountered_references)
             return schema
         elif schema_type == "fixed" or schema_type == "enum":
-            if schema["name"] in encountered_references :
+            if schema["name"] in encountered_references:
                 return schema["name"]
             encountered_references.append(schema["name"])
             if schema.get("aliases") is not None:

--- a/src/confluent_kafka/schema_registry/common/avro.py
+++ b/src/confluent_kafka/schema_registry/common/avro.py
@@ -5,7 +5,7 @@ import re
 from collections import defaultdict
 from copy import deepcopy
 from io import BytesIO
-from typing import Dict, Optional, Set, Tuple, Union, cast
+from typing import Dict, Optional, Set, Tuple, Union, cast, List
 
 from fastavro import repository, validate
 from fastavro.schema import load_schema
@@ -25,6 +25,7 @@ __all__ = [
     'get_type',
     '_disjoint',
     '_resolve_union',
+    '_collapse_schema',
     'get_inline_tags',
     '_get_inline_tags_recursively',
     '_implied_namespace',
@@ -229,12 +230,45 @@ def _resolve_union(schema: AvroSchema, message: AvroMessage) -> Tuple[Optional[A
                     if dict_schema["name"] == dict_message['-type']:
                         return (dict_schema, dict_message)
             else:
-                validate(message, subschema)
+                validate(message, _collapse_schema(deepcopy(subschema), []))
                 return (subschema, message)
         except:  # noqa: E722
             continue
     return (None, message)
 
+def _collapse_schema(schema: AvroSchema, encountered_references: List[str]) -> AvroSchema:
+    if isinstance(schema, str):
+        return schema
+    elif isinstance(schema, list):
+        return [_collapse_schema(subschema, encountered_references) for subschema in schema]
+    elif isinstance(schema, dict):
+        schema_type = schema.get("type")
+        if schema_type == 'array':
+            schema["items"] = _collapse_schema(schema['items'], encountered_references)
+            return schema
+        elif schema_type == 'map':
+            schema["values"] = _collapse_schema(schema["values"], encountered_references)
+            return schema
+        elif schema_type == "record":
+            if schema["name"] in encountered_references :
+                return schema["name"]
+            encountered_references.append(schema["name"])
+            if schema.get("aliases") is not None:
+                for alias in schema["aliases"]:
+                    encountered_references.append(alias)
+            schema["fields"] = _collapse_schema(schema["fields"], encountered_references)
+            return schema
+        elif schema_type == "fixed" or schema_type == "enum":
+            if schema["name"] in encountered_references :
+                return schema["name"]
+            encountered_references.append(schema["name"])
+            if schema.get("aliases") is not None:
+                for alias in schema["aliases"]:
+                    encountered_references.append(alias)
+            return schema
+        schema["type"] = _collapse_schema(schema["type"], encountered_references)
+        return schema
+    return schema
 
 def get_inline_tags(schema: AvroSchema) -> Dict[str, Set[str]]:
     inline_tags: Dict[str, Set[str]] = defaultdict(set)

--- a/src/confluent_kafka/src/Admin.c
+++ b/src/confluent_kafka/src/Admin.c
@@ -553,11 +553,11 @@ Admin_config_dict_to_c(void *c_obj, PyObject *dict, const char *op_name) {
 static PyObject *
 Admin_create_topics(Handle *self, PyObject *args, PyObject *kwargs) {
         PyObject *topics = NULL, *future, *validate_only_obj = NULL;
-        static char *kws[]                 = {"topics", "future",
-                                              /* options */
-                                              "validate_only", "request_timeout",
-                                              "operation_timeout", NULL};
-        struct Admin_options options       = Admin_options_INITIALIZER;
+        static char *kws[]           = {"topics", "future",
+                                        /* options */
+                                        "validate_only", "request_timeout",
+                                        "operation_timeout", NULL};
+        struct Admin_options options = Admin_options_INITIALIZER;
         rd_kafka_AdminOptions_t *c_options = NULL;
         int tcnt;
         int i;
@@ -702,10 +702,10 @@ err:
  */
 static PyObject *
 Admin_delete_topics(Handle *self, PyObject *args, PyObject *kwargs) {
-        PyObject *topics                   = NULL, *future;
-        static char *kws[]                 = {"topics", "future",
-                                              /* options */
-                                              "request_timeout", "operation_timeout", NULL};
+        PyObject *topics   = NULL, *future;
+        static char *kws[] = {"topics", "future",
+                              /* options */
+                              "request_timeout", "operation_timeout", NULL};
         struct Admin_options options       = Admin_options_INITIALIZER;
         rd_kafka_AdminOptions_t *c_options = NULL;
         int tcnt;
@@ -807,11 +807,11 @@ err:
 static PyObject *
 Admin_create_partitions(Handle *self, PyObject *args, PyObject *kwargs) {
         PyObject *topics = NULL, *future, *validate_only_obj = NULL;
-        static char *kws[]                 = {"topics", "future",
-                                              /* options */
-                                              "validate_only", "request_timeout",
-                                              "operation_timeout", NULL};
-        struct Admin_options options       = Admin_options_INITIALIZER;
+        static char *kws[]           = {"topics", "future",
+                                        /* options */
+                                        "validate_only", "request_timeout",
+                                        "operation_timeout", NULL};
+        struct Admin_options options = Admin_options_INITIALIZER;
         rd_kafka_AdminOptions_t *c_options = NULL;
         int tcnt;
         int i;
@@ -934,10 +934,10 @@ err:
 static PyObject *
 Admin_describe_configs(Handle *self, PyObject *args, PyObject *kwargs) {
         PyObject *resources, *future;
-        static char *kws[]                 = {"resources", "future",
-                                              /* options */
-                                              "request_timeout", "broker", NULL};
-        struct Admin_options options       = Admin_options_INITIALIZER;
+        static char *kws[]           = {"resources", "future",
+                                        /* options */
+                                        "request_timeout", "broker", NULL};
+        struct Admin_options options = Admin_options_INITIALIZER;
         rd_kafka_AdminOptions_t *c_options = NULL;
         PyObject *ConfigResource_type;
         int cnt, i;
@@ -1064,11 +1064,11 @@ static PyObject *Admin_incremental_alter_configs(Handle *self,
                                                  PyObject *args,
                                                  PyObject *kwargs) {
         PyObject *resources, *future;
-        PyObject *validate_only_obj        = NULL;
-        static char *kws[]                 = {"resources", "future",
-                                              /* options */
-                                              "validate_only", "request_timeout", "broker",
-                                              NULL};
+        PyObject *validate_only_obj = NULL;
+        static char *kws[] = {"resources", "future",
+                              /* options */
+                              "validate_only", "request_timeout", "broker",
+                              NULL};
         struct Admin_options options       = Admin_options_INITIALIZER;
         rd_kafka_AdminOptions_t *c_options = NULL;
         PyObject *ConfigResource_type, *ConfigEntry_type;
@@ -1232,11 +1232,11 @@ err:
 static PyObject *
 Admin_alter_configs(Handle *self, PyObject *args, PyObject *kwargs) {
         PyObject *resources, *future;
-        PyObject *validate_only_obj        = NULL;
-        static char *kws[]                 = {"resources", "future",
-                                              /* options */
-                                              "validate_only", "request_timeout", "broker",
-                                              NULL};
+        PyObject *validate_only_obj = NULL;
+        static char *kws[] = {"resources", "future",
+                              /* options */
+                              "validate_only", "request_timeout", "broker",
+                              NULL};
         struct Admin_options options       = Admin_options_INITIALIZER;
         rd_kafka_AdminOptions_t *c_options = NULL;
         PyObject *ConfigResource_type;
@@ -3696,8 +3696,8 @@ Admin_c_ConfigEntries_to_py(PyObject *ConfigEntry_type,
                                   rd_kafka_ConfigEntry_is_synonym(ent));
 
                 c_synonyms = rd_kafka_ConfigEntry_synonyms(ent, &synonym_cnt);
-                synonyms   = Admin_c_ConfigEntries_to_py(ConfigEntry_type,
-                                                         c_synonyms, synonym_cnt);
+                synonyms = Admin_c_ConfigEntries_to_py(ConfigEntry_type,
+                                                       c_synonyms, synonym_cnt);
                 if (!synonyms) {
                         Py_DECREF(kwargs);
                         Py_DECREF(dict);

--- a/tests/schema_registry/_async/test_avro_serdes.py
+++ b/tests/schema_registry/_async/test_avro_serdes.py
@@ -1309,17 +1309,12 @@ async def test_avro_encryption_complex_schema_union():
                         {
                             'name': 'complexSubType1',
                             'type': {
-                                'fields': [
-                                    {'name': 'stringValue', 'type': 'string', 'confluent:tags': ['PII']}
-                                ],
+                                'fields': [{'name': 'stringValue', 'type': 'string', 'confluent:tags': ['PII']}],
                                 'name': 'ComplexSubType',
-                                'type': 'record'
-                            }
+                                'type': 'record',
+                            },
                         },
-                        {
-                            'name': 'complexSubType2',
-                            'type': 'ComplexSubType'
-                        }
+                        {'name': 'complexSubType2', 'type': 'ComplexSubType'},
                     ],
                     'name': 'ComplexFieldType',
                     'type': 'record',

--- a/tests/schema_registry/_async/test_avro_serdes.py
+++ b/tests/schema_registry/_async/test_avro_serdes.py
@@ -1291,6 +1291,83 @@ async def test_avro_encryption_complex_schema():
     assert actual['complexField2']['stringValue'] == 'test2'
 
 
+async def test_avro_encryption_complex_schema_union():
+    executor = FieldEncryptionExecutor.register_with_clock(FakeClock())
+
+    conf = {'url': _BASE_URL}
+    client = AsyncSchemaRegistryClient.new_client(conf)
+    ser_conf = {'auto.register.schemas': False, 'use.latest.version': True}
+    rule_conf = {'secret': 'mysecret'}
+    schema = {
+        'type': 'record',
+        'name': 'test',
+        'fields': [
+            {
+                'name': 'complexField1',
+                'type': {
+                    'fields': [
+                        {
+                            'name': 'complexSubType1',
+                            'type': {
+                                'fields': [
+                                    {'name': 'stringValue', 'type': 'string', 'confluent:tags': ['PII']}
+                                ],
+                                'name': 'ComplexSubType',
+                                'type': 'record'
+                            }
+                        },
+                        {
+                            'name': 'complexSubType2',
+                            'type': 'ComplexSubType'
+                        }
+                    ],
+                    'name': 'ComplexFieldType',
+                    'type': 'record',
+                },
+            },
+            {'name': 'complexField2', 'type': ['null', 'ComplexFieldType']},
+        ],
+    }
+
+    rule = Rule(
+        "test-encrypt",
+        "",
+        RuleKind.TRANSFORM,
+        RuleMode.WRITEREAD,
+        "ENCRYPT",
+        ["PII"],
+        RuleParams({"encrypt.kek.name": "kek1", "encrypt.kms.type": "local-kms", "encrypt.kms.key.id": "mykey"}),
+        None,
+        None,
+        "ERROR,NONE",
+        False,
+    )
+    await client.register_schema(_SUBJECT, Schema(json.dumps(schema), "AVRO", [], None, RuleSet(None, [rule])))
+
+    obj = {
+        'complexField1': {'complexSubType1': {'stringValue': 'test1'}, 'complexSubType2': {'stringValue': 'test2'}},
+        'complexField2': {'complexSubType1': {'stringValue': 'test3'}, 'complexSubType2': {'stringValue': 'test4'}},
+    }
+
+    ser = await AsyncAvroSerializer(client, schema_str=None, conf=ser_conf, rule_conf=rule_conf)
+    dek_client = executor.executor.client
+    ser_ctx = SerializationContext(_TOPIC, MessageField.VALUE)
+    obj_bytes = await ser(obj, ser_ctx)
+
+    assert 'test1' not in str(obj_bytes)
+    assert 'test2' not in str(obj_bytes)
+    assert 'test3' not in str(obj_bytes)
+    assert 'test4' not in str(obj_bytes)
+
+    deser = await AsyncAvroDeserializer(client, rule_conf=rule_conf)
+    executor.executor.client = dek_client
+    actual = await deser(obj_bytes, ser_ctx)
+    assert actual['complexField1']['complexSubType1']['stringValue'] == 'test1'
+    assert actual['complexField1']['complexSubType2']['stringValue'] == 'test2'
+    assert actual['complexField2']['complexSubType1']['stringValue'] == 'test3'
+    assert actual['complexField2']['complexSubType2']['stringValue'] == 'test4'
+
+
 async def test_avro_payload_encryption():
     executor = EncryptionExecutor.register_with_clock(FakeClock())
 

--- a/tests/schema_registry/_sync/test_avro_serdes.py
+++ b/tests/schema_registry/_sync/test_avro_serdes.py
@@ -1291,6 +1291,78 @@ def test_avro_encryption_complex_schema():
     assert actual['complexField2']['stringValue'] == 'test2'
 
 
+def test_avro_encryption_complex_schema_union():
+    executor = FieldEncryptionExecutor.register_with_clock(FakeClock())
+
+    conf = {'url': _BASE_URL}
+    client = SchemaRegistryClient.new_client(conf)
+    ser_conf = {'auto.register.schemas': False, 'use.latest.version': True}
+    rule_conf = {'secret': 'mysecret'}
+    schema = {
+        'type': 'record',
+        'name': 'test',
+        'fields': [
+            {
+                'name': 'complexField1',
+                'type': {
+                    'fields': [
+                        {
+                            'name': 'complexSubType1',
+                            'type': {
+                                'fields': [{'name': 'stringValue', 'type': 'string', 'confluent:tags': ['PII']}],
+                                'name': 'ComplexSubType',
+                                'type': 'record',
+                            },
+                        },
+                        {'name': 'complexSubType2', 'type': 'ComplexSubType'},
+                    ],
+                    'name': 'ComplexFieldType',
+                    'type': 'record',
+                },
+            },
+            {'name': 'complexField2', 'type': ['null', 'ComplexFieldType']},
+        ],
+    }
+
+    rule = Rule(
+        "test-encrypt",
+        "",
+        RuleKind.TRANSFORM,
+        RuleMode.WRITEREAD,
+        "ENCRYPT",
+        ["PII"],
+        RuleParams({"encrypt.kek.name": "kek1", "encrypt.kms.type": "local-kms", "encrypt.kms.key.id": "mykey"}),
+        None,
+        None,
+        "ERROR,NONE",
+        False,
+    )
+    client.register_schema(_SUBJECT, Schema(json.dumps(schema), "AVRO", [], None, RuleSet(None, [rule])))
+
+    obj = {
+        'complexField1': {'complexSubType1': {'stringValue': 'test1'}, 'complexSubType2': {'stringValue': 'test2'}},
+        'complexField2': {'complexSubType1': {'stringValue': 'test3'}, 'complexSubType2': {'stringValue': 'test4'}},
+    }
+
+    ser = AvroSerializer(client, schema_str=None, conf=ser_conf, rule_conf=rule_conf)
+    dek_client = executor.executor.client
+    ser_ctx = SerializationContext(_TOPIC, MessageField.VALUE)
+    obj_bytes = ser(obj, ser_ctx)
+
+    assert 'test1' not in str(obj_bytes)
+    assert 'test2' not in str(obj_bytes)
+    assert 'test3' not in str(obj_bytes)
+    assert 'test4' not in str(obj_bytes)
+
+    deser = AvroDeserializer(client, rule_conf=rule_conf)
+    executor.executor.client = dek_client
+    actual = deser(obj_bytes, ser_ctx)
+    assert actual['complexField1']['complexSubType1']['stringValue'] == 'test1'
+    assert actual['complexField1']['complexSubType2']['stringValue'] == 'test2'
+    assert actual['complexField2']['complexSubType1']['stringValue'] == 'test3'
+    assert actual['complexField2']['complexSubType2']['stringValue'] == 'test4'
+
+
 def test_avro_payload_encryption():
     executor = EncryptionExecutor.register_with_clock(FakeClock())
 


### PR DESCRIPTION
<!--
Suggested PR template: Fill/delete/add sections as needed. Optionally delete any commented block.
-->
What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include implementation strategy.
-->

Fix Encryption fails when expanded union types have two references to the same record

Checklist
------------------
- [ ] Contains customer facing changes? Including API/behavior changes <!-- This can help identify if it has introduced any breaking changes -->
- [x] Did you add sufficient unit test and/or integration test coverage for this PR?
  - If not, please explain why it is not required

References
----------
Github: #2262 
<!--
Copy&paste links: to Jira ticket, other PRs, issues, Slack conversations...
For code bumps: link to PR, tag or GitHub `/compare/master...master`
-->


Test & Review
------------
<!--
Has it been tested? how?
Copy&paste any handy instructions, steps or requirements that can save time to the reviewer or any reader.
-->
Automatic tests