### PR TITLE
Support protobuf 7 by replacing removed FieldDescriptor.label

### DIFF
--- a/src/confluent_kafka/schema_registry/common/protobuf.py
+++ b/src/confluent_kafka/schema_registry/common/protobuf.py
@@ -5,6 +5,7 @@ from collections import deque
 from decimal import MAX_PREC, Context, Decimal
 from typing import Any, Deque, List, Set
 
+from google.protobuf import __version__ as _protobuf_version
 from google.protobuf import (
     any_pb2,
     api_pb2,
@@ -55,6 +56,7 @@ __all__ = [
     '_set_field',
     'get_type',
     'is_map_field',
+    '_is_repeated',
     'get_inline_tags',
     '_disjoint',
     '_is_builtin',
@@ -89,6 +91,17 @@ else:
 
 
 PROTOBUF_TYPE = "PROTOBUF"
+
+# protobuf 7 removed the deprecated FieldDescriptor.label property in favor of the
+# is_repeated/is_required boolean properties. Track the major version so we keep
+# working on both old (<7, has .label) and new (>=7, only .is_repeated) runtimes.
+PROTOBUF_MAJOR_VERSION = int(_protobuf_version.split('.')[0])
+
+
+def _is_repeated(fd: FieldDescriptor) -> bool:
+    if PROTOBUF_MAJOR_VERSION >= 7:
+        return fd.is_repeated
+    return fd.label == FieldDescriptor.LABEL_REPEATED
 
 
 class _ContextStringIO(io.BytesIO):
@@ -260,7 +273,7 @@ def _transform_field(
         value = getattr(message, fd.name)
         if is_map_field(fd):
             value = {key: value[key] for key in value}
-        elif fd.label == FieldDescriptor.LABEL_REPEATED:
+        elif _is_repeated(fd):
             value = [item for item in value]
         new_value = transform(ctx, desc, value, field_transform)
         if ctx.rule.kind == RuleKind.CONDITION:

--- a/src/confluent_kafka/schema_registry/rules/cel/constraints.py
+++ b/src/confluent_kafka/schema_registry/rules/cel/constraints.py
@@ -207,11 +207,7 @@ def check_field_type(field: descriptor.FieldDescriptor, expected: int, wrapper_n
 
 
 def _is_map(field: descriptor.FieldDescriptor):
-    return (
-        _is_repeated(field)
-        and field.message_type is not None
-        and field.message_type.GetOptions().map_entry
-    )
+    return _is_repeated(field) and field.message_type is not None and field.message_type.GetOptions().map_entry
 
 
 def _is_list(field: descriptor.FieldDescriptor):

--- a/src/confluent_kafka/schema_registry/rules/cel/constraints.py
+++ b/src/confluent_kafka/schema_registry/rules/cel/constraints.py
@@ -16,10 +16,22 @@
 import typing
 
 from celpy import celtypes
+from google.protobuf import __version__ as _protobuf_version
 from google.protobuf import descriptor, message, message_factory
 
 from confluent_kafka.schema_registry.rules.cel import string_format
 from confluent_kafka.schema_registry.rules.cel.cel_field_presence import in_has
+
+# protobuf 7 removed the deprecated FieldDescriptor.label property in favor of the
+# is_repeated/is_required boolean properties. Track the major version so we keep
+# working on both old (<7, has .label) and new (>=7, only .is_repeated) runtimes.
+PROTOBUF_MAJOR_VERSION = int(_protobuf_version.split('.')[0])
+
+
+def _is_repeated(field: descriptor.FieldDescriptor) -> bool:
+    if PROTOBUF_MAJOR_VERSION >= 7:
+        return field.is_repeated
+    return field.label == descriptor.FieldDescriptor.LABEL_REPEATED
 
 
 class CompilationError(Exception):
@@ -136,7 +148,7 @@ def _scalar_field_value_to_cel(val: typing.Any, field: descriptor.FieldDescripto
 
 
 def _field_value_to_cel(val: typing.Any, field: descriptor.FieldDescriptor) -> celtypes.Value:
-    if field.label == descriptor.FieldDescriptor.LABEL_REPEATED:
+    if _is_repeated(field):
         if field.message_type is not None and field.message_type.GetOptions().map_entry:
             return _map_field_value_to_cel(val, field)
         return _repeated_field_value_to_cel(val, field)
@@ -146,7 +158,7 @@ def _field_value_to_cel(val: typing.Any, field: descriptor.FieldDescriptor) -> c
 def _is_empty_field(msg: message.Message, field: descriptor.FieldDescriptor) -> bool:
     if field.has_presence:
         return not _proto_message_has_field(msg, field)
-    if field.label == descriptor.FieldDescriptor.LABEL_REPEATED:
+    if _is_repeated(field):
         return len(_proto_message_get_field(msg, field)) == 0
     return _proto_message_get_field(msg, field) == field.default_value
 
@@ -178,7 +190,7 @@ def _map_field_to_cel(msg: message.Message, field: descriptor.FieldDescriptor) -
 
 
 def _field_to_cel(msg: message.Message, field: descriptor.FieldDescriptor) -> celtypes.Value:
-    if field.label == descriptor.FieldDescriptor.LABEL_REPEATED:
+    if _is_repeated(field):
         return _repeated_field_to_cel(msg, field)
     elif field.message_type is not None and not _proto_message_has_field(msg, field):
         return None
@@ -196,18 +208,18 @@ def check_field_type(field: descriptor.FieldDescriptor, expected: int, wrapper_n
 
 def _is_map(field: descriptor.FieldDescriptor):
     return (
-        field.label == descriptor.FieldDescriptor.LABEL_REPEATED
+        _is_repeated(field)
         and field.message_type is not None
         and field.message_type.GetOptions().map_entry
     )
 
 
 def _is_list(field: descriptor.FieldDescriptor):
-    return field.label == descriptor.FieldDescriptor.LABEL_REPEATED and not _is_map(field)
+    return _is_repeated(field) and not _is_map(field)
 
 
 def _zero_value(field: descriptor.FieldDescriptor):
-    if field.message_type is not None and field.label != descriptor.FieldDescriptor.LABEL_REPEATED:
+    if field.message_type is not None and not _is_repeated(field):
         return _field_value_to_cel(message_factory.GetMessageClass(field.message_type)(), field)
     else:
         return _field_value_to_cel(field.default_value, field)


### PR DESCRIPTION
protobuf 7 removed the deprecated FieldDescriptor.label property in favor of the is_repeated boolean property, which broke the protobuf serde and CEL rule code that compared label against LABEL_REPEATED.

Add a PROTOBUF_MAJOR_VERSION-gated _is_repeated() helper in both common/protobuf.py and rules/cel/constraints.py: use fd.is_repeated on protobuf >= 7 and fall back to fd.label == LABEL_REPEATED on older runtimes, so the library keeps working across protobuf 4.x through 7.x.

<!--
Suggested PR template: Fill/delete/add sections as needed. Optionally delete any commented block.
-->
What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include implementation strategy.
-->

Checklist
------------------
- [ ] Contains customer facing changes? Including API/behavior changes <!-- This can help identify if it has introduced any breaking changes -->
  - No
- [ ] Did you add sufficient unit test and/or integration test coverage for this PR?
  - Tried the existing tests

References
----------
JIRA: 
<!--
Copy&paste links: to Jira ticket, other PRs, issues, Slack conversations...
For code bumps: link to PR, tag or GitHub `/compare/master...master`
-->

Test & Review
------------
<!--
Has it been tested? how?
Copy&paste any handy instructions, steps or requirements that can save time to the reviewer or any reader.
-->

Open questions / Follow-ups
--------------------------
<!--
Optional: anything open to discussion for the reviewer, out of scope, or follow-ups.
-->

<!--
Review stakeholders
------------------
<!--
Optional: mention stakeholders or if special context that is required to review.
-->
