### PR TITLE
validate protobuf message index bounds on deserialize

### DIFF
--- a/src/confluent_kafka/schema_registry/_async/protobuf.py
+++ b/src/confluent_kafka/schema_registry/_async/protobuf.py
@@ -788,13 +788,23 @@ class AsyncProtobufDeserializer(AsyncBaseDeserializer):
     ) -> Tuple[str, descriptor_pb2.DescriptorProto]:
         index = msg_index[0]
         if isinstance(desc, descriptor_pb2.FileDescriptorProto):
-            msg = desc.message_type[index]
+            messages = desc.message_type
+            if index < 0 or index >= len(messages):
+                raise SerializationError(
+                    "message index {} out of range, schema has {} top-level message(s)".format(index, len(messages))
+                )
+            msg = messages[index]
             path = path + "." + msg.name if path else msg.name
             if len(msg_index) == 1:
                 return path, msg
             return self._get_message_desc_proto(path, msg, msg_index[1:])
         else:
-            msg = desc.nested_type[index]
+            messages = desc.nested_type
+            if index < 0 or index >= len(messages):
+                raise SerializationError(
+                    "message index {} out of range, message has {} nested message(s)".format(index, len(messages))
+                )
+            msg = messages[index]
             path = path + "." + msg.name if path else msg.name
             if len(msg_index) == 1:
                 return path, msg

--- a/src/confluent_kafka/schema_registry/_sync/protobuf.py
+++ b/src/confluent_kafka/schema_registry/_sync/protobuf.py
@@ -777,13 +777,23 @@ class ProtobufDeserializer(BaseDeserializer):
     ) -> Tuple[str, descriptor_pb2.DescriptorProto]:
         index = msg_index[0]
         if isinstance(desc, descriptor_pb2.FileDescriptorProto):
-            msg = desc.message_type[index]
+            messages = desc.message_type
+            if index < 0 or index >= len(messages):
+                raise SerializationError(
+                    "message index {} out of range, schema has {} top-level message(s)".format(index, len(messages))
+                )
+            msg = messages[index]
             path = path + "." + msg.name if path else msg.name
             if len(msg_index) == 1:
                 return path, msg
             return self._get_message_desc_proto(path, msg, msg_index[1:])
         else:
-            msg = desc.nested_type[index]
+            messages = desc.nested_type
+            if index < 0 or index >= len(messages):
+                raise SerializationError(
+                    "message index {} out of range, message has {} nested message(s)".format(index, len(messages))
+                )
+            msg = messages[index]
             path = path + "." + msg.name if path else msg.name
             if len(msg_index) == 1:
                 return path, msg

--- a/tests/schema_registry/_async/test_proto.py
+++ b/tests/schema_registry/_async/test_proto.py
@@ -20,14 +20,17 @@ from decimal import Decimal
 from io import BytesIO
 
 import pytest
+from google.protobuf import descriptor_pb2
 
 from confluent_kafka.schema_registry.protobuf import (
+    AsyncProtobufDeserializer,
     AsyncProtobufSerializer,
     _create_index_array,
     decimal_to_protobuf,
     protobuf_to_decimal,
 )
 from confluent_kafka.schema_registry.serde import SchemaId
+from confluent_kafka.serialization import SerializationError
 from tests.integration.schema_registry.data.proto import DependencyTestProto_pb2, metadata_proto_pb2
 
 
@@ -46,6 +49,40 @@ def test_create_index(pb2, coordinates):
     msg_idx = _create_index_array(pb2.DESCRIPTOR)
 
     assert msg_idx == coordinates
+
+
+def _two_message_file_proto():
+    fdp = descriptor_pb2.FileDescriptorProto()
+    fdp.name = "test.proto"
+    fdp.package = "pkg"
+    first = fdp.message_type.add()
+    first.name = "First"
+    nested = first.nested_type.add()
+    nested.name = "Inner"
+    second = fdp.message_type.add()
+    second.name = "Second"
+    return fdp
+
+
+def test_message_index_in_range():
+    deserializer = object.__new__(AsyncProtobufDeserializer)
+    fdp = _two_message_file_proto()
+
+    assert deserializer._get_message_desc_proto("", fdp, [0])[0] == "First"
+    assert deserializer._get_message_desc_proto("", fdp, [1])[0] == "Second"
+    assert deserializer._get_message_desc_proto("", fdp, [0, 0])[0] == "First.Inner"
+
+
+@pytest.mark.parametrize("msg_index", [[-1], [2], [0, -1], [0, 5]])
+def test_message_index_out_of_range(msg_index):
+    # The message index array is attacker-controlled wire framing; a zigzag
+    # varint can decode to a negative or out-of-range value. A negative index
+    # would otherwise wrap around and resolve to a different message type.
+    deserializer = object.__new__(AsyncProtobufDeserializer)
+    fdp = _two_message_file_proto()
+
+    with pytest.raises(SerializationError, match="out of range"):
+        deserializer._get_message_desc_proto("", fdp, msg_index)
 
 
 @pytest.mark.parametrize(

--- a/tests/schema_registry/_sync/test_proto.py
+++ b/tests/schema_registry/_sync/test_proto.py
@@ -20,14 +20,17 @@ from decimal import Decimal
 from io import BytesIO
 
 import pytest
+from google.protobuf import descriptor_pb2
 
 from confluent_kafka.schema_registry.protobuf import (
+    ProtobufDeserializer,
     ProtobufSerializer,
     _create_index_array,
     decimal_to_protobuf,
     protobuf_to_decimal,
 )
 from confluent_kafka.schema_registry.serde import SchemaId
+from confluent_kafka.serialization import SerializationError
 from tests.integration.schema_registry.data.proto import DependencyTestProto_pb2, metadata_proto_pb2
 
 
@@ -46,6 +49,40 @@ def test_create_index(pb2, coordinates):
     msg_idx = _create_index_array(pb2.DESCRIPTOR)
 
     assert msg_idx == coordinates
+
+
+def _two_message_file_proto():
+    fdp = descriptor_pb2.FileDescriptorProto()
+    fdp.name = "test.proto"
+    fdp.package = "pkg"
+    first = fdp.message_type.add()
+    first.name = "First"
+    nested = first.nested_type.add()
+    nested.name = "Inner"
+    second = fdp.message_type.add()
+    second.name = "Second"
+    return fdp
+
+
+def test_message_index_in_range():
+    deserializer = object.__new__(ProtobufDeserializer)
+    fdp = _two_message_file_proto()
+
+    assert deserializer._get_message_desc_proto("", fdp, [0])[0] == "First"
+    assert deserializer._get_message_desc_proto("", fdp, [1])[0] == "Second"
+    assert deserializer._get_message_desc_proto("", fdp, [0, 0])[0] == "First.Inner"
+
+
+@pytest.mark.parametrize("msg_index", [[-1], [2], [0, -1], [0, 5]])
+def test_message_index_out_of_range(msg_index):
+    # The message index array is attacker-controlled wire framing; a zigzag
+    # varint can decode to a negative or out-of-range value. A negative index
+    # would otherwise wrap around and resolve to a different message type.
+    deserializer = object.__new__(ProtobufDeserializer)
+    fdp = _two_message_file_proto()
+
+    with pytest.raises(SerializationError, match="out of range"):
+        deserializer._get_message_desc_proto("", fdp, msg_index)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
What
----
The protobuf deserializer picks the writer message type by walking the message-index array from the Confluent wire framing into the parsed `FileDescriptorProto`. `SchemaId._read_index_array` caps the array length but not the individual index values, and those values are zigzag varints, so a crafted message can carry a negative or out-of-range index. `_get_message_desc_proto` then indexes `desc.message_type` / `desc.nested_type` with the value directly.

Before: a negative index (for example uvarint `0x01`, which zigzag-decodes to `-1`) wraps around and resolves to a different message type in the same file, so the payload is decoded against the wrong descriptor. An out-of-range positive index raises a bare `IndexError`.

After: an index outside `0 <= index < len(...)` raises `SerializationError` with the index and the available count, matching the bound check the confluent-kafka-go reference (`toMessageDesc`) already applies. Valid indexes behave the same as today.

Tradeoff: a message that previously decoded against an unintended message type now fails fast instead of returning a mis-typed object. That is the point of the change, but it does convert a silent wrong-result into a surfaced error.

Checklist
------------------
- [ ] Contains customer facing changes? Including API/behavior changes
- [x] Did you add sufficient unit test and/or integration test coverage for this PR?

References
----------
JIRA:

Test & Review
------------
Added `test_message_index_in_range` and `test_message_index_out_of_range` to `tests/schema_registry/_async/test_proto.py` (and the generated `_sync` counterpart). The out-of-range cases `[-1]`, `[2]`, `[0, -1]`, `[0, 5]` reproduce the issue on master and pass after the change. `_sync` files were regenerated with `tools/unasync.py`.

Open questions / Follow-ups
--------------------------
None.
