### PR TITLE
fix: align KafkaError stub keyword with runtime

### DIFF
--- a/src/confluent_kafka/cimpl.pyi
+++ b/src/confluent_kafka/cimpl.pyi
@@ -226,7 +226,7 @@ class KafkaError:
     _WAIT_COORD: int
     def __init__(
         self,
-        code: int,
+        error: int,
         reason: Optional[str] = None,
         fatal: bool = False,
         retriable: bool = False,

--- a/tests/test_kafka_error.py
+++ b/tests/test_kafka_error.py
@@ -94,6 +94,14 @@ def test_kafkaError_custom_msg():
     assert not err.txn_requires_abort()
 
 
+def test_kafkaError_init_keyword_matches_runtime_signature():
+    err = KafkaError(error=KafkaError._ALL_BROKERS_DOWN)
+    assert err == KafkaError._ALL_BROKERS_DOWN
+
+    with pytest.raises(TypeError):
+        KafkaError(code=KafkaError._ALL_BROKERS_DOWN)
+
+
 def test_kafkaError_unknown_error():
     with pytest.raises(KafkaException, match="Err-12345?") as e:
         raise KafkaError(12345)


### PR DESCRIPTION
Fixes #2243.

## Changes
- Rename the first `KafkaError` stub initializer parameter from `code` to `error`, matching the C extension keyword accepted at runtime.
- Add a regression test covering the runtime keyword contract: `error=` is accepted and `code=` raises `TypeError`.

## Validation
- `MYPYPATH=src uvx --from mypy==1.18.2 mypy --python-version 3.11 -c $'from confluent_kafka import KafkaError\\nKafkaError(error=1)'`
- `MYPYPATH=src uvx --from mypy==1.18.2 mypy --python-version 3.11 -c $'from confluent_kafka import KafkaError\\nKafkaError(code=1)'` confirms `code=` is rejected
- `python3 -m py_compile tests/test_kafka_error.py`
- `uvx --from black black --check --diff tests/test_kafka_error.py`
- `git diff --check`

Note: I could not run `pytest tests/test_kafka_error.py` locally because this fresh checkout does not have the compiled `confluent_kafka` extension or pytest installed. The added pytest is intended for CI, where the package is built before test execution.