### PR TITLE
[KIP-932] Add tests for user callbacks in share consumer 2/N

### DIFF
--- a/tests/integration/share_consumer/test_share_consumer_ack.py
+++ b/tests/integration/share_consumer/test_share_consumer_ack.py
@@ -1197,6 +1197,60 @@ def test_callback_reentrancy_guard(kafka_cluster):
         sc.close()
 
 
+def test_acknowledgement_commit_cb_reentrant_call_raises_state(kafka_cluster):
+    """poll() from inside the ack-commit callback raises _STATE, no crash.
+
+    The same reentrant poll() segfaults from error_cb / log_cb / throttle_cb
+    (those tests are skipped) — the ack-commit callback is the only one
+    librdkafka guards against reentrancy, so here it comes back as a clean
+    _STATE instead.
+
+    Needs a broker, unlike the error_cb / log_cb tests: the callback only fires
+    once there are real acknowledged offsets to commit, and an empty commit
+    fires nothing.
+    """
+    topic = kafka_cluster.create_topic_and_wait_propogation('test-share-consumer-ack-cb-reentrant-poll')
+
+    sc = kafka_cluster.share_consumer({'share.acknowledgement.mode': 'explicit'})
+    captured = []
+    reenter = [True]
+
+    def reentrant_cb(offsets, exc):
+        # re-enter once — that's all it takes to trip the guard
+        if reenter[0]:
+            reenter[0] = False
+            try:
+                sc.poll(timeout=0)
+            except KafkaException as ex:
+                captured.append(ex)
+
+    try:
+        sc.set_acknowledgement_commit_callback(reentrant_cb)
+        sc.subscribe([topic])
+
+        producer = kafka_cluster.cimpl_producer()
+        producer.produce(topic, value=b'msg-0')
+        producer.flush(timeout=10.0)
+
+        msgs = poll_first_batch(sc)
+        assert msgs
+        for m in msgs:
+            sc.acknowledge(m, AcknowledgeType.ACCEPT)
+
+        # the cb fires after the commit completes, so keep polling until it does
+        sc.commit_async()
+        deadline = time.time() + 10.0
+        while time.time() < deadline and not captured:
+            sc.poll(timeout=0.5)
+
+        assert captured, 'ack-commit cb never fired (or never re-entered)'
+        assert captured[0].args[0].code() == KafkaError._STATE
+    finally:
+        # drop the cb before close() so its drain doesn't trip the guard again
+        sc.set_acknowledgement_commit_callback(None)
+        sc.close()
+
+
 def test_share_consumer_methods_rejected_from_other_thread(kafka_cluster):
     """A ShareConsumer is single-threaded. While one thread is parked in a
     consumer call (here poll(), which holds the access gate the whole time),

--- a/tests/integration/share_consumer/test_share_consumer_ack.py
+++ b/tests/integration/share_consumer/test_share_consumer_ack.py
@@ -1221,7 +1221,7 @@ def test_acknowledgement_commit_cb_reentrant_call_raises_state(kafka_cluster):
             reenter[0] = False
             try:
                 sc.poll(timeout=0)
-            except KafkaException as ex:
+            except IllegalStateException as ex:
                 captured.append(ex)
 
     try:
@@ -1244,7 +1244,7 @@ def test_acknowledgement_commit_cb_reentrant_call_raises_state(kafka_cluster):
             sc.poll(timeout=0.5)
 
         assert captured, 'ack-commit cb never fired (or never re-entered)'
-        assert captured[0].args[0].code() == KafkaError._STATE
+        assert str(captured[0])
     finally:
         # drop the cb before close() so its drain doesn't trip the guard again
         sc.set_acknowledgement_commit_callback(None)

--- a/tests/integration/share_consumer/test_share_consumer_callbacks.py
+++ b/tests/integration/share_consumer/test_share_consumer_callbacks.py
@@ -21,43 +21,96 @@ These run against a real broker, unlike the unit tests in
 tests/test_ShareConsumer_callbacks.py. A real broker is needed to confirm
 that throttle_cb actually fires, not just that it registers without error.
 
-throttle_cb requires a broker-side quota to be configured first. See the
-SHARE_THROTTLE_QUOTA_CLIENT_ID environment variable and the setup steps on
-the test below. This follows the same convention as
-tests/integration/integration_test.py::verify_throttle_cb.
+throttle_cb needs a broker-side quota. The provision_client_quota fixture
+sets one up and removes it afterwards using kafka-configs.sh, so these tests
+run unattended as long as there's a trivup install or a KAFKA_HOME.
 """
 
+import glob
+import logging
 import os
+import shutil
+import subprocess
 import time
 
 import pytest
 
-from confluent_kafka import ThrottleEvent
-
-# Set this to the client.id that has a low consumer_byte_rate quota
-# configured on the broker (same approach as verify_throttle_cb in
-# integration_test.py). Configure the quota once before running the test:
-#
-#     ${KAFKA_HOME}/bin/kafka-configs.sh \
-#         --bootstrap-server <broker> \
-#         --alter \
-#         --add-config 'consumer_byte_rate=1024' \
-#         --entity-type clients \
-#         --entity-name <client.id>
-#
-# Then export SHARE_THROTTLE_QUOTA_CLIENT_ID=<client.id> and run pytest.
-_THROTTLE_CLIENT_ID_ENV = 'SHARE_THROTTLE_QUOTA_CLIENT_ID'
+from confluent_kafka import KafkaError, KafkaException, ThrottleEvent
+from tests.common import unique_id
 
 
-@pytest.mark.skipif(
-    not os.environ.get(_THROTTLE_CLIENT_ID_ENV),
-    reason=(
-        f"requires {_THROTTLE_CLIENT_ID_ENV} env var pointing at a client.id "
-        f"with a strict consumer_byte_rate quota preconfigured on the broker; "
-        f"see module docstring for the kafka-configs.sh setup recipe"
-    ),
-)
-def test_throttle_cb_fires_under_quota(kafka_cluster):
+def _resolve_kafka_configs_sh():
+    """Locate kafka-configs.sh: $KAFKA_HOME/bin, the trivup install, or PATH."""
+    kafka_home = os.environ.get('KAFKA_HOME')
+    if kafka_home:
+        candidate = os.path.join(kafka_home, 'bin', 'kafka-configs.sh')
+        if os.path.exists(candidate):
+            return candidate
+    # trivup extracts the broker distribution under <cwd>/tmp-KafkaCluster/.
+    matches = glob.glob(os.path.join('tmp-KafkaCluster', '**', 'bin', 'kafka-configs.sh'), recursive=True)
+    if matches:
+        return matches[0]
+    return shutil.which('kafka-configs.sh')
+
+
+def _run_kafka_configs(kafka_configs_sh, bootstrap_servers, alter_args, client_id):
+    """Run kafka-configs.sh against a clients entity (raises on failure)."""
+    cmd = [
+        kafka_configs_sh,
+        '--bootstrap-server',
+        bootstrap_servers,
+        '--alter',
+        *alter_args,
+        '--entity-type',
+        'clients',
+        '--entity-name',
+        client_id,
+    ]
+    subprocess.run(cmd, check=True, capture_output=True, text=True, timeout=60)
+
+
+@pytest.fixture
+def provision_client_quota(kafka_cluster):
+    """Set up a throttling client quota and tear it down afterwards.
+
+    Returns a function -- provision('consumer_byte_rate=1024') -> client.id --
+    that applies the quota with kafka-configs.sh (we shell out because
+    librdkafka has no admin op for client quotas). Skips the test if
+    kafka-configs.sh isn't found. Quotas are removed on teardown.
+    """
+    kafka_configs_sh = _resolve_kafka_configs_sh()
+    bootstrap_servers = kafka_cluster.client_conf()['bootstrap.servers']
+    provisioned = []
+
+    def _provision(add_config):
+        if not kafka_configs_sh:
+            pytest.skip("kafka-configs.sh not found; set KAFKA_HOME or run via trivup")
+        client_id = unique_id('throttled-client')
+        _run_kafka_configs(kafka_configs_sh, bootstrap_servers, ['--add-config', add_config], client_id)
+        config_keys = ','.join(entry.split('=', 1)[0] for entry in add_config.split(','))
+        provisioned.append((client_id, config_keys))
+        return client_id
+
+    yield _provision
+
+    for client_id, config_keys in provisioned:
+        try:
+            _run_kafka_configs(kafka_configs_sh, bootstrap_servers, ['--delete-config', config_keys], client_id)
+        except Exception:
+            pass  # best-effort cleanup; the broker may already be torn down
+
+
+def _produce_burst(kafka_cluster, topic, msg_count, msg_size):
+    """Produce msg_count messages of msg_size bytes and flush."""
+    payload = b'x' * msg_size
+    producer = kafka_cluster.cimpl_producer()
+    for _ in range(msg_count):
+        producer.produce(topic, value=payload)
+        producer.poll(0)  # drain the delivery queue to avoid BufferError
+    producer.flush(timeout=30.0)
+
+
+def test_throttle_cb_fires_under_quota(kafka_cluster, provision_client_quota):
     """throttle_cb is invoked when the broker throttles a share consumer.
 
     Produces a large volume of data, then consumes it through a share
@@ -70,7 +123,7 @@ def test_throttle_cb_fires_under_quota(kafka_cluster):
     throttle_time), and that at least one event reports a positive
     throttle_time, since a "cleared" event reports throttle_time=0.
     """
-    client_id = os.environ[_THROTTLE_CLIENT_ID_ENV]
+    client_id = provision_client_quota('consumer_byte_rate=1024')
 
     topic = kafka_cluster.create_topic_and_wait_propogation('test-share-consumer-throttle')
 
@@ -137,5 +190,139 @@ def test_throttle_cb_fires_under_quota(kafka_cluster):
             f"all {len(throttle_events)} throttle events reported "
             f"throttle_time=0; expected at least one with a positive delay"
         )
+    finally:
+        sc.close()
+
+
+def test_log_cb_share_facility_tags_present(kafka_cluster):
+    """log_cb surfaces the share-specific facility tags.
+
+    There's no dedicated share debug context, so debug=cgrp,fetch is what
+    turns on the share path's logging. With real produce/consume/commit
+    traffic, some records lead with a share facility (SHAREFETCH, SHAREACK,
+    SHARESESSION, SHAREHEARTBEAT); check at least one reaches the logger.
+    """
+    topic = kafka_cluster.create_topic_and_wait_propogation('test-share-log-facilities')
+    _produce_burst(kafka_cluster, topic, msg_count=50, msg_size=64)
+
+    records = []
+
+    class _CollectingHandler(logging.Handler):
+        def emit(self, record):
+            records.append(record)
+
+    logger = logging.getLogger('test-share-log-facilities')
+    logger.setLevel(logging.DEBUG)
+    logger.addHandler(_CollectingHandler())
+
+    sc = kafka_cluster.share_consumer({'debug': 'cgrp,fetch', 'logger': logger})
+    try:
+        sc.subscribe([topic])
+
+        deadline = time.monotonic() + 30.0
+        consumed = 0
+        while time.monotonic() < deadline and consumed == 0:
+            batch = sc.poll(timeout=1.0)
+            consumed += sum(1 for m in batch if m.error() is None)
+        # Commit drives ShareAcknowledge traffic (SHAREACK facility).
+        sc.commit_sync(timeout=10.0)
+
+        share_facilities = ('SHAREFETCH', 'SHAREACK', 'SHARESESSION', 'SHAREHEARTBEAT')
+        seen = {fac for r in records for fac in share_facilities if r.getMessage().startswith(fac)}
+        assert seen, (
+            f"expected a share facility tag among log records (consumed {consumed}); "
+            f"leading tokens seen: {sorted({r.getMessage().split(' ', 1)[0] for r in records})}"
+        )
+    finally:
+        sc.close()
+
+
+def test_throttle_cb_emits_cleared_zero_event(kafka_cluster, provision_client_quota):
+    """After throttling, a cleared (throttle_time=0) event is delivered.
+
+    librdkafka fires throttle_cb on each throttle, then once more once the
+    rate drops back below the quota (throttle_time=0). Go over the quota to
+    get a positive event, then keep polling with no new data so the rate
+    decays and the cleared event shows up.
+    """
+    client_id = provision_client_quota('consumer_byte_rate=1024')
+    topic = kafka_cluster.create_topic_and_wait_propogation('test-share-throttle-clear')
+    msg_count, msg_size = 5000, 1024
+    _produce_burst(kafka_cluster, topic, msg_count, msg_size)
+
+    events = []
+    sc = kafka_cluster.share_consumer(
+        {
+            'client.id': client_id,
+            'throttle_cb': events.append,
+            'fetch.max.bytes': msg_size * msg_count,
+        }
+    )
+    try:
+        sc.subscribe([topic])
+
+        # Phase 1: consume the burst until a positive throttle is observed.
+        deadline = time.monotonic() + 30.0
+        while time.monotonic() < deadline and not any(e.throttle_time > 0 for e in events):
+            sc.poll(timeout=1.0)
+        assert any(e.throttle_time > 0 for e in events), "expected a positive throttle_time event"
+
+        # Phase 2: idle-poll so the per-broker rate decays below the quota and
+        # librdkafka delivers the cleared (throttle_time=0) event.
+        deadline = time.monotonic() + 15.0
+        while time.monotonic() < deadline and not any(e.throttle_time == 0 for e in events):
+            sc.poll(timeout=1.0)
+        assert any(
+            e.throttle_time == 0.0 for e in events
+        ), "expected a cleared throttle event (throttle_time=0) after the rate decayed"
+    finally:
+        sc.close()
+
+
+@pytest.mark.skip(
+    reason="Calling the consumer from inside throttle_cb segfaults today, same root cause as "
+    "error_cb/log_cb (see test_ShareConsumer_callbacks.py::test_error_cb_reentrant_call_raises_state): "
+    "the reentrancy guard only covers the ack-commit callback. Un-skip and check for _STATE once "
+    "it covers the other callbacks."
+)
+def test_throttle_cb_reentrant_call_raises_state(kafka_cluster, provision_client_quota):
+    """Calling the consumer from inside throttle_cb (same thread) should raise _STATE.
+
+    The behavior we want once the reentrancy guard is fixed (matches the
+    ack-commit callback and Java's IllegalStateException). Skipped because it
+    crashes today.
+    """
+    client_id = provision_client_quota('consumer_byte_rate=1024')
+    topic = kafka_cluster.create_topic_and_wait_propogation('test-share-throttle-reentrant')
+    msg_count, msg_size = 5000, 1024
+    _produce_burst(kafka_cluster, topic, msg_count, msg_size)
+
+    captured = []
+    reenter = [True]
+    holder = {}
+
+    def throttle_cb(event):
+        sc = holder.get('sc')
+        if sc is not None and reenter[0]:
+            reenter[0] = False
+            try:
+                sc.poll(timeout=0)
+            except KafkaException as exc:
+                captured.append(exc)
+
+    sc = kafka_cluster.share_consumer(
+        {
+            'client.id': client_id,
+            'throttle_cb': throttle_cb,
+            'fetch.max.bytes': msg_size * msg_count,
+        }
+    )
+    holder['sc'] = sc
+    try:
+        sc.subscribe([topic])
+        deadline = time.monotonic() + 30.0
+        while time.monotonic() < deadline and not captured:
+            sc.poll(timeout=1.0)
+        assert captured and captured[0].args[0].code() == KafkaError._STATE
     finally:
         sc.close()

--- a/tests/test_ShareConsumer_callbacks.py
+++ b/tests/test_ShareConsumer_callbacks.py
@@ -17,7 +17,14 @@ import time
 
 import pytest
 
-from confluent_kafka import Consumer, KafkaError, KafkaException, Producer, ShareConsumer
+from confluent_kafka import (
+    ConcurrentModificationException,
+    Consumer,
+    KafkaError,
+    KafkaException,
+    Producer,
+    ShareConsumer,
+)
 from tests.common import unique_id
 
 
@@ -732,8 +739,9 @@ def test_error_cb_cross_thread_call_raises_conflict():
     release_callback.set()  # in case error_cb never fired
 
     assert captured, "worker thread should have caught a cross-thread error"
-    assert isinstance(captured[0], KafkaException)
-    assert captured[0].args[0].code() == KafkaError._CONFLICT
+    # The exception type alone signals _CONFLICT - there's no KafkaError code to inspect.
+    assert isinstance(captured[0], ConcurrentModificationException)
+    assert 'not safe for multi-threaded access' in str(captured[0])
     sc.close()
 
 
@@ -1007,35 +1015,6 @@ def test_log_cb_close_drains_pending_records():
 
     sc.close()
     assert any('INIT' in r.getMessage() for r in records), "close() should drain the log queue"
-
-
-def test_statistics_interval_ms_zero_explicit_rejected():
-    """statistics.interval.ms is rejected even when set to 0.
-
-    The check looks at whether the key is present, not its value, so the
-    usual "0 to disable" trick is rejected too (int and str alike).
-    """
-    config = {
-        'group.id': unique_id('test-share-stats-interval-zero'),
-        'bootstrap.servers': 'localhost:9092',
-    }
-    for value in (0, '0'):
-        with pytest.raises(ValueError, match='statistics.interval.ms is not supported'):
-            ShareConsumer({**config, 'statistics.interval.ms': value})
-
-
-def test_stats_cb_rejection_precedes_group_id_check():
-    """stats_cb is rejected before group.id is even checked.
-
-    The incompatible-config check runs first, so leaving out group.id still
-    gives the stats_cb error, not a missing-group.id one.
-    """
-
-    def my_stats_cb(stats_json_str):
-        pass
-
-    with pytest.raises(ValueError, match='stats_cb is not supported'):
-        ShareConsumer({'bootstrap.servers': 'localhost:9092', 'stats_cb': my_stats_cb})
 
 
 def test_log_cb_delivers_always_on_warning_without_debug():

--- a/tests/test_ShareConsumer_callbacks.py
+++ b/tests/test_ShareConsumer_callbacks.py
@@ -12,6 +12,7 @@ the constructor, subscribe, and lifecycle tests.
 """
 
 import logging
+import threading
 import time
 
 import pytest
@@ -536,3 +537,530 @@ def test_error_cb_dispatches_during_commit_async():
 
     assert error_called, "error_cb should have fired from commit_async's drain"
     sc.close()
+
+
+def _collecting_logger(name_suffix):
+    """Return (logger, records) where records is appended to by a handler."""
+    records = []
+
+    class _CollectingHandler(logging.Handler):
+        def emit(self, record):
+            records.append(record)
+
+    logger = logging.getLogger(unique_id(name_suffix))
+    logger.setLevel(logging.DEBUG)
+    logger.addHandler(_CollectingHandler())
+    return logger, records
+
+
+def _share_oauth_conf(group_suffix, oauth_cb):
+    """OAUTHBEARER config for the oauth tests.
+
+    Like test_oauth_cb.get_oauth_config, minus session.timeout.ms which the
+    share consumer rejects.
+    """
+    return {
+        'group.id': unique_id(group_suffix),
+        'bootstrap.servers': 'localhost:19999',
+        'socket.timeout.ms': 100,
+        'security.protocol': 'sasl_plaintext',
+        'sasl.mechanisms': 'OAUTHBEARER',
+        'sasl.oauthbearer.config': 'oauth_cb',
+        'oauth_cb': oauth_cb,
+    }
+
+
+def test_error_cb_resolve_failure():
+    """A bad hostname should reach error_cb as _RESOLVE.
+
+    The .invalid TLD never resolves, so we get _RESOLVE instead of the
+    connection-refused path test_error_cb already covers.
+    """
+    codes = []
+
+    def my_error_cb(error):
+        codes.append(error.code())
+
+    sc = ShareConsumer(
+        {
+            'group.id': unique_id('test-share-error-resolve'),
+            'bootstrap.servers': 'no-such-host-xyz.invalid:9092',
+            'socket.timeout.ms': 200,
+            'error_cb': my_error_cb,
+        }
+    )
+    sc.subscribe(['test-topic'])
+
+    deadline = time.monotonic() + 3.0
+    while time.monotonic() < deadline and KafkaError._RESOLVE not in codes:
+        sc.poll(timeout=0.3)
+
+    assert KafkaError._RESOLVE in codes, f"expected _RESOLVE among error_cb codes, got {codes}"
+    sc.close()
+
+
+def test_error_cb_raise_propagates_from_commit_sync():
+    """If error_cb raises, the exception comes back out of commit_sync().
+
+    commit_sync drains pending errors on entry, so a raising error_cb makes
+    the commit itself re-raise rather than swallow it.
+    """
+    raising = [True]
+
+    def error_cb_that_raises(error):
+        if raising[0]:
+            raise RuntimeError("boom from error_cb in commit_sync")
+
+    sc = ShareConsumer(
+        {
+            'group.id': unique_id('test-share-cb-raise-commit-sync'),
+            'bootstrap.servers': 'localhost:19999',
+            'socket.timeout.ms': 100,
+            'share.acknowledgement.mode': 'implicit',
+            'error_cb': error_cb_that_raises,
+        }
+    )
+    sc.subscribe(['test-topic'])
+    time.sleep(0.3)  # let some connection-refused errors pile up first
+
+    with pytest.raises(RuntimeError, match="boom from error_cb in commit_sync"):
+        sc.commit_sync(timeout=0.5)
+
+    raising[0] = False  # stop raising so close() is clean
+    sc.close()
+
+
+def test_error_cb_raise_propagates_from_commit_async():
+    """Same as the commit_sync case, but for commit_async().
+
+    commit_async drains errors on entry too, so a raising error_cb re-raises
+    here as well.
+    """
+    raising = [True]
+
+    def error_cb_that_raises(error):
+        if raising[0]:
+            raise RuntimeError("boom from error_cb in commit_async")
+
+    sc = ShareConsumer(
+        {
+            'group.id': unique_id('test-share-cb-raise-commit-async'),
+            'bootstrap.servers': 'localhost:19999',
+            'socket.timeout.ms': 100,
+            'share.acknowledgement.mode': 'implicit',
+            'error_cb': error_cb_that_raises,
+        }
+    )
+    sc.subscribe(['test-topic'])
+    time.sleep(0.3)
+
+    with pytest.raises(RuntimeError, match="boom from error_cb in commit_async"):
+        sc.commit_async()
+
+    raising[0] = False
+    sc.close()
+
+
+def test_error_cb_fires_during_close_without_polling():
+    """error_cb still fires from close() even if we never poll().
+
+    Errors queue up undelivered until something drains them, and close()
+    does that drain. So a consumer closed without ever polling still reports
+    what piled up.
+    """
+    calls = []
+
+    def my_error_cb(error):
+        calls.append(error.code())
+
+    sc = ShareConsumer(
+        {
+            'group.id': unique_id('test-share-cb-close-drain'),
+            'bootstrap.servers': 'localhost:19999',
+            'socket.timeout.ms': 100,
+            'error_cb': my_error_cb,
+        }
+    )
+    sc.subscribe(['test-topic'])
+    time.sleep(0.4)  # let errors queue up without draining them
+
+    assert not calls, "without poll(), no error_cb should fire before close()"
+    sc.close()
+    assert calls, "error_cb should fire from the close() drain"
+
+
+def test_error_cb_cross_thread_call_raises_conflict():
+    """Calling the consumer from another thread while error_cb runs -> _CONFLICT.
+
+    The poll thread holds the share lock while error_cb runs, so a second
+    thread calling commit_async() at the same time gets _CONFLICT (like
+    Java's ConcurrentModificationException).
+    """
+    captured = []
+    in_callback = threading.Event()
+    release_callback = threading.Event()
+
+    def my_error_cb(error):
+        # block here on the first call so the worker thread races us
+        if not in_callback.is_set():
+            in_callback.set()
+            release_callback.wait(timeout=3.0)
+
+    sc = ShareConsumer(
+        {
+            'group.id': unique_id('test-share-cb-cross-thread'),
+            'bootstrap.servers': 'localhost:19999',
+            'socket.timeout.ms': 100,
+            'error_cb': my_error_cb,
+        }
+    )
+
+    def worker():
+        if in_callback.wait(timeout=3.0):
+            try:
+                sc.commit_async()
+            except Exception as exc:
+                captured.append(exc)
+            finally:
+                release_callback.set()
+
+    sc.subscribe(['test-topic'])
+    thread = threading.Thread(target=worker)
+    thread.start()
+    sc.poll(timeout=1.5)  # fires error_cb here; worker races us from the other thread
+    thread.join(timeout=5.0)
+    release_callback.set()  # in case error_cb never fired
+
+    assert captured, "worker thread should have caught a cross-thread error"
+    assert isinstance(captured[0], KafkaException)
+    assert captured[0].args[0].code() == KafkaError._CONFLICT
+    sc.close()
+
+
+@pytest.mark.skip(
+    reason="Calling the consumer from inside error_cb segfaults today: librdkafka's "
+    "reentrancy guard only covers the ack-commit callback, not error_cb/log_cb. "
+    "Un-skip and check for _STATE once that's fixed."
+)
+def test_error_cb_reentrant_call_raises_state():
+    """Calling the consumer from inside error_cb (same thread) should raise _STATE.
+
+    This is the behavior we want once the reentrancy guard is fixed (matches
+    the ack-commit callback and Java's IllegalStateException). Skipped for
+    now because it crashes.
+    """
+    captured = []
+    reenter = [True]
+    holder = {}
+
+    def my_error_cb(error):
+        sc = holder.get('sc')
+        if sc is not None and reenter[0]:
+            reenter[0] = False
+            try:
+                sc.poll(timeout=0)
+            except KafkaException as exc:
+                captured.append(exc)
+
+    sc = ShareConsumer(
+        {
+            'group.id': unique_id('test-share-cb-reentrant-error'),
+            'bootstrap.servers': 'localhost:19999',
+            'socket.timeout.ms': 100,
+            'error_cb': my_error_cb,
+        }
+    )
+    holder['sc'] = sc
+    sc.subscribe(['test-topic'])
+
+    deadline = time.monotonic() + 3.0
+    while time.monotonic() < deadline and not captured:
+        sc.poll(timeout=0.3)
+
+    assert captured and captured[0].args[0].code() == KafkaError._STATE
+    sc.close()
+
+
+@pytest.mark.skip(
+    reason="Same segfault as test_error_cb_reentrant_call_raises_state: the reentrancy "
+    "guard doesn't cover log_cb yet. Un-skip and check for _STATE once it does."
+)
+def test_log_cb_reentrant_call_raises_state():
+    """Same reentrancy contract as error_cb, but from inside log_cb.
+
+    log_cb runs on the polling thread too, so calling the consumer from it
+    should raise _STATE. Skipped because it crashes today.
+    """
+    captured = []
+    reenter = [True]
+    holder = {}
+
+    class _ReentrantHandler(logging.Handler):
+        def emit(self, record):
+            sc = holder.get('sc')
+            if sc is not None and reenter[0]:
+                reenter[0] = False
+                try:
+                    sc.poll(timeout=0)
+                except KafkaException as exc:
+                    captured.append(exc)
+
+    logger = logging.getLogger(unique_id('test-share-cb-reentrant-log'))
+    logger.setLevel(logging.DEBUG)
+    logger.addHandler(_ReentrantHandler())
+
+    sc = ShareConsumer(
+        {
+            'group.id': unique_id('test-share-cb-reentrant-log'),
+            'bootstrap.servers': 'localhost:19999',
+            'socket.timeout.ms': 100,
+            'debug': 'msg',
+            'logger': logger,
+        }
+    )
+    holder['sc'] = sc
+    sc.subscribe(['test-topic'])
+    sc.poll(timeout=0.3)
+
+    assert captured and captured[0].args[0].code() == KafkaError._STATE
+    sc.close()
+
+
+def test_oauth_cb_principal_and_sasl_extensions():
+    """oauth_cb can return the full (token, lifetime, principal, extensions) tuple.
+
+    The extra principal and SASL-extensions elements are accepted and
+    construction completes (it blocks until the first token is set).
+    """
+    seen = []
+
+    def my_oauth_cb(oauth_config):
+        seen.append(oauth_config)
+        return 'token', time.time() + 300.0, oauth_config, {'extone': 'extoneval', 'exttwo': 'exttwoval'}
+
+    sc = ShareConsumer(_share_oauth_conf('test-share-oauth-ext', my_oauth_cb))
+    assert seen and seen[0] == 'oauth_cb'
+    sc.close()
+
+
+def test_oauth_cb_token_refresh_success_multiple_calls():
+    """The background thread re-invokes oauth_cb as the token expires.
+
+    A short (3s) token lifetime triggers a refresh, so oauth_cb fires more
+    than once without any poll() call.
+    """
+    count = [0]
+
+    def my_oauth_cb(oauth_config):
+        count[0] += 1
+        return 'token', time.time() + 3.0
+
+    sc = ShareConsumer(_share_oauth_conf('test-share-oauth-refresh-ok', my_oauth_cb))
+    assert count[0] == 1, "oauth_cb should fire once during init"
+
+    deadline = time.monotonic() + 6.0
+    while count[0] == 1 and time.monotonic() < deadline:
+        time.sleep(0.5)
+
+    sc.close()
+    assert count[0] > 1, "background thread should refresh the token at least once"
+
+
+def test_oauth_cb_token_refresh_failure_and_recovery():
+    """A failed token refresh is retried and recovers.
+
+    The 2nd call raises; librdkafka retries ~10s later and the 3rd call
+    succeeds. One bad refresh shouldn't wedge the token loop.
+    """
+    count = [0]
+
+    def my_oauth_cb(oauth_config):
+        count[0] += 1
+        if count[0] == 2:
+            raise RuntimeError("intentional refresh failure")
+        return 'token', time.time() + 3.0
+
+    sc = ShareConsumer(_share_oauth_conf('test-share-oauth-refresh-fail', my_oauth_cb))
+    assert count[0] == 1
+
+    # init + failing refresh + the ~10s retry, so give it a wide window
+    deadline = time.monotonic() + 16.0
+    while count[0] <= 2 and time.monotonic() < deadline:
+        time.sleep(0.5)
+
+    sc.close()
+    assert count[0] > 2, "oauth_cb should be retried and recover after a refresh failure"
+
+
+def test_oauth_cb_malformed_return_fails_construction():
+    """A bad oauth_cb return value fails construction cleanly, no crash.
+
+    Returning a bare string instead of a (token, lifetime, ...) tuple means
+    no valid token is ever set, so construction times out and raises.
+    """
+
+    def my_oauth_cb(oauth_config):
+        return 'just-a-token-string'  # not a (token, lifetime, ...) tuple
+
+    with pytest.raises(KafkaException) as exc_info:
+        ShareConsumer(_share_oauth_conf('test-share-oauth-malformed', my_oauth_cb))
+
+    message = str(exc_info.value).lower()
+    assert 'token' in message or 'authentication' in message or 'sasl' in message
+
+
+def test_log_cb_drains_on_commit_sync():
+    """commit_sync() drains the log queue, same as poll().
+
+    There's no background log thread, so records sit queued until poll or a
+    commit runs. test_log_cb covers poll; this covers commit_sync.
+    """
+    logger, records = _collecting_logger('test-share-log-commit-sync')
+    sc = ShareConsumer(
+        {
+            'group.id': unique_id('test-share-log-commit-sync'),
+            'bootstrap.servers': 'localhost:19999',
+            'socket.timeout.ms': 100,
+            'debug': 'msg',
+            'logger': logger,
+            'share.acknowledgement.mode': 'implicit',
+        }
+    )
+    sc.subscribe(['test-topic'])
+    time.sleep(0.2)
+    assert not records, "no records should surface before any drain"
+
+    sc.commit_sync(timeout=0.5)
+    assert any('INIT' in r.getMessage() for r in records), "commit_sync should drain the log queue"
+    sc.close()
+
+
+def test_log_cb_drains_on_commit_async():
+    """commit_async() drains the log queue too."""
+    logger, records = _collecting_logger('test-share-log-commit-async')
+    sc = ShareConsumer(
+        {
+            'group.id': unique_id('test-share-log-commit-async'),
+            'bootstrap.servers': 'localhost:19999',
+            'socket.timeout.ms': 100,
+            'debug': 'msg',
+            'logger': logger,
+            'share.acknowledgement.mode': 'implicit',
+        }
+    )
+    sc.subscribe(['test-topic'])
+    time.sleep(0.2)
+    assert not records, "no records should surface before any drain"
+
+    sc.commit_async()
+    assert any('INIT' in r.getMessage() for r in records), "commit_async should drain the log queue"
+    sc.close()
+
+
+def test_log_cb_record_format_and_fields():
+    """Log records come through as proper LogRecords with the right fields.
+
+    test_log_cb just checks the message; here we also check the logger name
+    and that debug=msg gives DEBUG-level records.
+    """
+    logger, records = _collecting_logger('test-share-log-format')
+    sc = ShareConsumer(
+        {
+            'group.id': unique_id('test-share-log-format'),
+            'bootstrap.servers': 'localhost:19999',
+            'socket.timeout.ms': 100,
+            'debug': 'msg',
+            'logger': logger,
+        }
+    )
+    sc.subscribe(['test-topic'])
+    sc.poll(timeout=0.2)
+    sc.close()
+
+    init_records = [r for r in records if 'INIT' in r.getMessage()]
+    assert init_records, "expected an INIT log record"
+    record = init_records[0]
+    assert record.name == logger.name
+    assert record.levelno == logging.DEBUG
+    assert record.levelname == 'DEBUG'
+
+
+def test_log_cb_close_drains_pending_records():
+    """close() drains queued log records even if poll() never ran.
+
+    Pairs with test_log_cb_requires_polling, which shows nothing surfaces
+    before a drain.
+    """
+    logger, records = _collecting_logger('test-share-log-close')
+    sc = ShareConsumer(
+        {
+            'group.id': unique_id('test-share-log-close'),
+            'bootstrap.servers': 'localhost:19999',
+            'socket.timeout.ms': 100,
+            'debug': 'msg',
+            'logger': logger,
+        }
+    )
+    sc.subscribe(['test-topic'])
+    time.sleep(0.2)
+    assert not records, "no records should surface before any drain"
+
+    sc.close()
+    assert any('INIT' in r.getMessage() for r in records), "close() should drain the log queue"
+
+
+def test_statistics_interval_ms_zero_explicit_rejected():
+    """statistics.interval.ms is rejected even when set to 0.
+
+    The check looks at whether the key is present, not its value, so the
+    usual "0 to disable" trick is rejected too (int and str alike).
+    """
+    config = {
+        'group.id': unique_id('test-share-stats-interval-zero'),
+        'bootstrap.servers': 'localhost:9092',
+    }
+    for value in (0, '0'):
+        with pytest.raises(ValueError, match='statistics.interval.ms is not supported'):
+            ShareConsumer({**config, 'statistics.interval.ms': value})
+
+
+def test_stats_cb_rejection_precedes_group_id_check():
+    """stats_cb is rejected before group.id is even checked.
+
+    The incompatible-config check runs first, so leaving out group.id still
+    gives the stats_cb error, not a missing-group.id one.
+    """
+
+    def my_stats_cb(stats_json_str):
+        pass
+
+    with pytest.raises(ValueError, match='stats_cb is not supported'):
+        ShareConsumer({'bootstrap.servers': 'localhost:9092', 'stats_cb': my_stats_cb})
+
+
+def test_log_cb_delivers_always_on_warning_without_debug():
+    """Always-on librdkafka logs reach log_cb even with no debug context set.
+
+    test_log_cb relies on debug=msg INIT records; here no 'debug' is
+    configured. A socket.timeout.ms below fetch.wait.max.ms (500) by >1s
+    triggers librdkafka's always-on CONFWARN at WARNING level, proving the
+    forwarded log queue delivers non-debug records too. (The facility is the
+    leading token of the record message.) The record drains on the first
+    poll().
+    """
+    logger, records = _collecting_logger('test-share-log-always-on')
+    sc = ShareConsumer(
+        {
+            'group.id': unique_id('test-share-log-always-on'),
+            'bootstrap.servers': 'localhost:19999',
+            'socket.timeout.ms': 100,  # < fetch.wait.max.ms (500) -> always-on CONFWARN
+            'logger': logger,
+        }
+    )
+    sc.subscribe(['test-topic'])
+    sc.poll(timeout=0.2)
+    sc.close()
+
+    warnings = [r for r in records if r.levelno >= logging.WARNING]
+    assert warnings, f"expected an always-on WARNING without debug; got {[r.getMessage() for r in records]}"
+    assert any('fetch.wait.max.ms' in r.getMessage() for r in warnings), "expected the CONFWARN about fetch.wait.max.ms"


### PR DESCRIPTION
**Summary**
  - Add 21 tests for ShareConsumer callbacks (error_cb, log_cb, oauth_cb, stats_cb, throttle_cb) across the unit and integration suites
  - Unit: error_cb dispatch + exception propagation through poll/commit_sync/commit_async/close; oauth_cb principal+extensions,  token-refresh success & failure-recovery, malformed-return; log_cb drain on
  commit/close, record format, and always-on (non-debug) delivery; stats_cb / statistics.interval.ms=0 rejection edges.
  - Integration: assert share-specific log facility tags (SHAREFETCH/SHAREACK/SHARESESSION/SHAREHEARTBEAT) and the cleared  throttle_time=0 throttle event.
  - Add a provision_client_quota fixture so throttle tests  self-provision/tear-down quotas and run unattended in CI — replacing the  manual SHARE_THROTTLE_QUOTA_CLIENT_ID env-var gating.
  - Document a real crash via 3 skipped tests: calling a ShareConsumer method from inside a generic callback SIGSEGVs (librdkafka's reentrancy guard covers  only the ack-commit cb); cross-thread correctly raises _CONFLICT — un-skip and assert _STATE once the guard is extended.