### PR TITLE
Make orjson optional in JSON serdes with stdlib json fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixes
 
 - Fix Encryption fails when expanded union types have two references to the same record (#2262)
+- Make orjson optional in JSON serdes with stdlib json fallback (#2281)
 
 ## v2.14.2 - 2026-06-03
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,7 +115,6 @@ optional-dependencies.dev = { file = [
     "requirements/requirements-rules.txt",
     "requirements/requirements-avro.txt",
     "requirements/requirements-json.txt",
-    "requirements/requirements-json-fast.txt",
     "requirements/requirements-protobuf.txt"] }
 optional-dependencies.docs = { file = [
     "requirements/requirements-docs.txt",
@@ -123,7 +122,6 @@ optional-dependencies.docs = { file = [
     "requirements/requirements-rules.txt",
     "requirements/requirements-avro.txt",
     "requirements/requirements-json.txt",
-    "requirements/requirements-json-fast.txt",
     "requirements/requirements-protobuf.txt"] }
 optional-dependencies.tests = { file = [
     "requirements/requirements-tests.txt",
@@ -131,7 +129,6 @@ optional-dependencies.tests = { file = [
     "requirements/requirements-rules.txt",
     "requirements/requirements-avro.txt",
     "requirements/requirements-json.txt",
-    "requirements/requirements-json-fast.txt",
     "requirements/requirements-protobuf.txt"] }
 optional-dependencies.examples = { file = ["requirements/requirements-examples.txt"] }
 optional-dependencies.soaktest = { file = ["requirements/requirements-soaktest.txt"] }
@@ -144,7 +141,6 @@ optional-dependencies.all = { file = [
     "requirements/requirements-rules.txt",
     "requirements/requirements-avro.txt",
     "requirements/requirements-json.txt",
-    "requirements/requirements-json-fast.txt",
     "requirements/requirements-protobuf.txt"] }
 
 [tool.pytest.ini_options]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,6 +105,7 @@ optional-dependencies.schema_registry = { file = ["requirements/requirements-sch
 optional-dependencies.rules = { file = ["requirements/requirements-rules.txt", "requirements/requirements-schemaregistry.txt"] }
 optional-dependencies.avro = { file = ["requirements/requirements-avro.txt", "requirements/requirements-schemaregistry.txt"] }
 optional-dependencies.json = { file = ["requirements/requirements-json.txt", "requirements/requirements-schemaregistry.txt"] }
+optional-dependencies.json-fast = { file = ["requirements/requirements-json.txt", "requirements/requirements-json-fast.txt", "requirements/requirements-schemaregistry.txt"] }
 optional-dependencies.protobuf = { file = ["requirements/requirements-protobuf.txt", "requirements/requirements-schemaregistry.txt"] }
 optional-dependencies.dev = { file = [
     "requirements/requirements-docs.txt",
@@ -114,6 +115,7 @@ optional-dependencies.dev = { file = [
     "requirements/requirements-rules.txt",
     "requirements/requirements-avro.txt",
     "requirements/requirements-json.txt",
+    "requirements/requirements-json-fast.txt",
     "requirements/requirements-protobuf.txt"] }
 optional-dependencies.docs = { file = [
     "requirements/requirements-docs.txt",
@@ -121,6 +123,7 @@ optional-dependencies.docs = { file = [
     "requirements/requirements-rules.txt",
     "requirements/requirements-avro.txt",
     "requirements/requirements-json.txt",
+    "requirements/requirements-json-fast.txt",
     "requirements/requirements-protobuf.txt"] }
 optional-dependencies.tests = { file = [
     "requirements/requirements-tests.txt",
@@ -128,6 +131,7 @@ optional-dependencies.tests = { file = [
     "requirements/requirements-rules.txt",
     "requirements/requirements-avro.txt",
     "requirements/requirements-json.txt",
+    "requirements/requirements-json-fast.txt",
     "requirements/requirements-protobuf.txt"] }
 optional-dependencies.examples = { file = ["requirements/requirements-examples.txt"] }
 optional-dependencies.soaktest = { file = ["requirements/requirements-soaktest.txt"] }
@@ -140,6 +144,7 @@ optional-dependencies.all = { file = [
     "requirements/requirements-rules.txt",
     "requirements/requirements-avro.txt",
     "requirements/requirements-json.txt",
+    "requirements/requirements-json-fast.txt",
     "requirements/requirements-protobuf.txt"] }
 
 [tool.pytest.ini_options]

--- a/requirements/requirements-examples.txt
+++ b/requirements/requirements-examples.txt
@@ -15,7 +15,6 @@ requests
 avro>=1.11.1,<2
 
 jsonschema >= 4.18.0
-orjson >= 3.10
 
 googleapis-common-protos
 protobuf

--- a/requirements/requirements-examples.txt
+++ b/requirements/requirements-examples.txt
@@ -14,7 +14,6 @@ fastavro >= 1.5.4, < 2; python_version > "3.7"
 requests
 avro>=1.11.1,<2
 
-pyrsistent
 jsonschema >= 4.18.0
 orjson >= 3.10
 

--- a/requirements/requirements-json-fast.txt
+++ b/requirements/requirements-json-fast.txt
@@ -1,0 +1,7 @@
+# Optional performance accelerator for the JSON serializer/deserializer.
+# The JSON serdes works without it by falling back to the stdlib json module
+# (see schema_registry/common/json_schema.py); installing orjson enables the
+# faster path. Kept separate from requirements-json.txt because orjson is a
+# compiled dependency without free-threaded (cp31Xt) wheels, which would
+# otherwise make the base `json` extra uninstallable on free-threaded CPython.
+orjson >= 3.10

--- a/requirements/requirements-json.txt
+++ b/requirements/requirements-json.txt
@@ -1,3 +1,2 @@
 pyrsistent
 jsonschema >= 4.18.0
-orjson >= 3.10

--- a/requirements/requirements-json.txt
+++ b/requirements/requirements-json.txt
@@ -1,2 +1,1 @@
-pyrsistent
 jsonschema >= 4.18.0

--- a/requirements/requirements-tests-install.txt
+++ b/requirements/requirements-tests-install.txt
@@ -1,7 +1,10 @@
--r requirements-tests.txt  
--r requirements-schemaregistry.txt  
+-r requirements-tests.txt
+-r requirements-schemaregistry.txt
 -r requirements-rules.txt
 -r requirements-avro.txt
--r requirements-protobuf.txt  
+-r requirements-protobuf.txt
 -r requirements-json.txt
+# Install orjson so CI exercises the orjson fast-path of the JSON codec (the
+# stdlib fallback is covered separately by tests/schema_registry/test_json_codec.py).
+-r requirements-json-fast.txt
 tests/trivup/trivup-0.14.0.tar.gz

--- a/requirements/requirements-tests-install.txt
+++ b/requirements/requirements-tests-install.txt
@@ -4,7 +4,4 @@
 -r requirements-avro.txt
 -r requirements-protobuf.txt
 -r requirements-json.txt
-# Install orjson so CI exercises the orjson fast-path of the JSON codec (the
-# stdlib fallback is covered separately by tests/schema_registry/test_json_codec.py).
--r requirements-json-fast.txt
 tests/trivup/trivup-0.14.0.tar.gz

--- a/requirements/requirements-tests.txt
+++ b/requirements/requirements-tests.txt
@@ -5,7 +5,6 @@ mypy
 attrs
 types-cachetools
 types-requests
-orjson
 pytest
 pytest-timeout
 requests-mock

--- a/src/confluent_kafka/schema_registry/_async/json_schema.py
+++ b/src/confluent_kafka/schema_registry/_async/json_schema.py
@@ -19,7 +19,6 @@ import io
 import logging
 from typing import Any, Callable, Coroutine, Optional, Tuple, Union, cast
 
-import orjson
 from cachetools import LRUCache
 from jsonschema import ValidationError
 from jsonschema.protocols import Validator
@@ -39,6 +38,8 @@ from confluent_kafka.schema_registry.common.json_schema import (
     JSON_TYPE,
     JsonSchema,
     _ContextStringIO,
+    _json_dumps,
+    _json_loads,
     _retrieve_via_httpx,
     transform,
 )
@@ -79,7 +80,7 @@ async def _resolve_named_schema(
             if referenced_schema.schema.schema_str is None:
                 raise TypeError("Schema string cannot be None")
 
-            referenced_schema_dict = orjson.loads(referenced_schema.schema.schema_str)
+            referenced_schema_dict = _json_loads(referenced_schema.schema.schema_str)
             resource = Resource.from_contents(referenced_schema_dict, default_specification=DEFAULT_SPEC)
             if ref.name is None:
                 raise TypeError("Name cannot be None")
@@ -265,7 +266,7 @@ class AsyncJSONSerializer(AsyncBaseSerializer):
         else:
             self._schema = None
 
-        self._json_encode = json_encode or (lambda x: orjson.dumps(x).decode("utf-8"))
+        self._json_encode = json_encode or _json_dumps
         self._registry = schema_registry_client
         self._rule_registry = rule_registry if rule_registry else RuleRegistry.get_global_instance()
         self._schema_id: Optional[SchemaId] = None
@@ -457,7 +458,7 @@ class AsyncJSONSerializer(AsyncBaseSerializer):
         ref_registry = await _resolve_named_schema(schema, self._registry)
         if schema.schema_str is None:
             raise TypeError("Schema string cannot be None")
-        parsed_schema = orjson.loads(schema.schema_str)
+        parsed_schema = _json_loads(schema.schema_str)
 
         self._parsed_schemas.set(schema, (parsed_schema, ref_registry))
         return parsed_schema, ref_registry
@@ -603,7 +604,7 @@ class AsyncJSONDeserializer(AsyncBaseDeserializer):
         self._parsed_schemas = ParsedSchemaCache()
         self._validators: LRUCache[Schema, Validator] = LRUCache(1000)
         self._validators_lock = _locks.Lock()
-        self._json_decode = json_decode or orjson.loads
+        self._json_decode = json_decode or _json_loads
         self._use_schema_id = None
 
         conf_copy = self._default_conf.copy()
@@ -790,7 +791,7 @@ class AsyncJSONDeserializer(AsyncBaseDeserializer):
         ref_registry = await _resolve_named_schema(schema, self._registry)
         if schema.schema_str is None:
             raise TypeError("Schema string cannot be None")
-        parsed_schema = orjson.loads(schema.schema_str)
+        parsed_schema = _json_loads(schema.schema_str)
 
         self._parsed_schemas.set(schema, (parsed_schema, ref_registry))
         return parsed_schema, ref_registry

--- a/src/confluent_kafka/schema_registry/_sync/json_schema.py
+++ b/src/confluent_kafka/schema_registry/_sync/json_schema.py
@@ -19,7 +19,6 @@ import logging
 import threading as _locks
 from typing import Any, Callable, Optional, Tuple, Union, cast
 
-import orjson
 from cachetools import LRUCache
 from jsonschema import ValidationError
 from jsonschema.protocols import Validator
@@ -38,6 +37,8 @@ from confluent_kafka.schema_registry.common.json_schema import (
     JSON_TYPE,
     JsonSchema,
     _ContextStringIO,
+    _json_dumps,
+    _json_loads,
     _retrieve_via_httpx,
     transform,
 )
@@ -78,7 +79,7 @@ def _resolve_named_schema(
             if referenced_schema.schema.schema_str is None:
                 raise TypeError("Schema string cannot be None")
 
-            referenced_schema_dict = orjson.loads(referenced_schema.schema.schema_str)
+            referenced_schema_dict = _json_loads(referenced_schema.schema.schema_str)
             resource = Resource.from_contents(referenced_schema_dict, default_specification=DEFAULT_SPEC)
             if ref.name is None:
                 raise TypeError("Name cannot be None")
@@ -263,7 +264,7 @@ class JSONSerializer(BaseSerializer):
         else:
             self._schema = None
 
-        self._json_encode = json_encode or (lambda x: orjson.dumps(x).decode("utf-8"))
+        self._json_encode = json_encode or _json_dumps
         self._registry = schema_registry_client
         self._rule_registry = rule_registry if rule_registry else RuleRegistry.get_global_instance()
         self._schema_id: Optional[SchemaId] = None
@@ -455,7 +456,7 @@ class JSONSerializer(BaseSerializer):
         ref_registry = _resolve_named_schema(schema, self._registry)
         if schema.schema_str is None:
             raise TypeError("Schema string cannot be None")
-        parsed_schema = orjson.loads(schema.schema_str)
+        parsed_schema = _json_loads(schema.schema_str)
 
         self._parsed_schemas.set(schema, (parsed_schema, ref_registry))
         return parsed_schema, ref_registry
@@ -600,7 +601,7 @@ class JSONDeserializer(BaseDeserializer):
         self._parsed_schemas = ParsedSchemaCache()
         self._validators: LRUCache[Schema, Validator] = LRUCache(1000)
         self._validators_lock = _locks.Lock()
-        self._json_decode = json_decode or orjson.loads
+        self._json_decode = json_decode or _json_loads
         self._use_schema_id = None
 
         conf_copy = self._default_conf.copy()
@@ -783,7 +784,7 @@ class JSONDeserializer(BaseDeserializer):
         ref_registry = _resolve_named_schema(schema, self._registry)
         if schema.schema_str is None:
             raise TypeError("Schema string cannot be None")
-        parsed_schema = orjson.loads(schema.schema_str)
+        parsed_schema = _json_loads(schema.schema_str)
 
         self._parsed_schemas.set(schema, (parsed_schema, ref_registry))
         return parsed_schema, ref_registry

--- a/src/confluent_kafka/schema_registry/common/json_schema.py
+++ b/src/confluent_kafka/schema_registry/common/json_schema.py
@@ -38,7 +38,7 @@ try:
 
     _HAS_ORJSON = True
 
-    def _json_loads(data: Union[str, bytes]) -> Any:
+    def _json_loads(data: Union[str, bytes, bytearray]) -> Any:
         return orjson.loads(data)
 
     def _json_dumps(obj: Any) -> str:
@@ -49,7 +49,7 @@ except ImportError:
 
     _HAS_ORJSON = False
 
-    def _json_loads(data: Union[str, bytes]) -> Any:
+    def _json_loads(data: Union[str, bytes, bytearray]) -> Any:
         # json.loads accepts bytes/bytearray (auto-detecting the encoding)
         # since Python 3.6, matching orjson.loads.
         return _stdlib_json.loads(data)

--- a/src/confluent_kafka/schema_registry/common/json_schema.py
+++ b/src/confluent_kafka/schema_registry/common/json_schema.py
@@ -30,9 +30,17 @@ __all__ = [
 
 # JSON codec: prefer orjson for speed, but fall back to the stdlib json module
 # when orjson is unavailable (e.g. on free-threaded CPython builds that do not
-# yet have orjson wheels). Both implementations accept str or bytes for loads
-# and return a str from dumps. The stdlib fallback mirrors orjson's wire output
-# (compact separators, non-ASCII preserved) so serialized bytes stay consistent.
+# yet have orjson wheels). Both implementations accept str/bytes/bytearray for
+# loads and return a str from dumps. The stdlib fallback mirrors orjson's wire
+# output (compact separators, non-ASCII preserved) so serialized bytes stay
+# consistent.
+#
+# Catch any exception (not just ImportError): orjson is a compiled extension and
+# may be present yet fail to import/initialize (ABI mismatch, broken shared lib,
+# init error raising OSError/RuntimeError/etc.). In that case we still degrade to
+# the stdlib codec rather than letting the failure break this module -- and with
+# it all JSON (de)serialization. Note `except Exception` deliberately does not
+# catch KeyboardInterrupt/SystemExit (those are BaseException).
 try:
     import orjson
 
@@ -44,7 +52,16 @@ try:
     def _json_dumps(obj: Any) -> str:
         return orjson.dumps(obj).decode("utf-8")
 
-except ImportError:
+except Exception as _orjson_exc:
+    if not isinstance(_orjson_exc, ImportError):
+        # Absence (ImportError) is the normal optional-dependency case and is
+        # silent; a present-but-broken orjson is unexpected, so surface it.
+        logging.getLogger(__name__).warning(
+            "orjson is installed but failed to import; falling back to the "
+            "stdlib json module",
+            exc_info=True,
+        )
+
     import json as _stdlib_json
 
     _HAS_ORJSON = False

--- a/src/confluent_kafka/schema_registry/common/json_schema.py
+++ b/src/confluent_kafka/schema_registry/common/json_schema.py
@@ -1,7 +1,7 @@
 import decimal
 import logging
 from io import BytesIO
-from typing import List, Optional, Set, Union
+from typing import Any, List, Optional, Set, Union
 
 import httpx
 import referencing
@@ -23,7 +23,39 @@ __all__ = [
     'get_type',
     '_disjoint',
     'get_inline_tags',
+    '_json_loads',
+    '_json_dumps',
+    '_HAS_ORJSON',
 ]
+
+# JSON codec: prefer orjson for speed, but fall back to the stdlib json module
+# when orjson is unavailable (e.g. on free-threaded CPython builds that do not
+# yet have orjson wheels). Both implementations accept str or bytes for loads
+# and return a str from dumps. The stdlib fallback mirrors orjson's wire output
+# (compact separators, non-ASCII preserved) so serialized bytes stay consistent.
+try:
+    import orjson
+
+    _HAS_ORJSON = True
+
+    def _json_loads(data: Union[str, bytes]) -> Any:
+        return orjson.loads(data)
+
+    def _json_dumps(obj: Any) -> str:
+        return orjson.dumps(obj).decode("utf-8")
+
+except ImportError:
+    import json as _stdlib_json
+
+    _HAS_ORJSON = False
+
+    def _json_loads(data: Union[str, bytes]) -> Any:
+        # json.loads accepts bytes/bytearray (auto-detecting the encoding)
+        # since Python 3.6, matching orjson.loads.
+        return _stdlib_json.loads(data)
+
+    def _json_dumps(obj: Any) -> str:
+        return _stdlib_json.dumps(obj, separators=(",", ":"), ensure_ascii=False)
 
 JSON_TYPE = "JSON"
 

--- a/src/confluent_kafka/schema_registry/common/json_schema.py
+++ b/src/confluent_kafka/schema_registry/common/json_schema.py
@@ -57,6 +57,7 @@ except ImportError:
     def _json_dumps(obj: Any) -> str:
         return _stdlib_json.dumps(obj, separators=(",", ":"), ensure_ascii=False)
 
+
 JSON_TYPE = "JSON"
 
 JsonMessage = Union[

--- a/src/confluent_kafka/schema_registry/common/json_schema.py
+++ b/src/confluent_kafka/schema_registry/common/json_schema.py
@@ -57,8 +57,7 @@ except Exception as _orjson_exc:
         # Absence (ImportError) is the normal optional-dependency case and is
         # silent; a present-but-broken orjson is unexpected, so surface it.
         logging.getLogger(__name__).warning(
-            "orjson is installed but failed to import; falling back to the "
-            "stdlib json module",
+            "orjson is installed but failed to import; falling back to the " "stdlib json module",
             exc_info=True,
         )
 

--- a/tests/schema_registry/test_json_codec.py
+++ b/tests/schema_registry/test_json_codec.py
@@ -23,37 +23,52 @@ is unavailable (e.g. on free-threaded CPython builds without orjson wheels).
 The fallback branch is otherwise never exercised in environments that ship
 orjson, so these tests force it explicitly.
 """
+import contextlib
 import importlib
-import importlib.util
 import sys
 
 import pytest
 
 from confluent_kafka.schema_registry.common import json_schema
 
-_MOD = "confluent_kafka.schema_registry.common.json_schema"
+
+def _orjson_importable() -> bool:
+    # Mirror the codec module's own logic: availability is driven by whether
+    # `import orjson` actually succeeds, not merely whether a spec is findable
+    # (a compiled extension can have a spec yet fail to import/initialize).
+    try:
+        import orjson  # noqa: F401
+    except Exception:
+        return False
+    return True
+
+
+_ORJSON_AVAILABLE = _orjson_importable()
 
 # A representative payload: nested structures, every JSON scalar type, key
 # ordering to verify it is preserved, and a non-ASCII character.
 _SAMPLE = {"b": 1, "a": "é", "n": None, "f": 1.5, "t": True, "list": [1, "x", None]}
 
 
-@pytest.fixture
-def stdlib_codec():
+@contextlib.contextmanager
+def _orjson_disabled():
     """Reload the codec module with orjson forced unavailable.
 
     Setting ``sys.modules['orjson'] = None`` makes ``import orjson`` raise
     ImportError, so reloading the module rebinds ``_json_loads``/``_json_dumps``
-    to the stdlib fallback. The original orjson-backed module is restored on
-    teardown so the rest of the suite is unaffected.
+    to the stdlib fallback. Note that ``importlib.reload`` mutates the module
+    object in place, so the module-level ``json_schema`` reference is also
+    switched to the fallback for the duration of this context. The original
+    orjson-backed codec is restored on exit so the rest of the suite is
+    unaffected.
     """
     sentinel = object()
     saved = sys.modules.get("orjson", sentinel)
     sys.modules["orjson"] = None  # type: ignore[assignment]  # => ImportError on import
     try:
-        mod = importlib.reload(json_schema)
-        assert mod._HAS_ORJSON is False
-        yield mod
+        importlib.reload(json_schema)
+        assert json_schema._HAS_ORJSON is False
+        yield json_schema
     finally:
         if saved is sentinel:
             sys.modules.pop("orjson", None)
@@ -62,9 +77,14 @@ def stdlib_codec():
         importlib.reload(json_schema)  # restore the orjson-backed codec
 
 
+@pytest.fixture
+def stdlib_codec():
+    with _orjson_disabled() as mod:
+        yield mod
+
+
 def test_has_orjson_reflects_availability():
-    orjson_installed = importlib.util.find_spec("orjson") is not None
-    assert json_schema._HAS_ORJSON is orjson_installed
+    assert json_schema._HAS_ORJSON is _ORJSON_AVAILABLE
 
 
 def test_stdlib_fallback_is_active(stdlib_codec):
@@ -93,12 +113,18 @@ def test_stdlib_fallback_output_is_compact_and_unicode_preserving(stdlib_codec):
 
 
 @pytest.mark.skipif(
-    importlib.util.find_spec("orjson") is None,
+    not _ORJSON_AVAILABLE,
     reason="orjson not installed; cannot compare backends",
 )
-def test_stdlib_and_orjson_produce_identical_output(stdlib_codec):
-    # stdlib_codec is the fallback module; the orjson path is the import at the
-    # top of this file (restored on fixture teardown but still bound here).
-    stdlib_out = stdlib_codec._json_dumps(_SAMPLE)
+def test_stdlib_and_orjson_produce_identical_output():
+    # Capture the orjson output FIRST, while the module is still orjson-backed.
+    # importlib.reload (used by _orjson_disabled) mutates json_schema in place,
+    # so once the fallback is active there is no live orjson codec to compare
+    # against -- the orjson value must be taken before entering the context.
+    assert json_schema._HAS_ORJSON is True
     orjson_out = json_schema._json_dumps(_SAMPLE)
+
+    with _orjson_disabled() as stdlib_codec:
+        stdlib_out = stdlib_codec._json_dumps(_SAMPLE)
+
     assert stdlib_out == orjson_out

--- a/tests/schema_registry/test_json_codec.py
+++ b/tests/schema_registry/test_json_codec.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Copyright 2026 Confluent Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""
+Tests for the JSON codec used by the JSON serializer/deserializer.
+
+The codec prefers orjson but falls back to the stdlib json module when orjson
+is unavailable (e.g. on free-threaded CPython builds without orjson wheels).
+The fallback branch is otherwise never exercised in environments that ship
+orjson, so these tests force it explicitly.
+"""
+import importlib
+import importlib.util
+import sys
+
+import pytest
+
+from confluent_kafka.schema_registry.common import json_schema
+
+_MOD = "confluent_kafka.schema_registry.common.json_schema"
+
+# A representative payload: nested structures, every JSON scalar type, key
+# ordering to verify it is preserved, and a non-ASCII character.
+_SAMPLE = {"b": 1, "a": "é", "n": None, "f": 1.5, "t": True, "list": [1, "x", None]}
+
+
+@pytest.fixture
+def stdlib_codec():
+    """Reload the codec module with orjson forced unavailable.
+
+    Setting ``sys.modules['orjson'] = None`` makes ``import orjson`` raise
+    ImportError, so reloading the module rebinds ``_json_loads``/``_json_dumps``
+    to the stdlib fallback. The original orjson-backed module is restored on
+    teardown so the rest of the suite is unaffected.
+    """
+    sentinel = object()
+    saved = sys.modules.get("orjson", sentinel)
+    sys.modules["orjson"] = None  # type: ignore[assignment]  # => ImportError on import
+    try:
+        mod = importlib.reload(json_schema)
+        assert mod._HAS_ORJSON is False
+        yield mod
+    finally:
+        if saved is sentinel:
+            sys.modules.pop("orjson", None)
+        else:
+            sys.modules["orjson"] = saved
+        importlib.reload(json_schema)  # restore the orjson-backed codec
+
+
+def test_has_orjson_reflects_availability():
+    orjson_installed = importlib.util.find_spec("orjson") is not None
+    assert json_schema._HAS_ORJSON is orjson_installed
+
+
+def test_stdlib_fallback_is_active(stdlib_codec):
+    assert stdlib_codec._HAS_ORJSON is False
+
+
+def test_stdlib_fallback_roundtrip(stdlib_codec):
+    encoded = stdlib_codec._json_dumps(_SAMPLE)
+    assert isinstance(encoded, str)
+    assert stdlib_codec._json_loads(encoded) == _SAMPLE
+
+
+def test_stdlib_fallback_loads_accepts_str_bytes_bytearray(stdlib_codec):
+    raw = '{"x": 1}'
+    expected = {"x": 1}
+    assert stdlib_codec._json_loads(raw) == expected
+    assert stdlib_codec._json_loads(raw.encode("utf-8")) == expected
+    assert stdlib_codec._json_loads(bytearray(raw.encode("utf-8"))) == expected
+
+
+def test_stdlib_fallback_output_is_compact_and_unicode_preserving(stdlib_codec):
+    # Compact separators (no whitespace) and non-ASCII left as UTF-8, matching
+    # orjson's wire output so serialized bytes stay consistent across backends.
+    assert stdlib_codec._json_dumps({"a": 1, "b": 2}) == '{"a":1,"b":2}'
+    assert stdlib_codec._json_dumps({"k": "é"}) == '{"k":"é"}'
+
+
+@pytest.mark.skipif(
+    importlib.util.find_spec("orjson") is None,
+    reason="orjson not installed; cannot compare backends",
+)
+def test_stdlib_and_orjson_produce_identical_output(stdlib_codec):
+    # stdlib_codec is the fallback module; the orjson path is the import at the
+    # top of this file (restored on fixture teardown but still bound here).
+    stdlib_out = stdlib_codec._json_dumps(_SAMPLE)
+    orjson_out = json_schema._json_dumps(_SAMPLE)
+    assert stdlib_out == orjson_out

--- a/tests/schema_registry/test_json_codec.py
+++ b/tests/schema_registry/test_json_codec.py
@@ -23,6 +23,7 @@ is unavailable (e.g. on free-threaded CPython builds without orjson wheels).
 The fallback branch is otherwise never exercised in environments that ship
 orjson, so these tests force it explicitly.
 """
+
 import contextlib
 import importlib
 import sys

--- a/tools/source-package-verification.sh
+++ b/tools/source-package-verification.sh
@@ -6,6 +6,12 @@
 set -e
 
 uv pip install -r requirements/requirements-tests-install.txt
+# Install orjson (CI-only) so the test suite exercises the orjson fast-path of
+# the JSON codec. It is intentionally NOT in requirements-tests-install.txt:
+# orjson has no free-threaded wheels yet, and keeping it out lets contributors
+# on such interpreters still install the default test deps. The stdlib fallback
+# is covered by tests/schema_registry/test_json_codec.py regardless.
+uv pip install -r requirements/requirements-json-fast.txt
 uv pip install -U build
 
 # Cache trivup Apache Kafka versions


### PR DESCRIPTION
<!--
Suggested PR template: Fill/delete/add sections as needed. Optionally delete any commented block.
-->
What
----
 `orjson` is a compiled (Rust/PyO3) dependency with **no free-threaded (`cp31Xt`) wheels** yet, and `pyrsistent` (historically pulled in) likewise has none. Because the JSON serializer imported `orjson` unconditionally and several                                                                                                   
  extras hard-required it, the JSON path was uninstallable on free-threaded CPython builds.                                                                                                                                                                   
                                                                                                                                                                                    
  After this change every extra is installable on free-threaded CPython **except** `json-fast`, whose sole purpose is to opt into orjson. `orjson` remains the default fast path wherever a wheel exists.                                                                                                                     
                                                                 

Checklist
------------------
- [ ] Contains customer facing changes? Including API/behavior changes <!-- This can help identify if it has introduced any breaking changes -->
- [ ] Did you add sufficient unit test and/or integration test coverage for this PR?
  - If not, please explain why it is not required

References
----------
JIRA: 
<!--
Copy&paste links: to Jira ticket, other PRs, issues, Slack conversations...
For code bumps: link to PR, tag or GitHub `/compare/master...master`
-->

Test & Review
------------
<!--
Has it been tested? how?
Copy&paste any handy instructions, steps or requirements that can save time to the reviewer or any reader.
-->

Open questions / Follow-ups
--------------------------
<!--
Optional: anything open to discussion for the reviewer, out of scope, or follow-ups.
-->

<!--
Review stakeholders
------------------
<!--
Optional: mention stakeholders or if special context that is required to review.
-->
