### PR TITLE
Fix Producer.poll wakeable early return

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ for a worked example.
 - Make orjson optional in JSON serdes with stdlib json fallback (#2281)
 - Handle non-http errors during retries (#2292)
 - Use TLS certification verification with Hashicorp Vault (#2294)
+- Return early from wakeable `Producer.poll()` once producer events are
+  served, instead of waiting for the full timeout.
 
 
 confluent-kafka-python v2.15.0rc1 is based on librdkafka v2.15.0-RC1, see the

--- a/src/confluent_kafka/src/Producer.c
+++ b/src/confluent_kafka/src/Producer.c
@@ -395,6 +395,9 @@ static int Producer_poll0(Handle *self, int tmout) {
                                 break;
                         }
                         r += chunk_result; /* Accumulate events processed */
+                        if (chunk_result > 0) {
+                                break;
+                        }
 
                         chunk_count++;
 

--- a/tests/integration/producer/test_producer_wakeable_poll_flush.py
+++ b/tests/integration/producer/test_producer_wakeable_poll_flush.py
@@ -80,17 +80,21 @@ def test_poll_message_delivery_with_wakeable_pattern(kafka_cluster):
     # Produce a test message with delivery callback
     producer.produce(topic, value=b'test-message', on_delivery=delivery_callback)
 
-    # Poll with wakeable pattern - should trigger delivery callback
+    # Poll with wakeable pattern - should trigger delivery callback and return
+    # when that event is served, rather than waiting for the whole timeout.
+    poll_timeout = 5.0
     start = time.time()
-    events_handled = producer.poll(timeout=2.0)
+    events_handled = producer.poll(timeout=poll_timeout)
     elapsed = time.time() - start
 
     # Verify delivery callback was called
     assert len(delivery_called) > 0, "Expected delivery callback to be called"
     assert len(delivery_errors) == 0, f"Unexpected delivery errors: {delivery_errors}"
     assert events_handled >= 0, "poll() should return non-negative int"
-    # Allow time for delivery callback, but should complete reasonably quickly
-    assert elapsed < 2.5, f"Poll took {elapsed:.2f}s, expected < 2.5s"
+    assert elapsed < poll_timeout - 1.0, (
+        f"Poll took {elapsed:.2f}s after delivery, expected it to return "
+        f"well before the {poll_timeout:.1f}s timeout"
+    )
 
     # Flush to ensure message is committed to Kafka
     producer.flush(timeout=1.0)


### PR DESCRIPTION
Fixes #2215.

## Summary
- return from wakeable `Producer.poll()` once `rd_kafka_poll()` serves producer events
- tighten the existing wakeable producer integration test so a full-timeout wait after delivery is caught
- add a changelog entry

## Validation
- `git diff --check`
- `.venv/bin/python -m py_compile tests/integration/producer/test_producer_wakeable_poll_flush.py`
- `.venv/bin/black --check tests/integration/producer/test_producer_wakeable_poll_flush.py`
- `.venv/bin/isort --check-only tests/integration/producer/test_producer_wakeable_poll_flush.py`
- `.venv/bin/flake8 tests/integration/producer/test_producer_wakeable_poll_flush.py`
- built editable install against `librdkafka v2.15.0-RC1`
- `DYLD_LIBRARY_PATH=/private/tmp/librdkafka-2.15.0-RC1-install/lib .venv/bin/python -c "import confluent_kafka; print(confluent_kafka.version()); print(confluent_kafka.libversion())"`
- `DYLD_LIBRARY_PATH=/private/tmp/librdkafka-2.15.0-RC1-install/lib .venv/bin/pytest -q tests/test_Wakeable.py::test_producer_wakeable_poll_interruptibility_and_messages tests/test_Wakeable.py::test_producer_wakeable_poll_edge_cases`

I also attempted `tests/integration/producer/test_producer_wakeable_poll_flush.py::test_poll_message_delivery_with_wakeable_pattern`; it reached trivup cluster setup but could not complete locally because the Docker daemon was not running for `confluentinc/cp-schema-registry:7.6.0`.
