### PR TITLE
Bump authlib min version to 1.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Confluent Python Client for Apache Kafka - CHANGELOG
 
+### Fixes
+
+- Bump minimum `authlib` version to 1.7.1 to avoid a spurious `authlib.jose` deprecation
+  warning raised on import by `authlib` 1.7.0 (#2242)
+
 ## v2.15.0
 
 ### [KIP-932](https://cwiki.apache.org/confluence/display/KAFKA/KIP-932%3A+Queues+for+Kafka) Queues for Kafka – Now in **Preview**

--- a/requirements/requirements-examples.txt
+++ b/requirements/requirements-examples.txt
@@ -7,7 +7,7 @@ six
 attrs
 cachetools
 httpx>=0.26
-authlib>=1.0.0
+authlib>=1.7.1
 
 fastavro >= 1.5.4, < 1.8.0; python_version == "3.7"
 fastavro >= 1.5.4, < 2; python_version > "3.7"

--- a/requirements/requirements-schemaregistry.txt
+++ b/requirements/requirements-schemaregistry.txt
@@ -2,4 +2,4 @@ attrs>=21.2.0
 cachetools>=5.5.0
 certifi
 httpx>=0.26
-authlib>=1.0.0
+authlib>=1.7.1


### PR DESCRIPTION
Fixes #2242

authlib 1.7.0 raises an `AuthlibDeprecationWarning` for `authlib.jose` on import, even though this repo only uses `authlib.integrations.httpx_client.OAuth2Client` and never touches `authlib.jose` directly. It's an authlib-side import chain issue, fixed upstream in 1.7.1.

Bumped the `authlib` floor in `requirements-schemaregistry.txt` and `requirements-examples.txt` from `>=1.0.0` to `>=1.7.1`.

Verified `tests/schema_registry/_sync/test_bearer_field_provider.py` and the async counterpart still pass unchanged against 1.7.1.