### PR TITLE
Add DLQ rule action to Schema Registry serdes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@
 - Pass context when clients make KEK calls to DEK Registry (#2308)
 - Minor fix for subjectPrefix parameter in subjects API (#2311)
 
+### Fixes
+
+- `DeserializingConsumer` and `DeserializingShareConsumer` now deserialize the
+  message key before the value (previously the value was deserialized first),
+  matching `SerializingProducer` and the Java client. This lets a key
+  deserializer stash state for the value deserializer (used by the Schema
+  Registry dead-letter-queue rule action to capture the original key). As a
+  side effect, when *both* the key and value fail to deserialize, the key
+  deserialization error is now surfaced instead of the value error.
+
 
 ## v2.15.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,22 +7,19 @@
 - Add support for saving Azure key version with DEK (#2306)
 - Pass context when clients make KEK calls to DEK Registry (#2308)
 - Minor fix for subjectPrefix parameter in subjects API (#2311)
+- Schema Registry: add support for the DLQ (dead-letter-queue) rule action
+  (`DlqAction`). When a rule fails, the record is teed to a configured DLQ
+  topic and the original serialize/deserialize call still raises. With the
+  default (global) `RuleRegistry` the DLQ is best-effort; set
+  `dlq.auto.flush=true` or give the serde its own `RuleRegistry` (closable on
+  shutdown) for durability.
 
 ### Fixes
 
-- Schema Registry `DlqAction`: with the default (global) `RuleRegistry` the DLQ
-  is best-effort — records teed just before process exit may be dropped, since
-  DLQ sends are asynchronous and a per-serde `close()`/`aclose()` does not close
-  the shared action. For durability, set `dlq.auto.flush=true` (flushes after
-  every send) or give the serde its own `RuleRegistry` and call `close()`/
-  `aclose()` on shutdown.
 - `DeserializingConsumer` and `DeserializingShareConsumer` now deserialize the
-  message key before the value (previously the value was deserialized first),
-  matching `SerializingProducer` and the Java client. This lets a key
-  deserializer stash state for the value deserializer (used by the Schema
-  Registry dead-letter-queue rule action to capture the original key). As a
-  side effect, when *both* the key and value fail to deserialize, the key
-  deserialization error is now surfaced instead of the value error.
+  message key before the value, matching `SerializingProducer` and the Java
+  client. When both key and value fail to deserialize, the key error is now
+  surfaced instead of the value error.
 
 
 ## v2.15.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@
 
 ### Fixes
 
+- Schema Registry `DlqAction`: with the default (global) `RuleRegistry` the DLQ
+  is best-effort — records teed just before process exit may be dropped, since
+  DLQ sends are asynchronous and a per-serde `close()`/`aclose()` does not close
+  the shared action. For durability, set `dlq.auto.flush=true` (flushes after
+  every send) or give the serde its own `RuleRegistry` and call `close()`/
+  `aclose()` on shutdown.
 - `DeserializingConsumer` and `DeserializingShareConsumer` now deserialize the
   message key before the value (previously the value was deserialized first),
   matching `SerializingProducer` and the Java client. This lets a key

--- a/src/confluent_kafka/deserializing_consumer.py
+++ b/src/confluent_kafka/deserializing_consumer.py
@@ -105,25 +105,42 @@ class DeserializingConsumer(_ConsumerImpl):
         if error is not None:
             raise ConsumeError(error, kafka_message=msg)
 
+        return self._deserialize(msg)
+
+    def _deserialize(self, msg: Message) -> Message:
+        """
+        Deserialize a single message's key and value in place and return it.
+
+        The key is deserialized before the value so a key deserializer can stash
+        the original key for the value deserializer (e.g. the Schema Registry
+        dead-letter-queue rule action tees the value's original key). This
+        matches ``SerializingProducer``, which serializes the key before the
+        value, and the Java client, whose consumer deserializes the key first.
+
+        Raises:
+            KeyDeserializationError: If an error occurs during key deserialization.
+
+            ValueDeserializationError: If an error occurs during value deserialization.
+        """
         topic = msg.topic()
         if topic is None:
             raise TypeError("Message topic is None")
-        ctx = SerializationContext(topic, MessageField.VALUE, msg.headers())
-
-        value = msg.value()
-        if self._value_deserializer is not None:
-            try:
-                value = self._value_deserializer(value, ctx)
-            except Exception as se:
-                raise ValueDeserializationError(exception=se, kafka_message=msg)
+        ctx = SerializationContext(topic, MessageField.KEY, msg.headers())
 
         key = msg.key()
-        ctx.field = MessageField.KEY
         if self._key_deserializer is not None:
             try:
                 key = self._key_deserializer(key, ctx)
             except Exception as se:
                 raise KeyDeserializationError(exception=se, kafka_message=msg)
+
+        value = msg.value()
+        ctx.field = MessageField.VALUE
+        if self._value_deserializer is not None:
+            try:
+                value = self._value_deserializer(value, ctx)
+            except Exception as se:
+                raise ValueDeserializationError(exception=se, kafka_message=msg)
 
         msg.set_key(key)
         msg.set_value(value)

--- a/src/confluent_kafka/deserializing_consumer.py
+++ b/src/confluent_kafka/deserializing_consumer.py
@@ -115,7 +115,7 @@ class DeserializingConsumer(_ConsumerImpl):
         the original key for the value deserializer (e.g. the Schema Registry
         dead-letter-queue rule action tees the value's original key). This
         matches ``SerializingProducer``, which serializes the key before the
-        value, and the Java client, whose consumer deserializes the key first.
+        value.
 
         Raises:
             KeyDeserializationError: If an error occurs during key deserialization.

--- a/src/confluent_kafka/deserializing_consumer.py
+++ b/src/confluent_kafka/deserializing_consumer.py
@@ -109,13 +109,11 @@ class DeserializingConsumer(_ConsumerImpl):
 
     def _deserialize(self, msg: Message) -> Message:
         """
-        Deserialize a single message's key and value in place and return it.
+        Deserialize a message's key and value in place and return it.
 
         The key is deserialized before the value so a key deserializer can stash
-        the original key for the value deserializer (e.g. the Schema Registry
-        dead-letter-queue rule action tees the value's original key). This
-        matches ``SerializingProducer``, which serializes the key before the
-        value.
+        state for the value deserializer (e.g. the Schema Registry DLQ action),
+        matching ``SerializingProducer``.
 
         Raises:
             KeyDeserializationError: If an error occurs during key deserialization.

--- a/src/confluent_kafka/deserializing_share_consumer.py
+++ b/src/confluent_kafka/deserializing_share_consumer.py
@@ -122,34 +122,23 @@ class DeserializingShareConsumer(_ShareConsumerImpl):
 
     def _deserialize(self, msg: Message) -> None:
         """
-        Deserialize a single message's key and value.
+        Deserialize a message's key and value.
 
         The key is deserialized before the value (matching
         :py:class:`DeserializingConsumer` and ``SerializingProducer``) so a key
-        deserializer can stash the original key for the value deserializer.
-
-        Both fields are deserialized into locals and written back to the
-        message only once *both* succeed, so a deserialization failure leaves
-        the record's raw key and value bytes untouched (and therefore still
-        acknowledgeable). On a deserialization failure the record is marked via
-        :py:func:`Message.set_error` rather than raising, so the rest of the
-        batch (already fetched from the broker) is not lost. The deserializer
-        calls are guarded, so a failure marks only this record instead of
-        aborting the batch.
-
-        A message with no topic is a broken invariant rather than a per-record
-        data error, so it raises :py:exc:`TypeError` (matching
-        :py:class:`DeserializingConsumer`).
+        deserializer can stash state for the value deserializer (e.g. the DLQ
+        action). Fields are written back only if *both* succeed; a failure marks
+        the record via :py:func:`Message.set_error` (leaving its raw bytes intact
+        and acknowledgeable) instead of raising, so the rest of the batch is kept.
+        A message with no topic is a broken invariant, so it raises
+        :py:exc:`TypeError`.
         """
 
         topic = msg.topic()
         if topic is None:
             raise TypeError("Message topic is None")
 
-        # Deserialize the key before the value. A key deserializer may stash the
-        # original key for the value deserializer to consume (e.g. the Schema
-        # Registry DLQ action), so the key must be processed first. This matches
-        # SerializingProducer and DeserializingConsumer.
+        # Key first: a key deserializer may stash state for the value deserializer.
         ctx = SerializationContext(topic, MessageField.KEY, msg.headers())
         try:
             key = msg.key()

--- a/src/confluent_kafka/deserializing_share_consumer.py
+++ b/src/confluent_kafka/deserializing_share_consumer.py
@@ -122,7 +122,11 @@ class DeserializingShareConsumer(_ShareConsumerImpl):
 
     def _deserialize(self, msg: Message) -> None:
         """
-        Deserialize a single message's value and key.
+        Deserialize a single message's key and value.
+
+        The key is deserialized before the value (matching
+        :py:class:`DeserializingConsumer` and ``SerializingProducer``) so a key
+        deserializer can stash the original key for the value deserializer.
 
         Both fields are deserialized into locals and written back to the
         message only once *both* succeed, so a deserialization failure leaves
@@ -142,22 +146,26 @@ class DeserializingShareConsumer(_ShareConsumerImpl):
         if topic is None:
             raise TypeError("Message topic is None")
 
-        ctx = SerializationContext(topic, MessageField.VALUE, msg.headers())
-        try:
-            value = msg.value()
-            if self._value_deserializer is not None:
-                value = self._value_deserializer(value, ctx)
-        except Exception as se:
-            msg.set_error(KafkaError(KafkaError._VALUE_DESERIALIZATION, str(se)))
-            return
-
+        # Deserialize the key before the value. A key deserializer may stash the
+        # original key for the value deserializer to consume (e.g. the Schema
+        # Registry DLQ action), so the key must be processed first. This matches
+        # SerializingProducer and DeserializingConsumer.
+        ctx = SerializationContext(topic, MessageField.KEY, msg.headers())
         try:
             key = msg.key()
             if self._key_deserializer is not None:
-                ctx.field = MessageField.KEY
                 key = self._key_deserializer(key, ctx)
         except Exception as se:
             msg.set_error(KafkaError(KafkaError._KEY_DESERIALIZATION, str(se)))
+            return
+
+        try:
+            value = msg.value()
+            if self._value_deserializer is not None:
+                ctx.field = MessageField.VALUE
+                value = self._value_deserializer(value, ctx)
+        except Exception as se:
+            msg.set_error(KafkaError(KafkaError._VALUE_DESERIALIZATION, str(se)))
             return
 
         msg.set_key(key)

--- a/src/confluent_kafka/schema_registry/_async/avro.py
+++ b/src/confluent_kafka/schema_registry/_async/avro.py
@@ -45,8 +45,10 @@ from confluent_kafka.schema_registry.serde import (
     AsyncBaseSerializer,
     ParsedSchemaCache,
     SchemaId,
+    clear_original_key,
+    set_original_key,
 )
-from confluent_kafka.serialization import SerializationContext, SerializationError
+from confluent_kafka.serialization import MessageField, SerializationContext, SerializationError
 
 __all__ = [
     '_resolve_named_schema',
@@ -371,6 +373,8 @@ class AsyncAvroSerializer(AsyncBaseSerializer):
 
         for rule in self._rule_registry.get_executors():
             rule.configure(self._registry.config() if self._registry else {}, rule_conf if rule_conf else {})
+        for action in self._rule_registry.get_actions():
+            action.configure(self._registry.config() if self._registry else {}, rule_conf if rule_conf else {})
 
     __init__ = __init_impl
 
@@ -380,6 +384,18 @@ class AsyncAvroSerializer(AsyncBaseSerializer):
         return self.__serialize(obj, ctx)
 
     async def __serialize(self, obj: object, ctx: Optional[SerializationContext] = None) -> Optional[bytes]:
+        try:
+            if obj is None:
+                return None
+            return await self.__serialize_impl(obj, ctx)
+        finally:
+            # Track the key for use when serializing the value, such as for a DLQ
+            if ctx is not None and ctx.field == MessageField.KEY:
+                set_original_key(obj)
+            else:
+                clear_original_key()
+
+    async def __serialize_impl(self, obj: object, ctx: Optional[SerializationContext] = None) -> Optional[bytes]:
         """
         Serializes an object to Avro binary format, prepending it with Confluent
         Schema Registry framing.
@@ -659,6 +675,8 @@ class AsyncAvroDeserializer(AsyncBaseDeserializer):
 
         for rule in self._rule_registry.get_executors():
             rule.configure(self._registry.config() if self._registry else {}, rule_conf if rule_conf else {})
+        for action in self._rule_registry.get_actions():
+            action.configure(self._registry.config() if self._registry else {}, rule_conf if rule_conf else {})
 
     __init__ = __init_impl
 
@@ -668,6 +686,20 @@ class AsyncAvroDeserializer(AsyncBaseDeserializer):
         return self.__deserialize(data, ctx)
 
     async def __deserialize(
+        self, data: Optional[bytes], ctx: Optional[SerializationContext] = None
+    ) -> Union[dict, object, None]:
+        try:
+            if data is None:
+                return None
+            return await self.__deserialize_impl(data, ctx)
+        finally:
+            # Track the key for use when deserializing the value, such as for a DLQ
+            if ctx is not None and ctx.field == MessageField.KEY:
+                set_original_key(data)
+            else:
+                clear_original_key()
+
+    async def __deserialize_impl(
         self, data: Optional[bytes], ctx: Optional[SerializationContext] = None
     ) -> Union[dict, object, None]:
         """
@@ -734,7 +766,7 @@ class AsyncAvroDeserializer(AsyncBaseDeserializer):
 
         if ctx is not None and subject is not None:
             payload = self._execute_rules_with_phase(
-                ctx, subject, RulePhase.ENCODING, RuleMode.READ, None, writer_schema_raw, payload, None, None
+                ctx, subject, RulePhase.ENCODING, RuleMode.READ, None, writer_schema_raw, payload, None, None, data
             )
         if isinstance(payload, bytes):
             payload = io.BytesIO(payload)
@@ -780,7 +812,7 @@ class AsyncAvroDeserializer(AsyncBaseDeserializer):
         if ctx is not None and subject is not None:
             inline_tags = get_inline_tags(reader_schema) if reader_schema is not None else None
             obj_dict = self._execute_rules(
-                ctx, subject, RuleMode.READ, None, reader_schema_raw, obj_dict, inline_tags, field_transformer
+                ctx, subject, RuleMode.READ, None, reader_schema_raw, obj_dict, inline_tags, field_transformer, data
             )
 
         if self._from_dict is not None:

--- a/src/confluent_kafka/schema_registry/_async/json_schema.py
+++ b/src/confluent_kafka/schema_registry/_async/json_schema.py
@@ -50,8 +50,10 @@ from confluent_kafka.schema_registry.serde import (
     AsyncBaseSerializer,
     ParsedSchemaCache,
     SchemaId,
+    clear_original_key,
+    set_original_key,
 )
-from confluent_kafka.serialization import SerializationContext, SerializationError
+from confluent_kafka.serialization import MessageField, SerializationContext, SerializationError
 
 __all__ = ['_resolve_named_schema', 'AsyncJSONSerializer', 'AsyncJSONDeserializer']
 
@@ -339,6 +341,8 @@ class AsyncJSONSerializer(AsyncBaseSerializer):
 
         for rule in self._rule_registry.get_executors():
             rule.configure(self._registry.config() if self._registry else {}, rule_conf if rule_conf else {})
+        for action in self._rule_registry.get_actions():
+            action.configure(self._registry.config() if self._registry else {}, rule_conf if rule_conf else {})
 
     __init__ = __init_impl
 
@@ -348,6 +352,18 @@ class AsyncJSONSerializer(AsyncBaseSerializer):
         return self.__serialize(obj, ctx)
 
     async def __serialize(self, obj: object, ctx: Optional[SerializationContext] = None) -> Optional[bytes]:
+        try:
+            if obj is None:
+                return None
+            return await self.__serialize_impl(obj, ctx)
+        finally:
+            # Track the key for use when serializing the value, such as for a DLQ
+            if ctx is not None and ctx.field == MessageField.KEY:
+                set_original_key(obj)
+            else:
+                clear_original_key()
+
+    async def __serialize_impl(self, obj: object, ctx: Optional[SerializationContext] = None) -> Optional[bytes]:
         """
         Serializes an object to JSON, prepending it with Confluent Schema Registry
         framing.
@@ -652,6 +668,8 @@ class AsyncJSONDeserializer(AsyncBaseDeserializer):
 
         for rule in self._rule_registry.get_executors():
             rule.configure(self._registry.config() if self._registry else {}, rule_conf if rule_conf else {})
+        for action in self._rule_registry.get_actions():
+            action.configure(self._registry.config() if self._registry else {}, rule_conf if rule_conf else {})
 
     __init__ = __init_impl
 
@@ -661,6 +679,20 @@ class AsyncJSONDeserializer(AsyncBaseDeserializer):
         return self.__deserialize(data, ctx)
 
     async def __deserialize(self, data: Optional[bytes], ctx: Optional[SerializationContext] = None) -> Optional[bytes]:
+        try:
+            if data is None:
+                return None
+            return await self.__deserialize_impl(data, ctx)
+        finally:
+            # Track the key for use when deserializing the value, such as for a DLQ
+            if ctx is not None and ctx.field == MessageField.KEY:
+                set_original_key(data)
+            else:
+                clear_original_key()
+
+    async def __deserialize_impl(
+        self, data: Optional[bytes], ctx: Optional[SerializationContext] = None
+    ) -> Optional[bytes]:
         """
         Deserialize a JSON encoded record with Confluent Schema Registry framing to
         a dict, or object instance according to from_dict if from_dict is specified.
@@ -713,7 +745,7 @@ class AsyncJSONDeserializer(AsyncBaseDeserializer):
 
         if ctx is not None and subject is not None:
             payload = self._execute_rules_with_phase(
-                ctx, subject, RulePhase.ENCODING, RuleMode.READ, None, writer_schema_raw, payload, None, None
+                ctx, subject, RulePhase.ENCODING, RuleMode.READ, None, writer_schema_raw, payload, None, None, data
             )
         if isinstance(payload, bytes):
             payload = io.BytesIO(payload)
@@ -753,7 +785,7 @@ class AsyncJSONDeserializer(AsyncBaseDeserializer):
 
             if ctx is not None and subject is not None:
                 obj_dict = self._execute_rules(
-                    ctx, subject, RuleMode.READ, None, reader_schema_raw, obj_dict, None, field_transformer
+                    ctx, subject, RuleMode.READ, None, reader_schema_raw, obj_dict, None, field_transformer, data
                 )
 
         if self._validate:

--- a/src/confluent_kafka/schema_registry/_async/protobuf.py
+++ b/src/confluent_kafka/schema_registry/_async/protobuf.py
@@ -52,8 +52,10 @@ from confluent_kafka.schema_registry.serde import (
     AsyncBaseSerializer,
     ParsedSchemaCache,
     SchemaId,
+    clear_original_key,
+    set_original_key,
 )
-from confluent_kafka.serialization import SerializationContext, SerializationError
+from confluent_kafka.serialization import MessageField, SerializationContext, SerializationError
 
 __all__ = [
     '_resolve_named_schema',
@@ -331,6 +333,8 @@ class AsyncProtobufSerializer(AsyncBaseSerializer):
 
         for rule in self._rule_registry.get_executors():
             rule.configure(self._registry.config() if self._registry else {}, rule_conf if rule_conf else {})
+        for action in self._rule_registry.get_actions():
+            action.configure(self._registry.config() if self._registry else {}, rule_conf if rule_conf else {})
 
     __init__ = __init_impl
 
@@ -408,6 +412,18 @@ class AsyncProtobufSerializer(AsyncBaseSerializer):
         return self.__serialize(message, ctx)
 
     async def __serialize(self, message: Message, ctx: Optional[SerializationContext] = None) -> Optional[bytes]:
+        try:
+            if message is None:
+                return None
+            return await self.__serialize_impl(message, ctx)
+        finally:
+            # Track the key for use when serializing the value, such as for a DLQ
+            if ctx is not None and ctx.field == MessageField.KEY:
+                set_original_key(message)
+            else:
+                clear_original_key()
+
+    async def __serialize_impl(self, message: Message, ctx: Optional[SerializationContext] = None) -> Optional[bytes]:
         """
         Serializes an instance of a class derived from Protobuf Message, and prepends
         it with Confluent Schema Registry framing.
@@ -634,6 +650,8 @@ class AsyncProtobufDeserializer(AsyncBaseDeserializer):
 
         for rule in self._rule_registry.get_executors():
             rule.configure(self._registry.config() if self._registry else {}, rule_conf if rule_conf else {})
+        for action in self._rule_registry.get_actions():
+            action.configure(self._registry.config() if self._registry else {}, rule_conf if rule_conf else {})
 
     __init__ = __init_impl
 
@@ -643,6 +661,20 @@ class AsyncProtobufDeserializer(AsyncBaseDeserializer):
         return self.__deserialize(data, ctx)
 
     async def __deserialize(self, data: Optional[bytes], ctx: Optional[SerializationContext] = None) -> Optional[bytes]:
+        try:
+            if data is None:
+                return None
+            return await self.__deserialize_impl(data, ctx)
+        finally:
+            # Track the key for use when deserializing the value, such as for a DLQ
+            if ctx is not None and ctx.field == MessageField.KEY:
+                set_original_key(data)
+            else:
+                clear_original_key()
+
+    async def __deserialize_impl(
+        self, data: Optional[bytes], ctx: Optional[SerializationContext] = None
+    ) -> Optional[bytes]:
         """
         Deserialize a serialized protobuf message with Confluent Schema Registry
         framing.
@@ -707,7 +739,7 @@ class AsyncProtobufDeserializer(AsyncBaseDeserializer):
 
         if ctx is not None and subject is not None:
             payload = self._execute_rules_with_phase(
-                ctx, subject, RulePhase.ENCODING, RuleMode.READ, None, writer_schema_raw, payload, None, None
+                ctx, subject, RulePhase.ENCODING, RuleMode.READ, None, writer_schema_raw, payload, None, None, data
             )
         if isinstance(payload, bytes):
             payload = io.BytesIO(payload)
@@ -753,7 +785,7 @@ class AsyncProtobufDeserializer(AsyncBaseDeserializer):
 
         if ctx is not None and subject is not None:
             msg = self._execute_rules(
-                ctx, subject, RuleMode.READ, None, reader_schema_raw, msg, None, field_transformer
+                ctx, subject, RuleMode.READ, None, reader_schema_raw, msg, None, field_transformer, data
             )
         return msg
 

--- a/src/confluent_kafka/schema_registry/_async/serde.py
+++ b/src/confluent_kafka/schema_registry/_async/serde.py
@@ -527,8 +527,8 @@ class AsyncBaseSerde(object):
         return rule.disabled
 
     def _is_dlq_replay(self, ctx: RuleContext, rule: Rule) -> bool:
-        # If the rule name exists as a header, then we are processing a record from a DLQ.
-        # In that case, we don't want the same rule to fail again, so we skip it.
+        # A __rule.name header means this record came from a DLQ; skip that rule
+        # so it doesn't fail again.
         headers = ctx.ser_ctx.headers if ctx.ser_ctx is not None else None
         if not headers or rule.name is None:
             return False
@@ -592,28 +592,15 @@ class AsyncBaseSerde(object):
         return self._rule_registry.get_action(action_name)
 
     async def aclose(self):
-        # Release rule executors/actions that THIS serde uniquely owns so their
-        # resources (e.g. a DlqAction's Kafka producer) are flushed and released,
-        # by calling close() on each executor and action.
-        #
-        # A serde that uses the shared global RuleRegistry (the default when no
-        # dedicated rule_registry is supplied) must NOT close its members: the
-        # same executor/action objects are shared by every other default serde in
-        # the process, so closing them here would tear down resources still in use
-        # elsewhere (e.g. close another serde's KMS client, or flush and null out
-        # a live DlqAction producer). Global rule resources are process-lifetime;
-        # only a serde given its own registry owns and closes them.
-        #
-        # Under asyncio, DlqAction.close()'s producer.flush() briefly blocks the
-        # event loop.
+        # Close only the executors/actions this serde owns via a dedicated
+        # registry. Members of the shared global registry are process-lifetime and
+        # used by other serdes, so closing them here would tear down live resources.
         from confluent_kafka.schema_registry.rule_registry import RuleRegistry
 
         if self._rule_registry is None or self._rule_registry is RuleRegistry.get_global_instance():
             return
-        # Flush actions (e.g. the DlqAction producer) before closing executors,
-        # and isolate every close in its own try/except, so one failing member
-        # can never skip the others -- most importantly, a buggy executor must
-        # not cost us buffered DLQ records.
+        # Close actions before executors, each isolated so one failure can't skip
+        # the rest (a buggy executor must not cost buffered DLQ records).
         for action in self._rule_registry.get_actions():
             try:
                 action.close()

--- a/src/confluent_kafka/schema_registry/_async/serde.py
+++ b/src/confluent_kafka/schema_registry/_async/serde.py
@@ -29,6 +29,7 @@ from confluent_kafka.schema_registry import (
 )
 from confluent_kafka.schema_registry.common.schema_registry_client import RulePhase
 from confluent_kafka.schema_registry.common.serde import (
+    DLQ_RULE_NAME_HEADER,
     STRATEGY_TYPE_MAP,
     ErrorAction,
     FieldTransformer,
@@ -40,6 +41,7 @@ from confluent_kafka.schema_registry.common.serde import (
     RuleError,
     SchemaId,
     SubjectNameStrategyType,
+    get_original_key,
 )
 from confluent_kafka.schema_registry.error import SchemaRegistryError
 from confluent_kafka.schema_registry.schema_registry_client import Rule, RuleKind, RuleMode, RuleSet, Schema
@@ -360,9 +362,19 @@ class AsyncBaseSerde(object):
         message: Any,
         inline_tags: Optional[Dict[str, Set[str]]],
         field_transformer: Optional[FieldTransformer],
+        original_message: Any = None,
     ) -> Any:
         return self._execute_rules_with_phase(
-            ser_ctx, subject, RulePhase.DOMAIN, rule_mode, source, target, message, inline_tags, field_transformer
+            ser_ctx,
+            subject,
+            RulePhase.DOMAIN,
+            rule_mode,
+            source,
+            target,
+            message,
+            inline_tags,
+            field_transformer,
+            original_message,
         )
 
     def _execute_rules_with_phase(
@@ -376,9 +388,12 @@ class AsyncBaseSerde(object):
         message: Any,
         inline_tags: Optional[Dict[str, Set[str]]],
         field_transformer: Optional[FieldTransformer],
+        original_message: Any = None,
     ) -> Any:
         if message is None or target is None:
             return message
+        if original_message is None:
+            original_message = message
         enabled_env: Optional[str] = None
         rules: Optional[List[Rule]] = None
         if rule_mode == RuleMode.UPGRADE:
@@ -406,6 +421,10 @@ class AsyncBaseSerde(object):
         if not rules:
             return message
 
+        is_key = ser_ctx is not None and ser_ctx.field == MessageField.KEY
+        original_key = original_message if is_key else get_original_key()
+        original_value = None if is_key else original_message
+
         for index in range(len(rules)):
             rule = rules[index]
             ctx = RuleContext(
@@ -420,8 +439,12 @@ class AsyncBaseSerde(object):
                 rules,
                 inline_tags,
                 field_transformer,
+                original_key,
+                original_value,
             )
             if self._is_disabled(ctx, rule):
+                continue
+            if self._is_dlq_replay(ctx, rule):
                 continue
             if rule.mode == RuleMode.WRITEREAD:
                 if rule_mode != RuleMode.READ and rule_mode != RuleMode.WRITE:
@@ -503,6 +526,29 @@ class AsyncBaseSerde(object):
             return True
         return rule.disabled
 
+    def _is_dlq_replay(self, ctx: RuleContext, rule: Rule) -> bool:
+        # If the rule name exists as a header, then we are processing a record from a DLQ.
+        # In that case, we don't want the same rule to fail again, so we skip it.
+        headers = ctx.ser_ctx.headers if ctx.ser_ctx is not None else None
+        if not headers or rule.name is None:
+            return False
+        value: Any = None
+        if isinstance(headers, dict):
+            value = headers.get(DLQ_RULE_NAME_HEADER)
+        else:
+            for k, v in headers:
+                # last occurrence wins, matching Java's Headers.lastHeader
+                if k == DLQ_RULE_NAME_HEADER:
+                    value = v
+        if value is None:
+            return False
+        if isinstance(value, (bytes, bytearray)):
+            try:
+                value = value.decode('utf-8')
+            except UnicodeDecodeError:
+                return False
+        return value == rule.name
+
     def _run_action(
         self,
         ctx: RuleContext,
@@ -544,6 +590,31 @@ class AsyncBaseSerde(object):
         elif action_name == 'NONE':
             return NoneAction()
         return self._rule_registry.get_action(action_name)
+
+    async def aclose(self):
+        # Release rule executors/actions that THIS serde uniquely owns so their
+        # resources (e.g. a DlqAction's Kafka producer) are flushed and released.
+        # Mirrors the Java SerDe close(), which calls RuleBase.close() on each
+        # executor and action.
+        #
+        # A serde that uses the shared global RuleRegistry (the default when no
+        # dedicated rule_registry is supplied) must NOT close its members: the
+        # same executor/action objects are shared by every other default serde in
+        # the process, so closing them here would tear down resources still in use
+        # elsewhere (e.g. close another serde's KMS client, or flush and null out
+        # a live DlqAction producer). Global rule resources are process-lifetime;
+        # only a serde given its own registry owns and closes them. (Java owns
+        # per-serde executor/action instances, so its close() never faces this.)
+        #
+        # Under asyncio, DlqAction.close()'s producer.flush() briefly blocks the
+        # event loop; this mirrors the synchronous Java close().
+        from confluent_kafka.schema_registry.rule_registry import RuleRegistry
+
+        if self._rule_registry is not None and self._rule_registry is not RuleRegistry.get_global_instance():
+            for executor in self._rule_registry.get_executors():
+                executor.close()
+            for action in self._rule_registry.get_actions():
+                action.close()
 
 
 class AsyncBaseSerializer(AsyncBaseSerde, Serializer):

--- a/src/confluent_kafka/schema_registry/_async/serde.py
+++ b/src/confluent_kafka/schema_registry/_async/serde.py
@@ -537,7 +537,7 @@ class AsyncBaseSerde(object):
             value = headers.get(DLQ_RULE_NAME_HEADER)
         else:
             for k, v in headers:
-                # last occurrence wins, matching Java's Headers.lastHeader
+                # last occurrence wins when a header key repeats
                 if k == DLQ_RULE_NAME_HEADER:
                     value = v
         if value is None:
@@ -593,9 +593,8 @@ class AsyncBaseSerde(object):
 
     async def aclose(self):
         # Release rule executors/actions that THIS serde uniquely owns so their
-        # resources (e.g. a DlqAction's Kafka producer) are flushed and released.
-        # Mirrors the Java SerDe close(), which calls RuleBase.close() on each
-        # executor and action.
+        # resources (e.g. a DlqAction's Kafka producer) are flushed and released,
+        # by calling close() on each executor and action.
         #
         # A serde that uses the shared global RuleRegistry (the default when no
         # dedicated rule_registry is supplied) must NOT close its members: the
@@ -603,11 +602,10 @@ class AsyncBaseSerde(object):
         # the process, so closing them here would tear down resources still in use
         # elsewhere (e.g. close another serde's KMS client, or flush and null out
         # a live DlqAction producer). Global rule resources are process-lifetime;
-        # only a serde given its own registry owns and closes them. (Java owns
-        # per-serde executor/action instances, so its close() never faces this.)
+        # only a serde given its own registry owns and closes them.
         #
         # Under asyncio, DlqAction.close()'s producer.flush() briefly blocks the
-        # event loop; this mirrors the synchronous Java close().
+        # event loop.
         from confluent_kafka.schema_registry.rule_registry import RuleRegistry
 
         if self._rule_registry is not None and self._rule_registry is not RuleRegistry.get_global_instance():

--- a/src/confluent_kafka/schema_registry/_async/serde.py
+++ b/src/confluent_kafka/schema_registry/_async/serde.py
@@ -608,11 +608,22 @@ class AsyncBaseSerde(object):
         # event loop.
         from confluent_kafka.schema_registry.rule_registry import RuleRegistry
 
-        if self._rule_registry is not None and self._rule_registry is not RuleRegistry.get_global_instance():
-            for executor in self._rule_registry.get_executors():
-                executor.close()
-            for action in self._rule_registry.get_actions():
+        if self._rule_registry is None or self._rule_registry is RuleRegistry.get_global_instance():
+            return
+        # Flush actions (e.g. the DlqAction producer) before closing executors,
+        # and isolate every close in its own try/except, so one failing member
+        # can never skip the others -- most importantly, a buggy executor must
+        # not cost us buffered DLQ records.
+        for action in self._rule_registry.get_actions():
+            try:
                 action.close()
+            except Exception as e:
+                log.warning("Error closing rule action %s: %s", type(action).__name__, e)
+        for executor in self._rule_registry.get_executors():
+            try:
+                executor.close()
+            except Exception as e:
+                log.warning("Error closing rule executor %s: %s", type(executor).__name__, e)
 
 
 class AsyncBaseSerializer(AsyncBaseSerde, Serializer):

--- a/src/confluent_kafka/schema_registry/_sync/avro.py
+++ b/src/confluent_kafka/schema_registry/_sync/avro.py
@@ -44,8 +44,10 @@ from confluent_kafka.schema_registry.serde import (
     BaseSerializer,
     ParsedSchemaCache,
     SchemaId,
+    clear_original_key,
+    set_original_key,
 )
-from confluent_kafka.serialization import SerializationContext, SerializationError
+from confluent_kafka.serialization import MessageField, SerializationContext, SerializationError
 
 __all__ = [
     '_resolve_named_schema',
@@ -367,6 +369,8 @@ class AvroSerializer(BaseSerializer):
 
         for rule in self._rule_registry.get_executors():
             rule.configure(self._registry.config() if self._registry else {}, rule_conf if rule_conf else {})
+        for action in self._rule_registry.get_actions():
+            action.configure(self._registry.config() if self._registry else {}, rule_conf if rule_conf else {})
 
     __init__ = __init_impl
 
@@ -376,6 +380,18 @@ class AvroSerializer(BaseSerializer):
         return self.__serialize(obj, ctx)
 
     def __serialize(self, obj: object, ctx: Optional[SerializationContext] = None) -> Optional[bytes]:
+        try:
+            if obj is None:
+                return None
+            return self.__serialize_impl(obj, ctx)
+        finally:
+            # Track the key for use when serializing the value, such as for a DLQ
+            if ctx is not None and ctx.field == MessageField.KEY:
+                set_original_key(obj)
+            else:
+                clear_original_key()
+
+    def __serialize_impl(self, obj: object, ctx: Optional[SerializationContext] = None) -> Optional[bytes]:
         """
         Serializes an object to Avro binary format, prepending it with Confluent
         Schema Registry framing.
@@ -654,6 +670,8 @@ class AvroDeserializer(BaseDeserializer):
 
         for rule in self._rule_registry.get_executors():
             rule.configure(self._registry.config() if self._registry else {}, rule_conf if rule_conf else {})
+        for action in self._rule_registry.get_actions():
+            action.configure(self._registry.config() if self._registry else {}, rule_conf if rule_conf else {})
 
     __init__ = __init_impl
 
@@ -661,6 +679,20 @@ class AvroDeserializer(BaseDeserializer):
         return self.__deserialize(data, ctx)
 
     def __deserialize(
+        self, data: Optional[bytes], ctx: Optional[SerializationContext] = None
+    ) -> Union[dict, object, None]:
+        try:
+            if data is None:
+                return None
+            return self.__deserialize_impl(data, ctx)
+        finally:
+            # Track the key for use when deserializing the value, such as for a DLQ
+            if ctx is not None and ctx.field == MessageField.KEY:
+                set_original_key(data)
+            else:
+                clear_original_key()
+
+    def __deserialize_impl(
         self, data: Optional[bytes], ctx: Optional[SerializationContext] = None
     ) -> Union[dict, object, None]:
         """
@@ -725,7 +757,7 @@ class AvroDeserializer(BaseDeserializer):
 
         if ctx is not None and subject is not None:
             payload = self._execute_rules_with_phase(
-                ctx, subject, RulePhase.ENCODING, RuleMode.READ, None, writer_schema_raw, payload, None, None
+                ctx, subject, RulePhase.ENCODING, RuleMode.READ, None, writer_schema_raw, payload, None, None, data
             )
         if isinstance(payload, bytes):
             payload = io.BytesIO(payload)
@@ -771,7 +803,7 @@ class AvroDeserializer(BaseDeserializer):
         if ctx is not None and subject is not None:
             inline_tags = get_inline_tags(reader_schema) if reader_schema is not None else None
             obj_dict = self._execute_rules(
-                ctx, subject, RuleMode.READ, None, reader_schema_raw, obj_dict, inline_tags, field_transformer
+                ctx, subject, RuleMode.READ, None, reader_schema_raw, obj_dict, inline_tags, field_transformer, data
             )
 
         if self._from_dict is not None:

--- a/src/confluent_kafka/schema_registry/_sync/json_schema.py
+++ b/src/confluent_kafka/schema_registry/_sync/json_schema.py
@@ -49,8 +49,10 @@ from confluent_kafka.schema_registry.serde import (
     BaseSerializer,
     ParsedSchemaCache,
     SchemaId,
+    clear_original_key,
+    set_original_key,
 )
-from confluent_kafka.serialization import SerializationContext, SerializationError
+from confluent_kafka.serialization import MessageField, SerializationContext, SerializationError
 
 __all__ = ['_resolve_named_schema', 'JSONSerializer', 'JSONDeserializer']
 
@@ -337,6 +339,8 @@ class JSONSerializer(BaseSerializer):
 
         for rule in self._rule_registry.get_executors():
             rule.configure(self._registry.config() if self._registry else {}, rule_conf if rule_conf else {})
+        for action in self._rule_registry.get_actions():
+            action.configure(self._registry.config() if self._registry else {}, rule_conf if rule_conf else {})
 
     __init__ = __init_impl
 
@@ -346,6 +350,18 @@ class JSONSerializer(BaseSerializer):
         return self.__serialize(obj, ctx)
 
     def __serialize(self, obj: object, ctx: Optional[SerializationContext] = None) -> Optional[bytes]:
+        try:
+            if obj is None:
+                return None
+            return self.__serialize_impl(obj, ctx)
+        finally:
+            # Track the key for use when serializing the value, such as for a DLQ
+            if ctx is not None and ctx.field == MessageField.KEY:
+                set_original_key(obj)
+            else:
+                clear_original_key()
+
+    def __serialize_impl(self, obj: object, ctx: Optional[SerializationContext] = None) -> Optional[bytes]:
         """
         Serializes an object to JSON, prepending it with Confluent Schema Registry
         framing.
@@ -649,6 +665,8 @@ class JSONDeserializer(BaseDeserializer):
 
         for rule in self._rule_registry.get_executors():
             rule.configure(self._registry.config() if self._registry else {}, rule_conf if rule_conf else {})
+        for action in self._rule_registry.get_actions():
+            action.configure(self._registry.config() if self._registry else {}, rule_conf if rule_conf else {})
 
     __init__ = __init_impl
 
@@ -656,6 +674,18 @@ class JSONDeserializer(BaseDeserializer):
         return self.__deserialize(data, ctx)
 
     def __deserialize(self, data: Optional[bytes], ctx: Optional[SerializationContext] = None) -> Optional[bytes]:
+        try:
+            if data is None:
+                return None
+            return self.__deserialize_impl(data, ctx)
+        finally:
+            # Track the key for use when deserializing the value, such as for a DLQ
+            if ctx is not None and ctx.field == MessageField.KEY:
+                set_original_key(data)
+            else:
+                clear_original_key()
+
+    def __deserialize_impl(self, data: Optional[bytes], ctx: Optional[SerializationContext] = None) -> Optional[bytes]:
         """
         Deserialize a JSON encoded record with Confluent Schema Registry framing to
         a dict, or object instance according to from_dict if from_dict is specified.
@@ -706,7 +736,7 @@ class JSONDeserializer(BaseDeserializer):
 
         if ctx is not None and subject is not None:
             payload = self._execute_rules_with_phase(
-                ctx, subject, RulePhase.ENCODING, RuleMode.READ, None, writer_schema_raw, payload, None, None
+                ctx, subject, RulePhase.ENCODING, RuleMode.READ, None, writer_schema_raw, payload, None, None, data
             )
         if isinstance(payload, bytes):
             payload = io.BytesIO(payload)
@@ -746,7 +776,7 @@ class JSONDeserializer(BaseDeserializer):
 
             if ctx is not None and subject is not None:
                 obj_dict = self._execute_rules(
-                    ctx, subject, RuleMode.READ, None, reader_schema_raw, obj_dict, None, field_transformer
+                    ctx, subject, RuleMode.READ, None, reader_schema_raw, obj_dict, None, field_transformer, data
                 )
 
         if self._validate:

--- a/src/confluent_kafka/schema_registry/_sync/protobuf.py
+++ b/src/confluent_kafka/schema_registry/_sync/protobuf.py
@@ -51,8 +51,10 @@ from confluent_kafka.schema_registry.serde import (
     BaseSerializer,
     ParsedSchemaCache,
     SchemaId,
+    clear_original_key,
+    set_original_key,
 )
-from confluent_kafka.serialization import SerializationContext, SerializationError
+from confluent_kafka.serialization import MessageField, SerializationContext, SerializationError
 
 __all__ = [
     '_resolve_named_schema',
@@ -329,6 +331,8 @@ class ProtobufSerializer(BaseSerializer):
 
         for rule in self._rule_registry.get_executors():
             rule.configure(self._registry.config() if self._registry else {}, rule_conf if rule_conf else {})
+        for action in self._rule_registry.get_actions():
+            action.configure(self._registry.config() if self._registry else {}, rule_conf if rule_conf else {})
 
     __init__ = __init_impl
 
@@ -404,6 +408,18 @@ class ProtobufSerializer(BaseSerializer):
         return self.__serialize(message, ctx)
 
     def __serialize(self, message: Message, ctx: Optional[SerializationContext] = None) -> Optional[bytes]:
+        try:
+            if message is None:
+                return None
+            return self.__serialize_impl(message, ctx)
+        finally:
+            # Track the key for use when serializing the value, such as for a DLQ
+            if ctx is not None and ctx.field == MessageField.KEY:
+                set_original_key(message)
+            else:
+                clear_original_key()
+
+    def __serialize_impl(self, message: Message, ctx: Optional[SerializationContext] = None) -> Optional[bytes]:
         """
         Serializes an instance of a class derived from Protobuf Message, and prepends
         it with Confluent Schema Registry framing.
@@ -627,6 +643,8 @@ class ProtobufDeserializer(BaseDeserializer):
 
         for rule in self._rule_registry.get_executors():
             rule.configure(self._registry.config() if self._registry else {}, rule_conf if rule_conf else {})
+        for action in self._rule_registry.get_actions():
+            action.configure(self._registry.config() if self._registry else {}, rule_conf if rule_conf else {})
 
     __init__ = __init_impl
 
@@ -634,6 +652,18 @@ class ProtobufDeserializer(BaseDeserializer):
         return self.__deserialize(data, ctx)
 
     def __deserialize(self, data: Optional[bytes], ctx: Optional[SerializationContext] = None) -> Optional[bytes]:
+        try:
+            if data is None:
+                return None
+            return self.__deserialize_impl(data, ctx)
+        finally:
+            # Track the key for use when deserializing the value, such as for a DLQ
+            if ctx is not None and ctx.field == MessageField.KEY:
+                set_original_key(data)
+            else:
+                clear_original_key()
+
+    def __deserialize_impl(self, data: Optional[bytes], ctx: Optional[SerializationContext] = None) -> Optional[bytes]:
         """
         Deserialize a serialized protobuf message with Confluent Schema Registry
         framing.
@@ -696,7 +726,7 @@ class ProtobufDeserializer(BaseDeserializer):
 
         if ctx is not None and subject is not None:
             payload = self._execute_rules_with_phase(
-                ctx, subject, RulePhase.ENCODING, RuleMode.READ, None, writer_schema_raw, payload, None, None
+                ctx, subject, RulePhase.ENCODING, RuleMode.READ, None, writer_schema_raw, payload, None, None, data
             )
         if isinstance(payload, bytes):
             payload = io.BytesIO(payload)
@@ -742,7 +772,7 @@ class ProtobufDeserializer(BaseDeserializer):
 
         if ctx is not None and subject is not None:
             msg = self._execute_rules(
-                ctx, subject, RuleMode.READ, None, reader_schema_raw, msg, None, field_transformer
+                ctx, subject, RuleMode.READ, None, reader_schema_raw, msg, None, field_transformer, data
             )
         return msg
 

--- a/src/confluent_kafka/schema_registry/_sync/serde.py
+++ b/src/confluent_kafka/schema_registry/_sync/serde.py
@@ -537,7 +537,7 @@ class BaseSerde(object):
             value = headers.get(DLQ_RULE_NAME_HEADER)
         else:
             for k, v in headers:
-                # last occurrence wins, matching Java's Headers.lastHeader
+                # last occurrence wins when a header key repeats
                 if k == DLQ_RULE_NAME_HEADER:
                     value = v
         if value is None:
@@ -593,9 +593,8 @@ class BaseSerde(object):
 
     def close(self):
         # Release rule executors/actions that THIS serde uniquely owns so their
-        # resources (e.g. a DlqAction's Kafka producer) are flushed and released.
-        # Mirrors the Java SerDe close(), which calls RuleBase.close() on each
-        # executor and action.
+        # resources (e.g. a DlqAction's Kafka producer) are flushed and released,
+        # by calling close() on each executor and action.
         #
         # A serde that uses the shared global RuleRegistry (the default when no
         # dedicated rule_registry is supplied) must NOT close its members: the
@@ -603,11 +602,10 @@ class BaseSerde(object):
         # the process, so closing them here would tear down resources still in use
         # elsewhere (e.g. close another serde's KMS client, or flush and null out
         # a live DlqAction producer). Global rule resources are process-lifetime;
-        # only a serde given its own registry owns and closes them. (Java owns
-        # per-serde executor/action instances, so its close() never faces this.)
+        # only a serde given its own registry owns and closes them.
         #
         # Under asyncio, DlqAction.close()'s producer.flush() briefly blocks the
-        # event loop; this mirrors the synchronous Java close().
+        # event loop.
         from confluent_kafka.schema_registry.rule_registry import RuleRegistry
 
         if self._rule_registry is not None and self._rule_registry is not RuleRegistry.get_global_instance():

--- a/src/confluent_kafka/schema_registry/_sync/serde.py
+++ b/src/confluent_kafka/schema_registry/_sync/serde.py
@@ -527,8 +527,8 @@ class BaseSerde(object):
         return rule.disabled
 
     def _is_dlq_replay(self, ctx: RuleContext, rule: Rule) -> bool:
-        # If the rule name exists as a header, then we are processing a record from a DLQ.
-        # In that case, we don't want the same rule to fail again, so we skip it.
+        # A __rule.name header means this record came from a DLQ; skip that rule
+        # so it doesn't fail again.
         headers = ctx.ser_ctx.headers if ctx.ser_ctx is not None else None
         if not headers or rule.name is None:
             return False
@@ -592,28 +592,15 @@ class BaseSerde(object):
         return self._rule_registry.get_action(action_name)
 
     def close(self):
-        # Release rule executors/actions that THIS serde uniquely owns so their
-        # resources (e.g. a DlqAction's Kafka producer) are flushed and released,
-        # by calling close() on each executor and action.
-        #
-        # A serde that uses the shared global RuleRegistry (the default when no
-        # dedicated rule_registry is supplied) must NOT close its members: the
-        # same executor/action objects are shared by every other default serde in
-        # the process, so closing them here would tear down resources still in use
-        # elsewhere (e.g. close another serde's KMS client, or flush and null out
-        # a live DlqAction producer). Global rule resources are process-lifetime;
-        # only a serde given its own registry owns and closes them.
-        #
-        # Under asyncio, DlqAction.close()'s producer.flush() briefly blocks the
-        # event loop.
+        # Close only the executors/actions this serde owns via a dedicated
+        # registry. Members of the shared global registry are process-lifetime and
+        # used by other serdes, so closing them here would tear down live resources.
         from confluent_kafka.schema_registry.rule_registry import RuleRegistry
 
         if self._rule_registry is None or self._rule_registry is RuleRegistry.get_global_instance():
             return
-        # Flush actions (e.g. the DlqAction producer) before closing executors,
-        # and isolate every close in its own try/except, so one failing member
-        # can never skip the others -- most importantly, a buggy executor must
-        # not cost us buffered DLQ records.
+        # Close actions before executors, each isolated so one failure can't skip
+        # the rest (a buggy executor must not cost buffered DLQ records).
         for action in self._rule_registry.get_actions():
             try:
                 action.close()

--- a/src/confluent_kafka/schema_registry/_sync/serde.py
+++ b/src/confluent_kafka/schema_registry/_sync/serde.py
@@ -29,6 +29,7 @@ from confluent_kafka.schema_registry import (
 )
 from confluent_kafka.schema_registry.common.schema_registry_client import RulePhase
 from confluent_kafka.schema_registry.common.serde import (
+    DLQ_RULE_NAME_HEADER,
     STRATEGY_TYPE_MAP,
     ErrorAction,
     FieldTransformer,
@@ -40,6 +41,7 @@ from confluent_kafka.schema_registry.common.serde import (
     RuleError,
     SchemaId,
     SubjectNameStrategyType,
+    get_original_key,
 )
 from confluent_kafka.schema_registry.error import SchemaRegistryError
 from confluent_kafka.schema_registry.schema_registry_client import Rule, RuleKind, RuleMode, RuleSet, Schema
@@ -360,9 +362,19 @@ class BaseSerde(object):
         message: Any,
         inline_tags: Optional[Dict[str, Set[str]]],
         field_transformer: Optional[FieldTransformer],
+        original_message: Any = None,
     ) -> Any:
         return self._execute_rules_with_phase(
-            ser_ctx, subject, RulePhase.DOMAIN, rule_mode, source, target, message, inline_tags, field_transformer
+            ser_ctx,
+            subject,
+            RulePhase.DOMAIN,
+            rule_mode,
+            source,
+            target,
+            message,
+            inline_tags,
+            field_transformer,
+            original_message,
         )
 
     def _execute_rules_with_phase(
@@ -376,9 +388,12 @@ class BaseSerde(object):
         message: Any,
         inline_tags: Optional[Dict[str, Set[str]]],
         field_transformer: Optional[FieldTransformer],
+        original_message: Any = None,
     ) -> Any:
         if message is None or target is None:
             return message
+        if original_message is None:
+            original_message = message
         enabled_env: Optional[str] = None
         rules: Optional[List[Rule]] = None
         if rule_mode == RuleMode.UPGRADE:
@@ -406,6 +421,10 @@ class BaseSerde(object):
         if not rules:
             return message
 
+        is_key = ser_ctx is not None and ser_ctx.field == MessageField.KEY
+        original_key = original_message if is_key else get_original_key()
+        original_value = None if is_key else original_message
+
         for index in range(len(rules)):
             rule = rules[index]
             ctx = RuleContext(
@@ -420,8 +439,12 @@ class BaseSerde(object):
                 rules,
                 inline_tags,
                 field_transformer,
+                original_key,
+                original_value,
             )
             if self._is_disabled(ctx, rule):
+                continue
+            if self._is_dlq_replay(ctx, rule):
                 continue
             if rule.mode == RuleMode.WRITEREAD:
                 if rule_mode != RuleMode.READ and rule_mode != RuleMode.WRITE:
@@ -503,6 +526,29 @@ class BaseSerde(object):
             return True
         return rule.disabled
 
+    def _is_dlq_replay(self, ctx: RuleContext, rule: Rule) -> bool:
+        # If the rule name exists as a header, then we are processing a record from a DLQ.
+        # In that case, we don't want the same rule to fail again, so we skip it.
+        headers = ctx.ser_ctx.headers if ctx.ser_ctx is not None else None
+        if not headers or rule.name is None:
+            return False
+        value: Any = None
+        if isinstance(headers, dict):
+            value = headers.get(DLQ_RULE_NAME_HEADER)
+        else:
+            for k, v in headers:
+                # last occurrence wins, matching Java's Headers.lastHeader
+                if k == DLQ_RULE_NAME_HEADER:
+                    value = v
+        if value is None:
+            return False
+        if isinstance(value, (bytes, bytearray)):
+            try:
+                value = value.decode('utf-8')
+            except UnicodeDecodeError:
+                return False
+        return value == rule.name
+
     def _run_action(
         self,
         ctx: RuleContext,
@@ -544,6 +590,31 @@ class BaseSerde(object):
         elif action_name == 'NONE':
             return NoneAction()
         return self._rule_registry.get_action(action_name)
+
+    def close(self):
+        # Release rule executors/actions that THIS serde uniquely owns so their
+        # resources (e.g. a DlqAction's Kafka producer) are flushed and released.
+        # Mirrors the Java SerDe close(), which calls RuleBase.close() on each
+        # executor and action.
+        #
+        # A serde that uses the shared global RuleRegistry (the default when no
+        # dedicated rule_registry is supplied) must NOT close its members: the
+        # same executor/action objects are shared by every other default serde in
+        # the process, so closing them here would tear down resources still in use
+        # elsewhere (e.g. close another serde's KMS client, or flush and null out
+        # a live DlqAction producer). Global rule resources are process-lifetime;
+        # only a serde given its own registry owns and closes them. (Java owns
+        # per-serde executor/action instances, so its close() never faces this.)
+        #
+        # Under asyncio, DlqAction.close()'s producer.flush() briefly blocks the
+        # event loop; this mirrors the synchronous Java close().
+        from confluent_kafka.schema_registry.rule_registry import RuleRegistry
+
+        if self._rule_registry is not None and self._rule_registry is not RuleRegistry.get_global_instance():
+            for executor in self._rule_registry.get_executors():
+                executor.close()
+            for action in self._rule_registry.get_actions():
+                action.close()
 
 
 class BaseSerializer(BaseSerde, Serializer):

--- a/src/confluent_kafka/schema_registry/_sync/serde.py
+++ b/src/confluent_kafka/schema_registry/_sync/serde.py
@@ -608,11 +608,22 @@ class BaseSerde(object):
         # event loop.
         from confluent_kafka.schema_registry.rule_registry import RuleRegistry
 
-        if self._rule_registry is not None and self._rule_registry is not RuleRegistry.get_global_instance():
-            for executor in self._rule_registry.get_executors():
-                executor.close()
-            for action in self._rule_registry.get_actions():
+        if self._rule_registry is None or self._rule_registry is RuleRegistry.get_global_instance():
+            return
+        # Flush actions (e.g. the DlqAction producer) before closing executors,
+        # and isolate every close in its own try/except, so one failing member
+        # can never skip the others -- most importantly, a buggy executor must
+        # not cost us buffered DLQ records.
+        for action in self._rule_registry.get_actions():
+            try:
                 action.close()
+            except Exception as e:
+                log.warning("Error closing rule action %s: %s", type(action).__name__, e)
+        for executor in self._rule_registry.get_executors():
+            try:
+                executor.close()
+            except Exception as e:
+                log.warning("Error closing rule executor %s: %s", type(executor).__name__, e)
 
 
 class BaseSerializer(BaseSerde, Serializer):

--- a/src/confluent_kafka/schema_registry/common/serde.py
+++ b/src/confluent_kafka/schema_registry/common/serde.py
@@ -17,6 +17,7 @@
 #
 
 import abc
+import contextvars
 import io
 import logging
 import struct
@@ -51,6 +52,15 @@ __all__ = [
     'RuleAction',
     'ErrorAction',
     'NoneAction',
+    'DLQ_HEADER_PREFIX',
+    'DLQ_RULE_NAME_HEADER',
+    'DLQ_RULE_MODE_HEADER',
+    'DLQ_RULE_SUBJECT_HEADER',
+    'DLQ_RULE_TOPIC_HEADER',
+    'DLQ_RULE_EXCEPTION_HEADER',
+    'set_original_key',
+    'get_original_key',
+    'clear_original_key',
     'RuleError',
     'RuleConditionError',
     'Migration',
@@ -59,6 +69,38 @@ __all__ = [
 ]
 
 log = logging.getLogger(__name__)
+
+
+DLQ_HEADER_PREFIX = "__rule."
+DLQ_RULE_NAME_HEADER = DLQ_HEADER_PREFIX + "name"
+DLQ_RULE_MODE_HEADER = DLQ_HEADER_PREFIX + "mode"
+DLQ_RULE_SUBJECT_HEADER = DLQ_HEADER_PREFIX + "subject"
+DLQ_RULE_TOPIC_HEADER = DLQ_HEADER_PREFIX + "topic"
+DLQ_RULE_EXCEPTION_HEADER = DLQ_HEADER_PREFIX + "exception"
+
+
+# Tracks the key for use when serializing/deserializing the value, such as for a DLQ.
+# Relies on the key serde being invoked before the value serde in the same thread
+# (or asyncio task), as is the case when producing/consuming a message. This mirrors
+# the Java client's ThreadLocal and carries the same limitation: the key is captured
+# only when a Schema-Registry key serde runs before the value serde. If the key uses
+# a non-SR serializer (or none is configured), the value-side DLQ record's key is
+# None. To avoid leaking a stale key across messages, an SR value serde clears the
+# stashed key on entry (including for a None/tombstone value), so the next value
+# reads None unless its own key serde stashed a fresh key first.
+_ORIGINAL_KEY: contextvars.ContextVar[Any] = contextvars.ContextVar('sr_original_key', default=None)
+
+
+def set_original_key(key: Any):
+    _ORIGINAL_KEY.set(key)
+
+
+def get_original_key() -> Any:
+    return _ORIGINAL_KEY.get()
+
+
+def clear_original_key():
+    _ORIGINAL_KEY.set(None)
 
 
 class SubjectNameStrategyType(str, Enum):
@@ -134,6 +176,8 @@ class RuleContext(object):
         'rules',
         'inline_tags',
         'field_transformer',
+        'original_key',
+        'original_value',
         '_field_contexts',
     ]
 
@@ -150,6 +194,8 @@ class RuleContext(object):
         rules: List[Rule],
         inline_tags: Optional[Dict[str, Set[str]]],
         field_transformer,
+        original_key: Any = None,
+        original_value: Any = None,
     ):
         self.enabled_env = enabled_env
         self.ser_ctx = ser_ctx
@@ -162,6 +208,8 @@ class RuleContext(object):
         self.rules = rules
         self.inline_tags = inline_tags
         self.field_transformer = field_transformer
+        self.original_key = original_key
+        self.original_value = original_value
         self._field_contexts: List[FieldContext] = []
 
     def get_parameter(self, name: str) -> Optional[str]:

--- a/src/confluent_kafka/schema_registry/common/serde.py
+++ b/src/confluent_kafka/schema_registry/common/serde.py
@@ -81,13 +81,15 @@ DLQ_RULE_EXCEPTION_HEADER = DLQ_HEADER_PREFIX + "exception"
 
 # Tracks the key for use when serializing/deserializing the value, such as for a DLQ.
 # Relies on the key serde being invoked before the value serde in the same thread
-# (or asyncio task), as is the case when producing/consuming a message. This mirrors
-# the Java client's ThreadLocal and carries the same limitation: the key is captured
-# only when a Schema-Registry key serde runs before the value serde. If the key uses
-# a non-SR serializer (or none is configured), the value-side DLQ record's key is
-# None. To avoid leaking a stale key across messages, an SR value serde clears the
-# stashed key on entry (including for a None/tombstone value), so the next value
-# reads None unless its own key serde stashed a fresh key first.
+# (or asyncio task), as is the case when producing/consuming a message: the built-in
+# SerializingProducer, DeserializingConsumer and DeserializingShareConsumer all
+# process the key before the value. This mirrors the Java client's ThreadLocal and
+# carries the same limitation: the key is captured only when a Schema-Registry key
+# serde runs before the value serde. If the key uses a non-SR serializer (or none is
+# configured), the value-side DLQ record's key is None. To avoid leaking a stale key
+# across messages, an SR value serde clears the stashed key once it has finished
+# (including for a None/tombstone value), so a later value serde reads None unless a
+# fresh key was stashed by its own key serde first.
 _ORIGINAL_KEY: contextvars.ContextVar[Any] = contextvars.ContextVar('sr_original_key', default=None)
 
 

--- a/src/confluent_kafka/schema_registry/common/serde.py
+++ b/src/confluent_kafka/schema_registry/common/serde.py
@@ -83,9 +83,9 @@ DLQ_RULE_EXCEPTION_HEADER = DLQ_HEADER_PREFIX + "exception"
 # Relies on the key serde being invoked before the value serde in the same thread
 # (or asyncio task), as is the case when producing/consuming a message: the built-in
 # SerializingProducer, DeserializingConsumer and DeserializingShareConsumer all
-# process the key before the value. This mirrors the Java client's ThreadLocal and
-# carries the same limitation: the key is captured only when a Schema-Registry key
-# serde runs before the value serde. If the key uses a non-SR serializer (or none is
+# process the key before the value. A limitation of this approach: the key is
+# captured only when a Schema-Registry key serde runs before the value serde. If
+# the key uses a non-SR serializer (or none is
 # configured), the value-side DLQ record's key is None. To avoid leaking a stale key
 # across messages, an SR value serde clears the stashed key once it has finished
 # (including for a None/tombstone value), so a later value serde reads None unless a

--- a/src/confluent_kafka/schema_registry/common/serde.py
+++ b/src/confluent_kafka/schema_registry/common/serde.py
@@ -79,17 +79,10 @@ DLQ_RULE_TOPIC_HEADER = DLQ_HEADER_PREFIX + "topic"
 DLQ_RULE_EXCEPTION_HEADER = DLQ_HEADER_PREFIX + "exception"
 
 
-# Tracks the key for use when serializing/deserializing the value, such as for a DLQ.
-# Relies on the key serde being invoked before the value serde in the same thread
-# (or asyncio task), as is the case when producing/consuming a message: the built-in
-# SerializingProducer, DeserializingConsumer and DeserializingShareConsumer all
-# process the key before the value. A limitation of this approach: the key is
-# captured only when a Schema-Registry key serde runs before the value serde. If
-# the key uses a non-SR serializer (or none is
-# configured), the value-side DLQ record's key is None. To avoid leaking a stale key
-# across messages, an SR value serde clears the stashed key once it has finished
-# (including for a None/tombstone value), so a later value serde reads None unless a
-# fresh key was stashed by its own key serde first.
+# Holds the key for the value serde (e.g. the DLQ action), set by the key serde
+# earlier in the same thread/asyncio task. Captured only when an SR key serde runs
+# before the value serde; otherwise the value-side DLQ key is None. The value serde
+# clears it when done so a stale key isn't leaked to the next message.
 _ORIGINAL_KEY: contextvars.ContextVar[Any] = contextvars.ContextVar('sr_original_key', default=None)
 
 

--- a/src/confluent_kafka/schema_registry/rules/dlq/__init__.py
+++ b/src/confluent_kafka/schema_registry/rules/dlq/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2026 Confluent Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/src/confluent_kafka/schema_registry/rules/dlq/dlq_action.py
+++ b/src/confluent_kafka/schema_registry/rules/dlq/dlq_action.py
@@ -53,12 +53,8 @@ _INT64_MAX = 2**63 - 1
 
 
 class FieldRedactionExecutor(FieldRuleExecutor):
-    """
-    A field-level rule executor that replaces tagged STRING fields with
-    ``"<REDACTED>"`` and tagged BYTES fields with ``b"<REDACTED>"``; all other
-    field types pass through unchanged. Used by :class:`DlqAction` to redact
-    fields tagged by encryption rules before writing a record to the DLQ.
-    """
+    """Replaces tagged STRING/BYTES fields with ``<REDACTED>``; used by
+    :class:`DlqAction` to mask encrypted fields before writing to the DLQ."""
 
     TYPE = "REDACT"
 
@@ -89,114 +85,27 @@ class FieldRedactionExecutor(FieldRuleExecutor):
 
 class DlqAction(RuleAction):
     """
-    A rule action that sends the record being processed to a dead-letter-queue
-    topic when a rule fails, then raises a :class:`SerializationError`. The DLQ
-    is a tee, not a swallow: the original serialize/deserialize call still fails.
+    Rule action that tees the record to a dead-letter-queue topic when a rule
+    fails, then raises ``SerializationError`` (the original call still fails).
 
-    The DLQ record is built from the original key/value as they were at entry to
-    the current rule phase. On serialize (WRITE), structured values are converted
-    to JSON after redacting every field tagged by rules whose type is in
-    ``dlq.redact.rule.types`` (default ``ENCRYPT,ENCRYPT_PAYLOAD``), so plaintext
-    for encrypted fields does not leak to the DLQ. On deserialize (READ), the
-    original wire bytes are sent verbatim (for encrypted payloads this is
-    ciphertext, and the DLQ record can be re-consumed directly). Records consumed
-    from a DLQ topic carry a ``__rule.name`` header, which causes the previously
-    failed rule to be skipped on deserialization.
+    On WRITE, structured values are JSON-encoded after redacting fields tagged
+    by ``dlq.redact.rule.types`` (default ``ENCRYPT,ENCRYPT_PAYLOAD``); on READ
+    the original wire bytes are sent verbatim. DLQ records carry ``__rule.*``
+    headers, so the failed rule is skipped when they are re-consumed.
 
-    Configuration keys (constructor ``conf`` dict; ``dlq.*`` and ``producer``
-    may also be supplied via the serializer/deserializer ``rule_conf``):
+    Config keys (constructor ``conf``; ``dlq.*``/``producer`` may also come from
+    the serde ``rule_conf``):
 
-    +--------------------------+----------------------------------------------------+
-    | Property name            | Description                                        |
-    +==========================+====================================================+
-    | ``dlq.topic``            | DLQ topic (overridable per rule via a ``dlq.topic``|
-    |                          | rule parameter)                                    |
-    +--------------------------+----------------------------------------------------+
-    | ``dlq.auto.flush``       | Flush the producer after each DLQ send             |
-    +--------------------------+----------------------------------------------------+
-    | ``dlq.redact.rule.types``| Comma-separated rule types whose tagged fields are |
-    |                          | redacted; defaults to ``ENCRYPT,ENCRYPT_PAYLOAD``  |
-    +--------------------------+----------------------------------------------------+
-    | ``producer``             | A pre-built producer to use instead of creating one|
-    +--------------------------+----------------------------------------------------+
-    | any other key            | Passed to the internal librdkafka producer, e.g.   |
-    |                          | ``bootstrap.servers``, ``security.protocol``, ...  |
-    +--------------------------+----------------------------------------------------+
+    - ``dlq.topic``: DLQ topic (a per-rule ``dlq.topic`` parameter overrides it)
+    - ``dlq.auto.flush``: flush after every send
+    - ``dlq.redact.rule.types``: rule types whose tagged fields are redacted
+    - ``producer``: pre-built producer; any other key is passed to librdkafka
 
-    Producer configuration and encoding notes:
-
-    - The serde only receives the Schema Registry client config, not Kafka
-      producer properties, so producer connectivity must be given explicitly in
-      ``conf`` (``bootstrap.servers`` etc.). librdkafka rejects unknown
-      properties, so the Schema Registry config cannot be merged into the
-      producer conf.
-    - ``produce()`` is non-blocking: a full queue raises and is logged. The
-      producer uses ``message.timeout.ms=0`` (infinite), so records are retried
-      until delivered.
-    - ``int`` and ``float`` values are encoded as 8-byte big-endian.
-    - ``dlq.auto.flush`` blocks, which stalls the event loop under asyncio.
-
-    Failure behaviors: redaction failures are fail-open (the unredacted value is
-    sent, with an error logged). Redaction operates on a deep copy, so the
-    caller's message object is not mutated (this diverges from the Java client,
-    which redacts in place).
-
-    .. warning::
-
-        **Field-level redaction only applies to field-level rules (e.g.**
-        ``ENCRYPT`` **).** A payload-level ``ENCRYPT_PAYLOAD`` rule runs in the
-        ENCODING phase on the already-serialized buffer, which carries no field
-        tags, so nothing can be redacted. On a **serialize (WRITE)** failure --
-        for example a transient KMS/DEK outage -- the DLQ therefore receives the
-        **entire record as unencrypted plaintext**. If the DLQ topic is less
-        protected than the source topic, a KMS outage becomes a plaintext
-        exposure. Restrict access to the DLQ topic accordingly, or use
-        field-level ``ENCRYPT`` rules (which redact tagged fields) when the DLQ
-        must not hold plaintext. On the READ path the wire bytes are ciphertext,
-        so this exposure does not apply. This matches the Java client.
-
-    Shared instance / register-once semantics: a ``DlqAction`` is registered once
-    into a :class:`RuleRegistry` and shared by every serde bound to that registry
-    (typically the process-wide global registry). This single instance holds one
-    ``_conf`` and one producer. Consequently:
-
-    - ``configure()`` is called by every serde's constructor and merges the
-      serde's ``rule_conf`` ``dlq.*``/``producer`` keys into the shared ``_conf``
-      (last writer wins). Two serdes sharing one action with different
-      ``rule_conf`` (e.g. different ``dlq.topic``) will clobber each other; give a
-      serde its own :class:`RuleRegistry` (with its own ``DlqAction``) if it needs
-      an isolated DLQ config. A per-rule ``dlq.topic`` parameter (see the table)
-      is resolved per invocation and is unaffected.
-    - Because the action (and its producer) is shared and process-lifetime, a
-      per-serde :meth:`close`/``aclose`` does NOT close it when it lives in the
-      global registry; see :meth:`AsyncBaseSerde.aclose`.
-
-    Durability contract: DLQ sends are asynchronous, so records still queued in
-    the producer when the process exits are lost -- the producer is destroyed
-    without a flush. A serde bound to the *global* registry is never closed by
-    :meth:`close`/``aclose`` (see above), so with the default (global) registry
-    the DLQ is **best-effort**: records teed just before shutdown may be dropped.
-    Two ways to make it durable:
-
-    - Set ``dlq.auto.flush=true`` so :meth:`run` flushes after every send (the
-      record is delivered before the failing serialize/deserialize call returns).
-      This is the durability knob for the global/default registry.
-    - Give the serde its own :class:`RuleRegistry`; then ``serde.close()`` /
-      ``await serde.aclose()`` flushes and closes this action's producer. This is
-      the deterministic, ownership-based path.
-
-    Original-key capture limitation: the value-side DLQ record's ``key`` is taken
-    from the key stashed by the key serde via ``set_original_key`` (a contextvar).
-    This only works when a Schema-Registry key
-    serializer/deserializer runs before the value serde in the same thread/task.
-    The built-in ``SerializingProducer``, ``DeserializingConsumer`` and
-    ``DeserializingShareConsumer`` all process the key before the value, so the
-    key is captured when both key and value use SR serdes. If the key uses a
-    non-SR serializer, no key serializer is configured, or the key serde failed
-    before stashing, the value-side DLQ record's key will be ``None``. After a
-    value serde runs it clears the stashed key, so a stale key is not leaked to a
-    later value serde that has no key of its own; see ``get_original_key`` in
-    ``common/serde.py``.
+    With the global registry the DLQ is best-effort (a per-serde close does not
+    close the shared action); use ``dlq.auto.flush`` or a dedicated ``RuleRegistry``
+    for durability. ``ENCRYPT_PAYLOAD`` carries no field tags, so a WRITE failure
+    tees plaintext -- restrict DLQ access accordingly. Redaction runs on a deep
+    copy, so the caller's object is not mutated.
     """
 
     TYPE = "DLQ"
@@ -227,17 +136,9 @@ class DlqAction(RuleAction):
         return self.TYPE
 
     def configure(self, client_conf: dict, rule_conf: dict):
-        # client_conf is the Schema Registry client config, which contains no
-        # Kafka producer properties and cannot be merged into the producer conf
-        # (librdkafka rejects unknown properties), so it is not used here.
-        #
-        # This instance is shared across every serde bound to the same registry, so
-        # each serde's constructor calls configure() concurrently in the worst case.
-        # Hold the lock while mutating _conf (and deriving fields from it) so a
-        # concurrent _get_producer() -- which iterates _conf under the same lock --
-        # cannot observe a half-written config or raise "dict changed size during
-        # iteration". _parse_conf() must not take the lock (it is called here with
-        # the lock already held).
+        # Shared across serdes: hold the lock while mutating _conf so a concurrent
+        # _get_producer() can't observe a half-written config. client_conf carries
+        # no producer properties, so it is unused here.
         with self._lock:
             if rule_conf:
                 for key, value in rule_conf.items():
@@ -246,8 +147,7 @@ class DlqAction(RuleAction):
             self._parse_conf()
 
     def _parse_conf(self):
-        # Not thread-safe on its own; callers must hold self._lock (or be __init__,
-        # which runs before the instance is shared).
+        # Callers must hold self._lock (except __init__, which runs pre-share).
         self._topic = self._conf.get(self.DLQ_TOPIC)
         auto_flush = self._conf.get(self.DLQ_AUTO_FLUSH)
         if auto_flush is not None:
@@ -266,7 +166,7 @@ class DlqAction(RuleAction):
             'enable.idempotence': False,
             'acks': 'all',
             'max.in.flight.requests.per.connection': 1,
-            # 0 = infinite message timeout: records are retried until delivered
+            # 0 = infinite: retry until delivered
             'message.timeout.ms': 0,
         }
 
@@ -333,9 +233,8 @@ class DlqAction(RuleAction):
             return message.encode('utf-8')
         elif isinstance(message, uuid.UUID):
             return str(message).encode('utf-8')
-        # bool is excluded so that it falls through to the JSON path.
-        # Ints outside the signed int64 range also fall through to the JSON path
-        # rather than raising struct.error, which would abort the whole DLQ send.
+        # bool and out-of-int64-range ints fall through to the JSON path
+        # (packing the latter with '>q' would raise struct.error).
         elif isinstance(message, int) and not isinstance(message, bool) and _INT64_MIN <= message <= _INT64_MAX:
             return struct.pack('>q', message)
         elif isinstance(message, float):
@@ -372,11 +271,8 @@ class DlqAction(RuleAction):
                 None,
                 RuleKind.TRANSFORM,
                 ctx.rule_mode,
-                # Labelled with the DLQ action's own type, matching the Java client.
-                # This synthetic rule drives FieldRedactionExecutor.transform() directly
-                # (it is never looked up by type), and in the single-rule context below
-                # are_transforms_with_same_tag() is unreachable, so rule.type is never
-                # read. Kept equal to Java so any future type-based dispatch stays in sync.
+                # DLQ action's own type, matching Java; unused here (the executor
+                # is invoked directly, never looked up by type).
                 self.TYPE,
                 sorted(tags),
                 None,
@@ -400,12 +296,8 @@ class DlqAction(RuleAction):
                 ctx.original_key,
                 ctx.original_value,
             )
-            # Redact a copy so the caller's live object is never mutated: on a
-            # WRITE failure the message is the record the application still holds
-            # and may retry, and masking its fields in place would silently
-            # replace real (e.g. PII) values with "<REDACTED>". This diverges
-            # from the Java client, which redacts in place; the DLQ record bytes
-            # are identical either way, so cross-client behavior is unaffected.
+            # Redact a copy so the caller's object is not mutated (Java redacts
+            # in place; the DLQ bytes are identical either way).
             message = copy.deepcopy(message)
             executor = FieldRedactionExecutor()
             try:
@@ -454,9 +346,8 @@ class DlqAction(RuleAction):
         return str(value).encode('utf-8')
 
     def close(self):
-        # Detach the producer under the lock (so it can't race _get_producer /
-        # configure), then flush outside the lock: flush() can block for a long
-        # time (message.timeout.ms=0 is infinite) and must not stall other callers.
+        # Detach under the lock, then flush outside it: flush() can block
+        # indefinitely (message.timeout.ms=0) and must not stall other callers.
         with self._lock:
             producer = self._producer
             self._producer = None

--- a/src/confluent_kafka/schema_registry/rules/dlq/dlq_action.py
+++ b/src/confluent_kafka/schema_registry/rules/dlq/dlq_action.py
@@ -200,13 +200,24 @@ class DlqAction(RuleAction):
         # client_conf is the Schema Registry client config, which contains no
         # Kafka producer properties and cannot be merged into the producer conf
         # (librdkafka rejects unknown properties), so it is not used here.
-        if rule_conf:
-            for key, value in rule_conf.items():
-                if key == self.PRODUCER or key.startswith('dlq.'):
-                    self._conf[key] = value
-        self._parse_conf()
+        #
+        # This instance is shared across every serde bound to the same registry, so
+        # each serde's constructor calls configure() concurrently in the worst case.
+        # Hold the lock while mutating _conf (and deriving fields from it) so a
+        # concurrent _get_producer() -- which iterates _conf under the same lock --
+        # cannot observe a half-written config or raise "dict changed size during
+        # iteration". _parse_conf() must not take the lock (it is called here with
+        # the lock already held).
+        with self._lock:
+            if rule_conf:
+                for key, value in rule_conf.items():
+                    if key == self.PRODUCER or key.startswith('dlq.'):
+                        self._conf[key] = value
+            self._parse_conf()
 
     def _parse_conf(self):
+        # Not thread-safe on its own; callers must hold self._lock (or be __init__,
+        # which runs before the instance is shared).
         self._topic = self._conf.get(self.DLQ_TOPIC)
         auto_flush = self._conf.get(self.DLQ_AUTO_FLUSH)
         if auto_flush is not None:
@@ -401,9 +412,14 @@ class DlqAction(RuleAction):
         return str(value).encode('utf-8')
 
     def close(self):
-        if self._producer is not None:
-            self._producer.flush()
+        # Detach the producer under the lock (so it can't race _get_producer /
+        # configure), then flush outside the lock: flush() can block for a long
+        # time (message.timeout.ms=0 is infinite) and must not stall other callers.
+        with self._lock:
+            producer = self._producer
             self._producer = None
+        if producer is not None:
+            producer.flush()
 
     @classmethod
     def register(cls, conf: Optional[dict] = None) -> 'DlqAction':

--- a/src/confluent_kafka/schema_registry/rules/dlq/dlq_action.py
+++ b/src/confluent_kafka/schema_registry/rules/dlq/dlq_action.py
@@ -161,11 +161,14 @@ class DlqAction(RuleAction):
     Original-key capture limitation: the value-side DLQ record's ``key`` is taken
     from the key stashed by the key serde via ``set_original_key`` (a contextvar,
     mirroring Java's ThreadLocal). This only works when a Schema-Registry key
-    serializer/deserializer runs before the value serde in the same thread/task. If
-    the key uses a non-SR serializer, no key serializer is configured, or the key
-    serde failed before stashing, the value-side DLQ record's key will be ``None``.
-    A value serde clears any stashed key on entry, so a stale key is not leaked
-    across messages by an SR value serde; see ``get_original_key`` in
+    serializer/deserializer runs before the value serde in the same thread/task.
+    The built-in ``SerializingProducer``, ``DeserializingConsumer`` and
+    ``DeserializingShareConsumer`` all process the key before the value, so the
+    key is captured when both key and value use SR serdes. If the key uses a
+    non-SR serializer, no key serializer is configured, or the key serde failed
+    before stashing, the value-side DLQ record's key will be ``None``. After a
+    value serde runs it clears the stashed key, so a stale key is not leaked to a
+    later value serde that has no key of its own; see ``get_original_key`` in
     ``common/serde.py``.
     """
 

--- a/src/confluent_kafka/schema_registry/rules/dlq/dlq_action.py
+++ b/src/confluent_kafka/schema_registry/rules/dlq/dlq_action.py
@@ -1,0 +1,412 @@
+# Copyright 2026 Confluent Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+import logging
+import struct
+import threading
+import uuid
+from typing import Any, Callable, Dict, List, Optional, Set, Tuple, Union
+
+from confluent_kafka import Producer
+from confluent_kafka.schema_registry.rule_registry import RuleRegistry
+from confluent_kafka.schema_registry.schema_registry_client import Rule, RuleKind
+from confluent_kafka.schema_registry.serde import (
+    DLQ_HEADER_PREFIX,
+    DLQ_RULE_EXCEPTION_HEADER,
+    DLQ_RULE_MODE_HEADER,
+    DLQ_RULE_NAME_HEADER,
+    DLQ_RULE_SUBJECT_HEADER,
+    DLQ_RULE_TOPIC_HEADER,
+    FieldContext,
+    FieldRuleExecutor,
+    FieldTransform,
+    FieldType,
+    RuleAction,
+    RuleContext,
+)
+from confluent_kafka.serialization import SerializationError
+
+__all__ = [
+    'FieldRedactionExecutor',
+    'DlqAction',
+]
+
+log = logging.getLogger(__name__)
+
+# Bounds of a signed 64-bit integer; ints outside this range cannot be packed
+# with struct '>q' and are sent via the JSON path instead.
+_INT64_MIN = -(2**63)
+_INT64_MAX = 2**63 - 1
+
+
+class FieldRedactionExecutor(FieldRuleExecutor):
+    """
+    A field-level rule executor that replaces tagged STRING fields with
+    ``"<REDACTED>"`` and tagged BYTES fields with ``b"<REDACTED>"``; all other
+    field types pass through unchanged. Used by :class:`DlqAction` to redact
+    fields tagged by encryption rules before writing a record to the DLQ.
+    """
+
+    TYPE = "REDACT"
+
+    REDACTED_STRING = "<REDACTED>"
+    REDACTED_BYTES = REDACTED_STRING.encode('utf-8')
+
+    def type(self) -> str:
+        return self.TYPE
+
+    def new_transform(self, ctx: RuleContext) -> FieldTransform:
+        def _redact(ctx: RuleContext, field_ctx: FieldContext, field_value: Any) -> Any:
+            if field_value is None:
+                return None
+            if field_ctx.field_type == FieldType.STRING:
+                return FieldRedactionExecutor.REDACTED_STRING
+            elif field_ctx.field_type == FieldType.BYTES:
+                return FieldRedactionExecutor.REDACTED_BYTES
+            return field_value
+
+        return _redact
+
+    @classmethod
+    def register(cls) -> 'FieldRedactionExecutor':
+        executor = cls()
+        RuleRegistry.register_rule_executor(executor)
+        return executor
+
+
+class DlqAction(RuleAction):
+    """
+    A rule action that sends the record being processed to a dead-letter-queue
+    topic when a rule fails, then raises a :class:`SerializationError`. The DLQ
+    is a tee, not a swallow: the original serialize/deserialize call still fails.
+
+    The DLQ record is built from the original key/value as they were at entry to
+    the current rule phase. On serialize (WRITE), structured values are converted
+    to JSON after redacting every field tagged by rules whose type is in
+    ``dlq.redact.rule.types`` (default ``ENCRYPT,ENCRYPT_PAYLOAD``), so plaintext
+    for encrypted fields does not leak to the DLQ. On deserialize (READ), the
+    original wire bytes are sent verbatim (for encrypted payloads this is
+    ciphertext, and the DLQ record can be re-consumed directly). Records consumed
+    from a DLQ topic carry a ``__rule.name`` header, which causes the previously
+    failed rule to be skipped on deserialization.
+
+    Configuration keys (constructor ``conf`` dict; ``dlq.*`` and ``producer``
+    may also be supplied via the serializer/deserializer ``rule_conf``):
+
+    +--------------------------+----------------------------------------------------+
+    | Property name            | Description                                        |
+    +==========================+====================================================+
+    | ``dlq.topic``            | DLQ topic (overridable per rule via a ``dlq.topic``|
+    |                          | rule parameter)                                    |
+    +--------------------------+----------------------------------------------------+
+    | ``dlq.auto.flush``       | Flush the producer after each DLQ send             |
+    +--------------------------+----------------------------------------------------+
+    | ``dlq.redact.rule.types``| Comma-separated rule types whose tagged fields are |
+    |                          | redacted; defaults to ``ENCRYPT,ENCRYPT_PAYLOAD``  |
+    +--------------------------+----------------------------------------------------+
+    | ``producer``             | A pre-built producer to use instead of creating one|
+    +--------------------------+----------------------------------------------------+
+    | any other key            | Passed to the internal librdkafka producer, e.g.   |
+    |                          | ``bootstrap.servers``, ``security.protocol``, ...  |
+    +--------------------------+----------------------------------------------------+
+
+    Differences from the Java client, forced by the platform:
+
+    - Java serializers receive the producer's config map, so the Java DlqAction
+      inherits ``bootstrap.servers`` etc. automatically. Python serdes only see
+      the Schema Registry client config, so producer connectivity must be given
+      explicitly in ``conf`` (librdkafka also rejects unknown properties, so the
+      Schema Registry config cannot be merged in).
+    - Java's ``max.block.ms``/``delivery.timeout.ms`` map to a non-blocking
+      ``produce()`` (a full queue raises and is logged) and
+      ``message.timeout.ms=0`` (infinite).
+    - Python ``int``/``float`` are encoded as 8-byte big-endian (Java picks the
+      width from the boxed type).
+    - ``dlq.auto.flush`` blocks, which stalls the event loop under asyncio.
+
+    Behaviors intentionally matching Java: redaction failures are fail-open (the
+    unredacted value is sent, with an error logged); redaction mutates the failed
+    message in place; ``ENCRYPT_PAYLOAD`` failures on serialize send the plaintext
+    serialized bytes verbatim (payload-level rules carry no field tags to redact).
+
+    Shared instance / register-once semantics (differs from Java): a ``DlqAction``
+    is registered once into a :class:`RuleRegistry` and shared by every serde bound
+    to that registry (typically the process-wide global registry). Unlike the Java
+    client, which owns a per-serde action instance, this instance holds a single
+    ``_conf``/producer. Consequently:
+
+    - ``configure()`` is called by every serde's constructor and merges the
+      serde's ``rule_conf`` ``dlq.*``/``producer`` keys into the shared ``_conf``
+      (last writer wins). Two serdes sharing one action with different
+      ``rule_conf`` (e.g. different ``dlq.topic``) will clobber each other; give a
+      serde its own :class:`RuleRegistry` (with its own ``DlqAction``) if it needs
+      an isolated DLQ config. A per-rule ``dlq.topic`` parameter (see the table)
+      is resolved per invocation and is unaffected.
+    - Because the action (and its producer) is shared and process-lifetime, a
+      per-serde :meth:`close`/``aclose`` does NOT close it when it lives in the
+      global registry; see :meth:`AsyncBaseSerde.aclose`.
+
+    Original-key capture limitation: the value-side DLQ record's ``key`` is taken
+    from the key stashed by the key serde via ``set_original_key`` (a contextvar,
+    mirroring Java's ThreadLocal). This only works when a Schema-Registry key
+    serializer/deserializer runs before the value serde in the same thread/task. If
+    the key uses a non-SR serializer, no key serializer is configured, or the key
+    serde failed before stashing, the value-side DLQ record's key will be ``None``.
+    A value serde clears any stashed key on entry, so a stale key is not leaked
+    across messages by an SR value serde; see ``get_original_key`` in
+    ``common/serde.py``.
+    """
+
+    TYPE = "DLQ"
+
+    DLQ_TOPIC = "dlq.topic"
+    DLQ_AUTO_FLUSH = "dlq.auto.flush"
+    DLQ_REDACT_RULE_TYPES = "dlq.redact.rule.types"
+    DLQ_REDACT_RULE_TYPES_DEFAULT = "ENCRYPT,ENCRYPT_PAYLOAD"
+    PRODUCER = "producer"  # for testing
+
+    HEADER_PREFIX = DLQ_HEADER_PREFIX
+    RULE_NAME = DLQ_RULE_NAME_HEADER
+    RULE_MODE = DLQ_RULE_MODE_HEADER
+    RULE_SUBJECT = DLQ_RULE_SUBJECT_HEADER
+    RULE_TOPIC = DLQ_RULE_TOPIC_HEADER
+    RULE_EXCEPTION = DLQ_RULE_EXCEPTION_HEADER
+
+    def __init__(self, conf: Optional[dict] = None):
+        self._conf: Dict[str, Any] = dict(conf) if conf else {}
+        self._lock = threading.Lock()
+        self._topic: Optional[str] = None
+        self._auto_flush = False
+        self._redact_rule_types: List[str] = []
+        self._producer: Optional[Producer] = None
+        self._parse_conf()
+
+    def type(self) -> str:
+        return self.TYPE
+
+    def configure(self, client_conf: dict, rule_conf: dict):
+        # client_conf is the Schema Registry client config, which contains no
+        # Kafka producer properties and cannot be merged into the producer conf
+        # (librdkafka rejects unknown properties), so it is not used here.
+        if rule_conf:
+            for key, value in rule_conf.items():
+                if key == self.PRODUCER or key.startswith('dlq.'):
+                    self._conf[key] = value
+        self._parse_conf()
+
+    def _parse_conf(self):
+        self._topic = self._conf.get(self.DLQ_TOPIC)
+        auto_flush = self._conf.get(self.DLQ_AUTO_FLUSH)
+        if auto_flush is not None:
+            self._auto_flush = str(auto_flush).lower() == 'true'
+        redact_rule_types = self._conf.get(self.DLQ_REDACT_RULE_TYPES)
+        if redact_rule_types is None:
+            redact_rule_types = self.DLQ_REDACT_RULE_TYPES_DEFAULT
+        self._redact_rule_types = [s.strip() for s in str(redact_rule_types).split(',')]
+        producer = self._conf.get(self.PRODUCER)
+        if producer is not None:
+            self._producer = producer
+
+    @staticmethod
+    def _base_producer_conf() -> Dict[str, Any]:
+        return {
+            'enable.idempotence': False,
+            'acks': 'all',
+            'max.in.flight.requests.per.connection': 1,
+            # librdkafka equivalent of Java's delivery.timeout.ms=MAX; 0 is infinite
+            'message.timeout.ms': 0,
+        }
+
+    def _get_producer(self) -> Producer:
+        if self._producer is None:
+            with self._lock:
+                if self._producer is None:
+                    producer_conf = self._base_producer_conf()
+                    for key, value in self._conf.items():
+                        if key == self.PRODUCER or key.startswith('dlq.'):
+                            continue
+                        producer_conf[key] = value
+                    self._producer = Producer(producer_conf)
+        return self._producer
+
+    def run(self, ctx: RuleContext, message: Any, ex: Optional[Exception]):
+        topic = self._topic
+        if not topic:
+            topic = ctx.get_parameter(self.DLQ_TOPIC)
+        if not topic:
+            raise SerializationError("Could not send to DLQ as no topic is configured")
+        try:
+            key_bytes = self._convert_to_bytes(ctx, ctx.original_key)
+            value_bytes = self._convert_to_bytes(ctx, ctx.original_value)
+            headers = self._populate_headers(ctx, ex)
+            producer = self._get_producer()
+            producer.produce(
+                topic,
+                key=key_bytes,
+                value=value_bytes,
+                headers=headers,
+                on_delivery=self._on_delivery(topic),
+            )
+            producer.poll(0)
+            if self._auto_flush:
+                producer.flush()
+        except Exception as e:
+            log.error("Could not produce message to DLQ topic %s: %s", topic, e)
+        msg = f"Rule failed: {ctx.rule.name}"
+        if ex is not None:
+            raise SerializationError(msg) from ex
+        raise SerializationError(msg)
+
+    @staticmethod
+    def _on_delivery(topic: str) -> Callable[[Any, Any], None]:
+        def callback(err: Any, _msg: Any):
+            if err is not None:
+                log.error("Could not produce message to DLQ topic %s: %s", topic, err)
+            else:
+                log.info("Sent message to DLQ topic %s", topic)
+
+        return callback
+
+    def _convert_to_bytes(self, ctx: RuleContext, message: Any) -> Optional[bytes]:
+        if message is None:
+            return None
+        elif isinstance(message, bytes):
+            return message
+        elif isinstance(message, bytearray):
+            return bytes(message)
+        elif isinstance(message, memoryview):
+            return message.tobytes()
+        elif isinstance(message, str):
+            return message.encode('utf-8')
+        elif isinstance(message, uuid.UUID):
+            return str(message).encode('utf-8')
+        # bool is excluded so that it falls through to the JSON path, as in Java.
+        # Ints outside the signed int64 range also fall through to the JSON path
+        # rather than raising struct.error, which would abort the whole DLQ send.
+        elif isinstance(message, int) and not isinstance(message, bool) and _INT64_MIN <= message <= _INT64_MAX:
+            return struct.pack('>q', message)
+        elif isinstance(message, float):
+            return struct.pack('>d', message)
+        else:
+            return self._convert_to_json_bytes(ctx, message)
+
+    def _convert_to_json_bytes(self, ctx: RuleContext, message: Any) -> bytes:
+        message = self._redact_fields(ctx, message)
+        if hasattr(message, 'DESCRIPTOR'):
+            # protobuf is an optional dependency, so only import it when the
+            # message is a protobuf Message
+            from google.protobuf import json_format
+
+            return json_format.MessageToJson(message).encode('utf-8')
+        return json.dumps(message, default=self._json_default).encode('utf-8')
+
+    @staticmethod
+    def _json_default(obj: Any) -> str:
+        if isinstance(obj, (bytes, bytearray)):
+            # matches the ISO-8859-1 rendering of bytes in the Java client
+            return bytes(obj).decode('latin-1')
+        return str(obj)
+
+    def _redact_fields(self, ctx: RuleContext, message: Any) -> Any:
+        redact_rules = self._get_rules_to_redact(ctx)
+        if not redact_rules:
+            # No rules require redaction
+            return message
+        try:
+            tags = self._get_tags_to_redact(redact_rules)
+            new_rule = Rule(
+                'redact',
+                None,
+                RuleKind.TRANSFORM,
+                ctx.rule_mode,
+                self.TYPE,
+                sorted(tags),
+                None,
+                None,
+                None,
+                None,
+                False,
+            )
+            new_ctx = RuleContext(
+                ctx.enabled_env,
+                ctx.ser_ctx,
+                ctx.source,
+                ctx.target,
+                ctx.subject,
+                ctx.rule_mode,
+                new_rule,
+                0,
+                [new_rule],
+                ctx.inline_tags,
+                ctx.field_transformer,
+                ctx.original_key,
+                ctx.original_value,
+            )
+            executor = FieldRedactionExecutor()
+            try:
+                return executor.transform(new_ctx, message)
+            finally:
+                executor.close()
+        except Exception as e:
+            log.error("Could not redact fields: %s", e)
+            return message
+
+    def _get_rules_to_redact(self, ctx: RuleContext) -> List[Rule]:
+        return [rule for rule in (ctx.rules or []) if rule.type in self._redact_rule_types]
+
+    @staticmethod
+    def _get_tags_to_redact(redact_rules: List[Rule]) -> Set[str]:
+        tags: Set[str] = set()
+        for rule in redact_rules:
+            if rule.tags:
+                tags.update(rule.tags)
+        return tags
+
+    def _populate_headers(self, ctx: RuleContext, ex: Optional[Exception]) -> List[Tuple[str, Union[str, bytes, None]]]:
+        headers: List[Tuple[str, Union[str, bytes, None]]] = []
+        incoming = ctx.ser_ctx.headers if ctx.ser_ctx is not None else None
+        if incoming:
+            if isinstance(incoming, dict):
+                headers.extend((k, self._to_header_bytes(v)) for k, v in incoming.items())
+            else:
+                headers.extend((k, self._to_header_bytes(v)) for k, v in incoming)
+        headers.append((self.RULE_NAME, self._to_header_bytes(ctx.rule.name)))
+        headers.append((self.RULE_MODE, self._to_header_bytes(ctx.rule_mode.value if ctx.rule_mode else None)))
+        headers.append((self.RULE_SUBJECT, self._to_header_bytes(ctx.subject)))
+        headers.append((self.RULE_TOPIC, self._to_header_bytes(ctx.ser_ctx.topic if ctx.ser_ctx else None)))
+        if ex is not None:
+            headers.append((self.RULE_EXCEPTION, self._to_header_bytes(str(ex))))
+        return headers
+
+    @staticmethod
+    def _to_header_bytes(value: Any) -> Optional[bytes]:
+        if value is None:
+            return None
+        if isinstance(value, bytes):
+            return value
+        if isinstance(value, bytearray):
+            return bytes(value)
+        return str(value).encode('utf-8')
+
+    def close(self):
+        if self._producer is not None:
+            self._producer.flush()
+            self._producer = None
+
+    @classmethod
+    def register(cls, conf: Optional[dict] = None) -> 'DlqAction':
+        action = cls(conf)
+        RuleRegistry.register_rule_action(action)
+        return action

--- a/src/confluent_kafka/schema_registry/rules/dlq/dlq_action.py
+++ b/src/confluent_kafka/schema_registry/rules/dlq/dlq_action.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import copy
 import json
 import logging
 import struct
@@ -136,9 +137,23 @@ class DlqAction(RuleAction):
     - ``dlq.auto.flush`` blocks, which stalls the event loop under asyncio.
 
     Failure behaviors: redaction failures are fail-open (the unredacted value is
-    sent, with an error logged); redaction mutates the failed message in place;
-    an ``ENCRYPT_PAYLOAD`` failure on serialize sends the plaintext serialized
-    bytes verbatim (payload-level rules carry no field tags to redact).
+    sent, with an error logged). Redaction operates on a deep copy, so the
+    caller's message object is not mutated (this diverges from the Java client,
+    which redacts in place).
+
+    .. warning::
+
+        **Field-level redaction only applies to field-level rules (e.g.**
+        ``ENCRYPT`` **).** A payload-level ``ENCRYPT_PAYLOAD`` rule runs in the
+        ENCODING phase on the already-serialized buffer, which carries no field
+        tags, so nothing can be redacted. On a **serialize (WRITE)** failure --
+        for example a transient KMS/DEK outage -- the DLQ therefore receives the
+        **entire record as unencrypted plaintext**. If the DLQ topic is less
+        protected than the source topic, a KMS outage becomes a plaintext
+        exposure. Restrict access to the DLQ topic accordingly, or use
+        field-level ``ENCRYPT`` rules (which redact tagged fields) when the DLQ
+        must not hold plaintext. On the READ path the wire bytes are ciphertext,
+        so this exposure does not apply. This matches the Java client.
 
     Shared instance / register-once semantics: a ``DlqAction`` is registered once
     into a :class:`RuleRegistry` and shared by every serde bound to that registry
@@ -380,6 +395,13 @@ class DlqAction(RuleAction):
                 ctx.original_key,
                 ctx.original_value,
             )
+            # Redact a copy so the caller's live object is never mutated: on a
+            # WRITE failure the message is the record the application still holds
+            # and may retry, and masking its fields in place would silently
+            # replace real (e.g. PII) values with "<REDACTED>". This diverges
+            # from the Java client, which redacts in place; the DLQ record bytes
+            # are identical either way, so cross-client behavior is unaffected.
+            message = copy.deepcopy(message)
             executor = FieldRedactionExecutor()
             try:
                 return executor.transform(new_ctx, message)

--- a/src/confluent_kafka/schema_registry/rules/dlq/dlq_action.py
+++ b/src/confluent_kafka/schema_registry/rules/dlq/dlq_action.py
@@ -372,6 +372,11 @@ class DlqAction(RuleAction):
                 None,
                 RuleKind.TRANSFORM,
                 ctx.rule_mode,
+                # Labelled with the DLQ action's own type, matching the Java client.
+                # This synthetic rule drives FieldRedactionExecutor.transform() directly
+                # (it is never looked up by type), and in the single-rule context below
+                # are_transforms_with_same_tag() is unreachable, so rule.type is never
+                # read. Kept equal to Java so any future type-based dispatch stays in sync.
                 self.TYPE,
                 sorted(tags),
                 None,

--- a/src/confluent_kafka/schema_registry/rules/dlq/dlq_action.py
+++ b/src/confluent_kafka/schema_registry/rules/dlq/dlq_action.py
@@ -122,30 +122,28 @@ class DlqAction(RuleAction):
     |                          | ``bootstrap.servers``, ``security.protocol``, ...  |
     +--------------------------+----------------------------------------------------+
 
-    Differences from the Java client, forced by the platform:
+    Producer configuration and encoding notes:
 
-    - Java serializers receive the producer's config map, so the Java DlqAction
-      inherits ``bootstrap.servers`` etc. automatically. Python serdes only see
-      the Schema Registry client config, so producer connectivity must be given
-      explicitly in ``conf`` (librdkafka also rejects unknown properties, so the
-      Schema Registry config cannot be merged in).
-    - Java's ``max.block.ms``/``delivery.timeout.ms`` map to a non-blocking
-      ``produce()`` (a full queue raises and is logged) and
-      ``message.timeout.ms=0`` (infinite).
-    - Python ``int``/``float`` are encoded as 8-byte big-endian (Java picks the
-      width from the boxed type).
+    - The serde only receives the Schema Registry client config, not Kafka
+      producer properties, so producer connectivity must be given explicitly in
+      ``conf`` (``bootstrap.servers`` etc.). librdkafka rejects unknown
+      properties, so the Schema Registry config cannot be merged into the
+      producer conf.
+    - ``produce()`` is non-blocking: a full queue raises and is logged. The
+      producer uses ``message.timeout.ms=0`` (infinite), so records are retried
+      until delivered.
+    - ``int`` and ``float`` values are encoded as 8-byte big-endian.
     - ``dlq.auto.flush`` blocks, which stalls the event loop under asyncio.
 
-    Behaviors intentionally matching Java: redaction failures are fail-open (the
-    unredacted value is sent, with an error logged); redaction mutates the failed
-    message in place; ``ENCRYPT_PAYLOAD`` failures on serialize send the plaintext
-    serialized bytes verbatim (payload-level rules carry no field tags to redact).
+    Failure behaviors: redaction failures are fail-open (the unredacted value is
+    sent, with an error logged); redaction mutates the failed message in place;
+    an ``ENCRYPT_PAYLOAD`` failure on serialize sends the plaintext serialized
+    bytes verbatim (payload-level rules carry no field tags to redact).
 
-    Shared instance / register-once semantics (differs from Java): a ``DlqAction``
-    is registered once into a :class:`RuleRegistry` and shared by every serde bound
-    to that registry (typically the process-wide global registry). Unlike the Java
-    client, which owns a per-serde action instance, this instance holds a single
-    ``_conf``/producer. Consequently:
+    Shared instance / register-once semantics: a ``DlqAction`` is registered once
+    into a :class:`RuleRegistry` and shared by every serde bound to that registry
+    (typically the process-wide global registry). This single instance holds one
+    ``_conf`` and one producer. Consequently:
 
     - ``configure()`` is called by every serde's constructor and merges the
       serde's ``rule_conf`` ``dlq.*``/``producer`` keys into the shared ``_conf``
@@ -158,9 +156,23 @@ class DlqAction(RuleAction):
       per-serde :meth:`close`/``aclose`` does NOT close it when it lives in the
       global registry; see :meth:`AsyncBaseSerde.aclose`.
 
+    Durability contract: DLQ sends are asynchronous, so records still queued in
+    the producer when the process exits are lost -- the producer is destroyed
+    without a flush. A serde bound to the *global* registry is never closed by
+    :meth:`close`/``aclose`` (see above), so with the default (global) registry
+    the DLQ is **best-effort**: records teed just before shutdown may be dropped.
+    Two ways to make it durable:
+
+    - Set ``dlq.auto.flush=true`` so :meth:`run` flushes after every send (the
+      record is delivered before the failing serialize/deserialize call returns).
+      This is the durability knob for the global/default registry.
+    - Give the serde its own :class:`RuleRegistry`; then ``serde.close()`` /
+      ``await serde.aclose()`` flushes and closes this action's producer. This is
+      the deterministic, ownership-based path.
+
     Original-key capture limitation: the value-side DLQ record's ``key`` is taken
-    from the key stashed by the key serde via ``set_original_key`` (a contextvar,
-    mirroring Java's ThreadLocal). This only works when a Schema-Registry key
+    from the key stashed by the key serde via ``set_original_key`` (a contextvar).
+    This only works when a Schema-Registry key
     serializer/deserializer runs before the value serde in the same thread/task.
     The built-in ``SerializingProducer``, ``DeserializingConsumer`` and
     ``DeserializingShareConsumer`` all process the key before the value, so the
@@ -239,7 +251,7 @@ class DlqAction(RuleAction):
             'enable.idempotence': False,
             'acks': 'all',
             'max.in.flight.requests.per.connection': 1,
-            # librdkafka equivalent of Java's delivery.timeout.ms=MAX; 0 is infinite
+            # 0 = infinite message timeout: records are retried until delivered
             'message.timeout.ms': 0,
         }
 
@@ -306,7 +318,7 @@ class DlqAction(RuleAction):
             return message.encode('utf-8')
         elif isinstance(message, uuid.UUID):
             return str(message).encode('utf-8')
-        # bool is excluded so that it falls through to the JSON path, as in Java.
+        # bool is excluded so that it falls through to the JSON path.
         # Ints outside the signed int64 range also fall through to the JSON path
         # rather than raising struct.error, which would abort the whole DLQ send.
         elif isinstance(message, int) and not isinstance(message, bool) and _INT64_MIN <= message <= _INT64_MAX:
@@ -329,7 +341,7 @@ class DlqAction(RuleAction):
     @staticmethod
     def _json_default(obj: Any) -> str:
         if isinstance(obj, (bytes, bytearray)):
-            # matches the ISO-8859-1 rendering of bytes in the Java client
+            # render bytes as an ISO-8859-1 (latin-1) string
             return bytes(obj).decode('latin-1')
         return str(obj)
 

--- a/src/confluent_kafka/schema_registry/rules/encryption/encrypt_executor.py
+++ b/src/confluent_kafka/schema_registry/rules/encryption/encrypt_executor.py
@@ -542,8 +542,11 @@ class FieldEncryptionExecutor(FieldRuleExecutor):
         return transform.transform
 
     def close(self):
-        if self.client is not None:
-            self.client.__exit__()
+        # Delegate to the wrapped EncryptionExecutor, which owns the
+        # DekRegistryClient (self.executor.client). This executor holds no
+        # client of its own, so referencing self.client here would raise
+        # AttributeError.
+        self.executor.close()
 
     @classmethod
     def register(cls):

--- a/src/confluent_kafka/schema_registry/rules/encryption/encrypt_executor.py
+++ b/src/confluent_kafka/schema_registry/rules/encryption/encrypt_executor.py
@@ -542,10 +542,8 @@ class FieldEncryptionExecutor(FieldRuleExecutor):
         return transform.transform
 
     def close(self):
-        # Delegate to the wrapped EncryptionExecutor, which owns the
-        # DekRegistryClient (self.executor.client). This executor holds no
-        # client of its own, so referencing self.client here would raise
-        # AttributeError.
+        # Delegate to the wrapped EncryptionExecutor, which owns the client;
+        # this executor has none of its own.
         self.executor.close()
 
     @classmethod

--- a/tests/integration/schema_registry/_async/test_dlq.py
+++ b/tests/integration/schema_registry/_async/test_dlq.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Copyright 2026 Confluent Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+import json
+
+import pytest
+
+from confluent_kafka import TopicPartition
+from confluent_kafka.schema_registry import Schema
+from confluent_kafka.schema_registry.avro import AsyncAvroDeserializer, AsyncAvroSerializer
+from confluent_kafka.schema_registry.rules.cel.cel_executor import CelExecutor
+from confluent_kafka.schema_registry.rules.dlq.dlq_action import DlqAction
+from confluent_kafka.schema_registry.schema_registry_client import Rule, RuleKind, RuleMode, RuleSet
+from confluent_kafka.serialization import MessageField, SerializationContext, SerializationError
+
+_SCHEMA = {
+    'type': 'record',
+    'name': 'test',
+    'fields': [
+        {'name': 'intField', 'type': 'int'},
+        {'name': 'stringField', 'type': 'string'},
+    ],
+}
+
+
+async def test_dlq_read_failure_and_replay(kafka_cluster):
+    """
+    A failing READ rule with on_failure=DLQ tees the original record to the DLQ
+    topic and still raises; the teed record is replayable because the
+    __rule.name header skips the previously failed rule.
+
+    Args:
+        kafka_cluster (KafkaClusterFixture): cluster fixture
+    """
+    CelExecutor.register()
+
+    topic = kafka_cluster.create_topic_and_wait_propogation("dlq-source")
+    dlq_topic = kafka_cluster.create_topic_and_wait_propogation("dlq-dead-letter")
+    sr = kafka_cluster.async_schema_registry()
+
+    rule = Rule(
+        "test-cel",
+        "",
+        RuleKind.CONDITION,
+        RuleMode.READ,
+        "CEL",
+        None,
+        None,
+        "message.stringField != 'hi'",
+        None,
+        "DLQ",
+        False,
+    )
+    await sr.register_schema(topic + "-value", Schema(json.dumps(_SCHEMA), "AVRO", [], None, RuleSet(None, [rule])))
+
+    client_conf = kafka_cluster.client_conf()
+    DlqAction.register(
+        {
+            'dlq.topic': dlq_topic,
+            'dlq.auto.flush': True,
+            'bootstrap.servers': client_conf['bootstrap.servers'],
+        }
+    )
+
+    ser_conf = {'auto.register.schemas': False, 'use.latest.version': True}
+    ser = await AsyncAvroSerializer(sr, schema_str=None, conf=ser_conf)
+    ser_ctx = SerializationContext(topic, MessageField.VALUE)
+    obj = {'intField': 123, 'stringField': 'hi'}
+    obj_bytes = await ser(obj, ser_ctx)
+
+    deser = await AsyncAvroDeserializer(sr)
+    with pytest.raises(SerializationError, match="Rule failed: test-cel"):
+        await deser(obj_bytes, ser_ctx)
+
+    consumer = kafka_cluster.async_consumer()
+    consumer.assign([TopicPartition(dlq_topic, 0)])
+    msg = await consumer.poll()
+    # the original wire bytes were teed verbatim
+    assert msg.value() == obj_bytes
+    headers = dict(msg.headers())
+    assert headers[DlqAction.RULE_NAME] == b'test-cel'
+    assert headers[DlqAction.RULE_MODE] == b'READ'
+    assert headers[DlqAction.RULE_SUBJECT] == (topic + "-value").encode('utf-8')
+    assert headers[DlqAction.RULE_TOPIC] == topic.encode('utf-8')
+    assert DlqAction.RULE_EXCEPTION in headers
+
+    # replaying the DLQ record does not fail again on the same rule
+    replay_ctx = SerializationContext(topic, MessageField.VALUE, msg.headers())
+    obj2 = await deser(msg.value(), replay_ctx)
+    assert obj2 == obj

--- a/tests/integration/schema_registry/_sync/test_dlq.py
+++ b/tests/integration/schema_registry/_sync/test_dlq.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Copyright 2026 Confluent Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+import json
+
+import pytest
+
+from confluent_kafka import TopicPartition
+from confluent_kafka.schema_registry import Schema
+from confluent_kafka.schema_registry.avro import AvroDeserializer, AvroSerializer
+from confluent_kafka.schema_registry.rules.cel.cel_executor import CelExecutor
+from confluent_kafka.schema_registry.rules.dlq.dlq_action import DlqAction
+from confluent_kafka.schema_registry.schema_registry_client import Rule, RuleKind, RuleMode, RuleSet
+from confluent_kafka.serialization import MessageField, SerializationContext, SerializationError
+
+_SCHEMA = {
+    'type': 'record',
+    'name': 'test',
+    'fields': [
+        {'name': 'intField', 'type': 'int'},
+        {'name': 'stringField', 'type': 'string'},
+    ],
+}
+
+
+def test_dlq_read_failure_and_replay(kafka_cluster):
+    """
+    A failing READ rule with on_failure=DLQ tees the original record to the DLQ
+    topic and still raises; the teed record is replayable because the
+    __rule.name header skips the previously failed rule.
+
+    Args:
+        kafka_cluster (KafkaClusterFixture): cluster fixture
+    """
+    CelExecutor.register()
+
+    topic = kafka_cluster.create_topic_and_wait_propogation("dlq-source")
+    dlq_topic = kafka_cluster.create_topic_and_wait_propogation("dlq-dead-letter")
+    sr = kafka_cluster.schema_registry()
+
+    rule = Rule(
+        "test-cel",
+        "",
+        RuleKind.CONDITION,
+        RuleMode.READ,
+        "CEL",
+        None,
+        None,
+        "message.stringField != 'hi'",
+        None,
+        "DLQ",
+        False,
+    )
+    sr.register_schema(topic + "-value", Schema(json.dumps(_SCHEMA), "AVRO", [], None, RuleSet(None, [rule])))
+
+    client_conf = kafka_cluster.client_conf()
+    DlqAction.register(
+        {
+            'dlq.topic': dlq_topic,
+            'dlq.auto.flush': True,
+            'bootstrap.servers': client_conf['bootstrap.servers'],
+        }
+    )
+
+    ser_conf = {'auto.register.schemas': False, 'use.latest.version': True}
+    ser = AvroSerializer(sr, schema_str=None, conf=ser_conf)
+    ser_ctx = SerializationContext(topic, MessageField.VALUE)
+    obj = {'intField': 123, 'stringField': 'hi'}
+    obj_bytes = ser(obj, ser_ctx)
+
+    deser = AvroDeserializer(sr)
+    with pytest.raises(SerializationError, match="Rule failed: test-cel"):
+        deser(obj_bytes, ser_ctx)
+
+    consumer = kafka_cluster.consumer()
+    consumer.assign([TopicPartition(dlq_topic, 0)])
+    msg = consumer.poll()
+    # the original wire bytes were teed verbatim
+    assert msg.value() == obj_bytes
+    headers = dict(msg.headers())
+    assert headers[DlqAction.RULE_NAME] == b'test-cel'
+    assert headers[DlqAction.RULE_MODE] == b'READ'
+    assert headers[DlqAction.RULE_SUBJECT] == (topic + "-value").encode('utf-8')
+    assert headers[DlqAction.RULE_TOPIC] == topic.encode('utf-8')
+    assert DlqAction.RULE_EXCEPTION in headers
+
+    # replaying the DLQ record does not fail again on the same rule
+    replay_ctx = SerializationContext(topic, MessageField.VALUE, msg.headers())
+    obj2 = deser(msg.value(), replay_ctx)
+    assert obj2 == obj

--- a/tests/schema_registry/_async/test_dlq_serdes.py
+++ b/tests/schema_registry/_async/test_dlq_serdes.py
@@ -202,8 +202,8 @@ async def test_avro_dlq_encryption_write_redaction():
     assert headers_dict[DlqAction.RULE_SUBJECT] == _SUBJECT.encode('utf-8')
     assert headers_dict[DlqAction.RULE_TOPIC] == _TOPIC.encode('utf-8')
     assert DlqAction.RULE_EXCEPTION in headers_dict
-    # redaction mutates the failed message in place
-    assert obj['stringField'] == FieldRedactionExecutor.REDACTED_STRING
+    # redaction runs on a copy: the caller's object keeps its original value
+    assert obj['stringField'] == 'hi'
 
 
 async def test_avro_dlq_encryption_read_ciphertext_and_replay_skip():
@@ -335,6 +335,56 @@ async def test_serializer_close_flushes_dlq_and_closes_executors():
     await ser.aclose()
     assert producer.flush_count == 1
     assert spy.closed is True
+
+
+async def test_field_encryption_executor_close_does_not_raise():
+    # Regression: FieldEncryptionExecutor.close() used to reference a
+    # non-existent self.client and raise AttributeError; it must delegate to the
+    # wrapped EncryptionExecutor. An unconfigured executor closes cleanly.
+    FieldEncryptionExecutor().close()  # must not raise
+
+
+async def test_serializer_close_with_real_encryption_executor_flushes_dlq():
+    # The DLQ_DESIGN "durable shutdown" path: a dedicated registry holding a real
+    # FieldEncryptionExecutor plus a DlqAction. Closing the serde must close the
+    # encryption executor without raising AND still flush the DLQ producer.
+    conf = {'url': _BASE_URL}
+    client = AsyncSchemaRegistryClient.new_client(conf)
+
+    producer = RecordingProducer()
+    registry = RuleRegistry()
+    registry.register_executor(FieldEncryptionExecutor(FakeClock()))
+    registry.register_action(DlqAction({'dlq.topic': _DLQ_TOPIC, 'producer': producer}))
+
+    ser = await AsyncAvroSerializer(
+        client, schema_str='"string"', conf={'auto.register.schemas': True}, rule_registry=registry
+    )
+    await ser.aclose()  # must not raise
+    assert producer.flush_count == 1
+
+
+async def test_close_isolates_failing_executor_and_still_flushes_dlq():
+    # Regression: a failing executor.close() must not abort shutdown before the
+    # DlqAction is flushed. Actions are flushed first and every close is isolated,
+    # so buffered DLQ records survive a buggy executor.
+    conf = {'url': _BASE_URL}
+    client = AsyncSchemaRegistryClient.new_client(conf)
+
+    producer = RecordingProducer()
+    registry = RuleRegistry()
+
+    class _BoomExecutor(FieldRedactionExecutor):
+        def close(self):
+            raise RuntimeError("boom")
+
+    registry.register_executor(_BoomExecutor())
+    registry.register_action(DlqAction({'dlq.topic': _DLQ_TOPIC, 'producer': producer}))
+
+    ser = await AsyncAvroSerializer(
+        client, schema_str='"string"', conf={'auto.register.schemas': True}, rule_registry=registry
+    )
+    await ser.aclose()  # must not raise despite the failing executor
+    assert producer.flush_count == 1
 
 
 async def test_serializer_close_does_not_close_shared_global_registry():
@@ -604,5 +654,5 @@ async def test_proto_dlq_encryption_write_redaction():
     assert base64.b64encode(b'foobar') not in value
     assert b'<REDACTED>' in value
     assert b'The Castle' in value
-    # redaction mutates the failed message in place
-    assert obj.name == FieldRedactionExecutor.REDACTED_STRING
+    # redaction runs on a copy: the caller's object keeps its original value
+    assert obj.name == 'Kafka'

--- a/tests/schema_registry/_async/test_dlq_serdes.py
+++ b/tests/schema_registry/_async/test_dlq_serdes.py
@@ -1,0 +1,608 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Copyright 2026 Confluent Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+import base64
+import json
+import os
+import sys
+import time
+
+import pytest
+
+from confluent_kafka.schema_registry import AsyncSchemaRegistryClient, Schema
+from confluent_kafka.schema_registry._async.json_schema import AsyncJSONSerializer
+from confluent_kafka.schema_registry._async.protobuf import AsyncProtobufSerializer
+from confluent_kafka.schema_registry.avro import AsyncAvroDeserializer, AsyncAvroSerializer
+from confluent_kafka.schema_registry.common.serde import clear_original_key, get_original_key
+from confluent_kafka.schema_registry.protobuf import _schema_to_str
+from confluent_kafka.schema_registry.rule_registry import RuleOverride, RuleRegistry
+from confluent_kafka.schema_registry.rules.cel.cel_executor import CelExecutor
+from confluent_kafka.schema_registry.rules.dlq.dlq_action import DlqAction, FieldRedactionExecutor
+from confluent_kafka.schema_registry.rules.encryption.encrypt_executor import (
+    Clock,
+    EncryptionExecutor,
+    FieldEncryptionExecutor,
+)
+from confluent_kafka.schema_registry.rules.encryption.localkms.local_driver import LocalKmsDriver
+from confluent_kafka.schema_registry.schema_registry_client import Rule, RuleKind, RuleMode, RuleParams, RuleSet
+from confluent_kafka.serialization import MessageField, SerializationContext, SerializationError
+
+# Add proto directory to sys.path to resolve protobuf import dependencies
+proto_path = os.path.join(os.path.dirname(os.path.dirname(__file__)), 'data', 'proto')
+if proto_path not in sys.path:
+    sys.path.insert(0, proto_path)
+
+from tests.schema_registry.data.proto import example_pb2  # noqa: E402
+
+
+class FakeClock(Clock):
+
+    def __init__(self):
+        self.fixed_now = int(round(time.time() * 1000))
+
+    def now(self) -> int:
+        return self.fixed_now
+
+
+class RecordingProducer:
+    def __init__(self):
+        self.records = []
+        self.flush_count = 0
+
+    def produce(self, topic, value=None, key=None, headers=None, on_delivery=None, **kwargs):
+        self.records.append((topic, key, value, headers))
+
+    def poll(self, timeout=0):
+        return 0
+
+    def flush(self, timeout=None):
+        self.flush_count += 1
+        return 0
+
+
+_BASE_URL = "mock://"
+_TOPIC = "topic1"
+_SUBJECT = _TOPIC + "-value"
+_DLQ_TOPIC = "dlq-topic"
+
+_AVRO_SCHEMA = {
+    'type': 'record',
+    'name': 'test',
+    'fields': [
+        {'name': 'intField', 'type': 'int'},
+        {'name': 'doubleField', 'type': 'double'},
+        {'name': 'stringField', 'type': 'string', 'confluent:tags': ['PII']},
+        {'name': 'booleanField', 'type': 'boolean'},
+        {'name': 'bytesField', 'type': 'bytes', 'confluent:tags': ['PII']},
+    ],
+}
+
+
+def _avro_obj():
+    return {
+        'intField': 123,
+        'doubleField': 45.67,
+        'stringField': 'hi',
+        'booleanField': True,
+        'bytesField': b'foobar',
+    }
+
+
+def _encrypt_rule(kms_type='local-kms', rule_type='ENCRYPT', tags=None, on_failure="ERROR,NONE", extra_params=None):
+    params = {"encrypt.kek.name": "kek1", "encrypt.kms.type": kms_type, "encrypt.kms.key.id": "mykey"}
+    if extra_params:
+        params.update(extra_params)
+    if tags is None and rule_type == 'ENCRYPT':
+        tags = ["PII"]
+    return Rule(
+        "test-encrypt",
+        "",
+        RuleKind.TRANSFORM,
+        RuleMode.WRITEREAD,
+        rule_type,
+        tags,
+        RuleParams(params),
+        None,
+        None,
+        on_failure,
+        False,
+    )
+
+
+def _cel_fail_rule(mode, on_failure, params=None):
+    return Rule(
+        "test-cel",
+        "",
+        RuleKind.CONDITION,
+        mode,
+        "CEL",
+        None,
+        RuleParams(params) if params is not None else None,
+        "message.stringField != 'hi'",
+        None,
+        on_failure,
+        False,
+    )
+
+
+def _register_dlq_action(topic=_DLQ_TOPIC):
+    producer = RecordingProducer()
+    conf = {'producer': producer}
+    if topic is not None:
+        conf['dlq.topic'] = topic
+    DlqAction.register(conf)
+    return producer
+
+
+@pytest.fixture(autouse=True)
+async def run_before_and_after_tests(tmpdir):
+    """Fixture to execute asserts before and after a test is run"""
+    CelExecutor.register()
+    LocalKmsDriver.register()
+
+    yield  # this is where the testing happens
+
+    conf = {'url': _BASE_URL}
+    client = AsyncSchemaRegistryClient.new_client(conf)
+    subjects = await client.get_subjects()
+    for subject in subjects:
+        try:
+            await client.delete_subject(subject, True)
+        except Exception:
+            pass
+
+
+async def test_avro_dlq_encryption_write_redaction():
+    FieldEncryptionExecutor.register_with_clock(FakeClock())
+    producer = _register_dlq_action()
+
+    conf = {'url': _BASE_URL}
+    client = AsyncSchemaRegistryClient.new_client(conf)
+    ser_conf = {'auto.register.schemas': False, 'use.latest.version': True}
+    rule_conf = {'secret': 'mysecret'}
+    rule = _encrypt_rule(kms_type='bad-kms', on_failure="DLQ,NONE")
+    await client.register_schema(_SUBJECT, Schema(json.dumps(_AVRO_SCHEMA), "AVRO", [], None, RuleSet(None, [rule])))
+
+    obj = _avro_obj()
+    ser = await AsyncAvroSerializer(client, schema_str=None, conf=ser_conf, rule_conf=rule_conf)
+    ser_ctx = SerializationContext(_TOPIC, MessageField.VALUE)
+    with pytest.raises(SerializationError, match="Rule failed: test-encrypt"):
+        await ser(obj, ser_ctx)
+
+    assert len(producer.records) == 1
+    topic, key, value, headers = producer.records[0]
+    assert topic == _DLQ_TOPIC
+    assert key is None
+    # tagged fields are redacted, so no plaintext leaks to the DLQ
+    dlq_value = json.loads(value)
+    assert dlq_value['stringField'] == FieldRedactionExecutor.REDACTED_STRING
+    assert dlq_value['bytesField'] == FieldRedactionExecutor.REDACTED_STRING
+    assert b'"hi"' not in value
+    assert b'foobar' not in value
+    # untagged fields are passed through
+    assert dlq_value['intField'] == 123
+    assert dlq_value['booleanField'] is True
+    headers_dict = dict(headers)
+    assert headers_dict[DlqAction.RULE_NAME] == b'test-encrypt'
+    assert headers_dict[DlqAction.RULE_MODE] == b'WRITE'
+    assert headers_dict[DlqAction.RULE_SUBJECT] == _SUBJECT.encode('utf-8')
+    assert headers_dict[DlqAction.RULE_TOPIC] == _TOPIC.encode('utf-8')
+    assert DlqAction.RULE_EXCEPTION in headers_dict
+    # redaction mutates the failed message in place, as in Java
+    assert obj['stringField'] == FieldRedactionExecutor.REDACTED_STRING
+
+
+async def test_avro_dlq_encryption_read_ciphertext_and_replay_skip():
+    FieldEncryptionExecutor.register_with_clock(FakeClock())
+    producer = _register_dlq_action()
+
+    conf = {'url': _BASE_URL}
+    client = AsyncSchemaRegistryClient.new_client(conf)
+    ser_conf = {'auto.register.schemas': False, 'use.latest.version': True}
+    rule_conf = {'secret': 'mysecret'}
+    rule = _encrypt_rule(on_failure="ERROR,DLQ")
+    await client.register_schema(_SUBJECT, Schema(json.dumps(_AVRO_SCHEMA), "AVRO", [], None, RuleSet(None, [rule])))
+
+    obj = _avro_obj()
+    ser = await AsyncAvroSerializer(client, schema_str=None, conf=ser_conf, rule_conf=rule_conf)
+    ser_ctx = SerializationContext(_TOPIC, MessageField.VALUE)
+    obj_bytes = await ser(obj, ser_ctx)
+    # encryption succeeded, so nothing went to the DLQ
+    assert producer.records == []
+
+    # a fresh executor (as in a separate consumer process) has an empty DEK
+    # registry, so decryption fails
+    FieldEncryptionExecutor.register_with_clock(FakeClock())
+    deser = await AsyncAvroDeserializer(client, rule_conf=rule_conf)
+    with pytest.raises(SerializationError, match="Rule failed: test-encrypt"):
+        await deser(obj_bytes, ser_ctx)
+
+    assert len(producer.records) == 1
+    topic, key, value, headers = producer.records[0]
+    assert key is None
+    # the original wire bytes (ciphertext) are sent verbatim, so the DLQ record is replayable
+    assert value == obj_bytes
+    assert dict(headers)[DlqAction.RULE_MODE] == b'READ'
+
+    # a record consumed from the DLQ carries a __rule.name header, which skips
+    # the previously failed rule so the replay does not fail again
+    replay_ctx = SerializationContext(_TOPIC, MessageField.VALUE, [(DlqAction.RULE_NAME, b'test-encrypt')])
+    obj2 = await deser(obj_bytes, replay_ctx)
+    assert obj2['intField'] == 123
+    # the rule was skipped, so the tagged fields still hold ciphertext
+    assert obj2['stringField'] != 'hi'
+
+    # dict-shaped headers are also supported
+    replay_ctx = SerializationContext(_TOPIC, MessageField.VALUE, {DlqAction.RULE_NAME: b'test-encrypt'})
+    obj3 = await deser(obj_bytes, replay_ctx)
+    assert obj3['intField'] == 123
+
+
+async def test_avro_dlq_with_key():
+    FieldEncryptionExecutor.register_with_clock(FakeClock())
+    producer = _register_dlq_action()
+
+    conf = {'url': _BASE_URL}
+    client = AsyncSchemaRegistryClient.new_client(conf)
+    ser_conf = {'auto.register.schemas': False, 'use.latest.version': True}
+    rule_conf = {'secret': 'mysecret'}
+    rule = _encrypt_rule(kms_type='bad-kms', on_failure="DLQ,NONE")
+    await client.register_schema(_SUBJECT, Schema(json.dumps(_AVRO_SCHEMA), "AVRO", [], None, RuleSet(None, [rule])))
+
+    key_ser = await AsyncAvroSerializer(client, schema_str='"string"', conf={'auto.register.schemas': True})
+    key_bytes = await key_ser('mykey', SerializationContext(_TOPIC, MessageField.KEY))
+    assert key_bytes is not None
+
+    obj = _avro_obj()
+    ser = await AsyncAvroSerializer(client, schema_str=None, conf=ser_conf, rule_conf=rule_conf)
+    with pytest.raises(SerializationError, match="Rule failed: test-encrypt"):
+        await ser(obj, SerializationContext(_TOPIC, MessageField.VALUE))
+
+    assert len(producer.records) == 1
+    topic, key, value, headers = producer.records[0]
+    # the key serde stashed the original key for the value-side DLQ record
+    assert key == b'mykey'
+    assert json.loads(value)['stringField'] == FieldRedactionExecutor.REDACTED_STRING
+
+
+async def test_avro_dlq_tombstone_clears_original_key():
+    FieldEncryptionExecutor.register_with_clock(FakeClock())
+    producer = _register_dlq_action()
+
+    conf = {'url': _BASE_URL}
+    client = AsyncSchemaRegistryClient.new_client(conf)
+    ser_conf = {'auto.register.schemas': False, 'use.latest.version': True}
+    rule_conf = {'secret': 'mysecret'}
+    rule = _encrypt_rule(kms_type='bad-kms', on_failure="DLQ,NONE")
+    await client.register_schema(_SUBJECT, Schema(json.dumps(_AVRO_SCHEMA), "AVRO", [], None, RuleSet(None, [rule])))
+
+    clear_original_key()
+    key_ser = await AsyncAvroSerializer(client, schema_str='"string"', conf={'auto.register.schemas': True})
+    await key_ser('keyA', SerializationContext(_TOPIC, MessageField.KEY))
+    # the key serde stashed the original key for a subsequent value-side DLQ record
+    assert get_original_key() == 'keyA'
+
+    value_ser = await AsyncAvroSerializer(client, schema_str=None, conf=ser_conf, rule_conf=rule_conf)
+    # a tombstone (value=None) must still clear the stashed key rather than leak it
+    assert await value_ser(None, SerializationContext(_TOPIC, MessageField.VALUE)) is None
+    assert get_original_key() is None
+
+    # a subsequent keyless failing value must produce a DLQ record with key=None,
+    # not the stale key from the earlier key serialization
+    with pytest.raises(SerializationError, match="Rule failed: test-encrypt"):
+        await value_ser(_avro_obj(), SerializationContext(_TOPIC, MessageField.VALUE))
+    assert len(producer.records) == 1
+    topic, key, value, headers = producer.records[0]
+    assert key is None
+
+
+async def test_serializer_close_flushes_dlq_and_closes_executors():
+    conf = {'url': _BASE_URL}
+    client = AsyncSchemaRegistryClient.new_client(conf)
+
+    producer = RecordingProducer()
+    registry = RuleRegistry()
+
+    class _SpyExecutor(FieldRedactionExecutor):
+        def __init__(self):
+            self.closed = False
+
+        def close(self):
+            self.closed = True
+
+    spy = _SpyExecutor()
+    registry.register_executor(spy)
+    registry.register_action(DlqAction({'dlq.topic': _DLQ_TOPIC, 'producer': producer}))
+
+    ser = await AsyncAvroSerializer(
+        client, schema_str='"string"', conf={'auto.register.schemas': True}, rule_registry=registry
+    )
+    # closing the serde flushes the DLQ producer and closes each registered executor
+    await ser.aclose()
+    assert producer.flush_count == 1
+    assert spy.closed is True
+
+
+async def test_serializer_close_does_not_close_shared_global_registry():
+    # Closing a serde bound to the shared global RuleRegistry must NOT tear down
+    # executors/actions still in use by other default-configured serdes.
+    conf = {'url': _BASE_URL}
+    client = AsyncSchemaRegistryClient.new_client(conf)
+
+    registry = RuleRegistry.get_global_instance()
+    registry.clear()
+
+    producer = RecordingProducer()
+
+    class _SpyExecutor(FieldRedactionExecutor):
+        def __init__(self):
+            self.closed = False
+
+        def close(self):
+            self.closed = True
+
+    spy = _SpyExecutor()
+    registry.register_executor(spy)
+    action = DlqAction({'dlq.topic': _DLQ_TOPIC, 'producer': producer})
+    registry.register_action(action)
+
+    # a default serde (no rule_registry) shares the global instance
+    ser = await AsyncAvroSerializer(client, schema_str='"string"', conf={'auto.register.schemas': True})
+    assert ser._rule_registry is registry
+    await ser.aclose()
+
+    # the shared action's producer is untouched and the shared executor is not closed,
+    # so a still-live sibling serde keeps working
+    assert producer.flush_count == 0
+    assert action._producer is producer
+    assert spy.closed is False
+
+    registry.clear()
+
+
+async def test_avro_dlq_cel_condition_read():
+    producer = _register_dlq_action()
+
+    conf = {'url': _BASE_URL}
+    client = AsyncSchemaRegistryClient.new_client(conf)
+    ser_conf = {'auto.register.schemas': False, 'use.latest.version': True}
+    rule = _cel_fail_rule(RuleMode.READ, "DLQ")
+    schema = dict(_AVRO_SCHEMA)
+    await client.register_schema(_SUBJECT, Schema(json.dumps(schema), "AVRO", [], None, RuleSet(None, [rule])))
+
+    obj = _avro_obj()
+    ser = await AsyncAvroSerializer(client, schema_str=None, conf=ser_conf)
+    ser_ctx = SerializationContext(_TOPIC, MessageField.VALUE)
+    obj_bytes = await ser(obj, ser_ctx)
+    assert producer.records == []
+
+    deser = await AsyncAvroDeserializer(client)
+    with pytest.raises(SerializationError, match="Rule failed: test-cel"):
+        await deser(obj_bytes, ser_ctx)
+
+    assert len(producer.records) == 1
+    topic, key, value, headers = producer.records[0]
+    # on the read path the original wire bytes are sent verbatim
+    assert value == obj_bytes
+    headers_dict = dict(headers)
+    assert headers_dict[DlqAction.RULE_MODE] == b'READ'
+    assert headers_dict[DlqAction.RULE_EXCEPTION] == b"Rule expr failed: message.stringField != 'hi'"
+
+
+async def test_avro_dlq_on_failure_from_override():
+    conf = {'url': _BASE_URL}
+    client = AsyncSchemaRegistryClient.new_client(conf)
+    ser_conf = {'auto.register.schemas': False, 'use.latest.version': True}
+    rule = _cel_fail_rule(RuleMode.WRITE, None)
+    await client.register_schema(_SUBJECT, Schema(json.dumps(_AVRO_SCHEMA), "AVRO", [], None, RuleSet(None, [rule])))
+
+    producer = RecordingProducer()
+    registry = RuleRegistry()
+    registry.register_rule_executor(CelExecutor())
+    registry.register_action(DlqAction({'dlq.topic': _DLQ_TOPIC, 'producer': producer}))
+    registry.register_override(RuleOverride("CEL", None, "DLQ", None))
+
+    ser = await AsyncAvroSerializer(client, schema_str=None, conf=ser_conf, rule_registry=registry)
+    with pytest.raises(SerializationError, match="Rule failed: test-cel"):
+        await ser(_avro_obj(), SerializationContext(_TOPIC, MessageField.VALUE))
+    assert len(producer.records) == 1
+    assert producer.records[0][0] == _DLQ_TOPIC
+
+
+async def test_avro_dlq_disabled_from_override():
+    conf = {'url': _BASE_URL}
+    client = AsyncSchemaRegistryClient.new_client(conf)
+    ser_conf = {'auto.register.schemas': False, 'use.latest.version': True}
+    rule = _cel_fail_rule(RuleMode.WRITE, "DLQ")
+    await client.register_schema(_SUBJECT, Schema(json.dumps(_AVRO_SCHEMA), "AVRO", [], None, RuleSet(None, [rule])))
+
+    producer = RecordingProducer()
+    registry = RuleRegistry()
+    registry.register_rule_executor(CelExecutor())
+    registry.register_action(DlqAction({'dlq.topic': _DLQ_TOPIC, 'producer': producer}))
+    registry.register_override(RuleOverride("CEL", None, None, True))
+
+    ser = await AsyncAvroSerializer(client, schema_str=None, conf=ser_conf, rule_registry=registry)
+    obj_bytes = await ser(_avro_obj(), SerializationContext(_TOPIC, MessageField.VALUE))
+    assert obj_bytes is not None
+    assert producer.records == []
+
+
+async def test_avro_dlq_topic_from_rule_params():
+    producer = _register_dlq_action(topic=None)
+
+    conf = {'url': _BASE_URL}
+    client = AsyncSchemaRegistryClient.new_client(conf)
+    ser_conf = {'auto.register.schemas': False, 'use.latest.version': True}
+    rule = _cel_fail_rule(RuleMode.WRITE, "DLQ", params={'dlq.topic': 'param-dlq'})
+    await client.register_schema(_SUBJECT, Schema(json.dumps(_AVRO_SCHEMA), "AVRO", [], None, RuleSet(None, [rule])))
+
+    ser = await AsyncAvroSerializer(client, schema_str=None, conf=ser_conf)
+    with pytest.raises(SerializationError, match="Rule failed: test-cel"):
+        await ser(_avro_obj(), SerializationContext(_TOPIC, MessageField.VALUE))
+    assert len(producer.records) == 1
+    assert producer.records[0][0] == 'param-dlq'
+
+
+async def test_avro_dlq_no_topic_configured():
+    producer = _register_dlq_action(topic=None)
+
+    conf = {'url': _BASE_URL}
+    client = AsyncSchemaRegistryClient.new_client(conf)
+    ser_conf = {'auto.register.schemas': False, 'use.latest.version': True}
+    rule = _cel_fail_rule(RuleMode.WRITE, "DLQ")
+    await client.register_schema(_SUBJECT, Schema(json.dumps(_AVRO_SCHEMA), "AVRO", [], None, RuleSet(None, [rule])))
+
+    ser = await AsyncAvroSerializer(client, schema_str=None, conf=ser_conf)
+    with pytest.raises(SerializationError, match="Could not send to DLQ as no topic is configured"):
+        await ser(_avro_obj(), SerializationContext(_TOPIC, MessageField.VALUE))
+    assert producer.records == []
+
+
+async def test_avro_dlq_payload_encryption_write():
+    EncryptionExecutor.register_with_clock(FakeClock())
+    producer = _register_dlq_action()
+
+    conf = {'url': _BASE_URL}
+    client = AsyncSchemaRegistryClient.new_client(conf)
+    ser_conf = {'auto.register.schemas': False, 'use.latest.version': True}
+    rule_conf = {'secret': 'mysecret'}
+    rule = _encrypt_rule(kms_type='bad-kms', rule_type='ENCRYPT_PAYLOAD', on_failure="DLQ,NONE")
+    await client.register_schema(
+        _SUBJECT, Schema(json.dumps(_AVRO_SCHEMA), "AVRO", [], None, RuleSet(None, None, [rule]))
+    )
+
+    obj = _avro_obj()
+    ser = await AsyncAvroSerializer(client, schema_str=None, conf=ser_conf, rule_conf=rule_conf)
+    with pytest.raises(SerializationError, match="Rule failed: test-encrypt"):
+        await ser(obj, SerializationContext(_TOPIC, MessageField.VALUE))
+
+    assert len(producer.records) == 1
+    topic, key, value, headers = producer.records[0]
+    # payload-level rules carry no field tags, so the plaintext serialized bytes
+    # are sent verbatim, matching Java
+    assert b'hi' in value
+    assert b'foobar' in value
+    assert dict(headers)[DlqAction.RULE_MODE] == b'WRITE'
+
+
+async def test_avro_dlq_payload_encryption_read_ciphertext():
+    EncryptionExecutor.register_with_clock(FakeClock())
+    producer = _register_dlq_action()
+
+    conf = {'url': _BASE_URL}
+    client = AsyncSchemaRegistryClient.new_client(conf)
+    ser_conf = {'auto.register.schemas': False, 'use.latest.version': True}
+    rule_conf = {'secret': 'mysecret'}
+    rule = _encrypt_rule(rule_type='ENCRYPT_PAYLOAD', on_failure="ERROR,DLQ")
+    await client.register_schema(
+        _SUBJECT, Schema(json.dumps(_AVRO_SCHEMA), "AVRO", [], None, RuleSet(None, None, [rule]))
+    )
+
+    obj = _avro_obj()
+    ser = await AsyncAvroSerializer(client, schema_str=None, conf=ser_conf, rule_conf=rule_conf)
+    ser_ctx = SerializationContext(_TOPIC, MessageField.VALUE)
+    obj_bytes = await ser(obj, ser_ctx)
+    # payload encryption succeeded on write, so nothing went to the DLQ
+    assert producer.records == []
+
+    # a fresh executor (as in a separate consumer process) cannot decrypt
+    EncryptionExecutor.register_with_clock(FakeClock())
+    deser = await AsyncAvroDeserializer(client, rule_conf=rule_conf)
+    with pytest.raises(SerializationError, match="Rule failed: test-encrypt"):
+        await deser(obj_bytes, ser_ctx)
+
+    assert len(producer.records) == 1
+    topic, key, value, headers = producer.records[0]
+    # the encoding-phase read DLQ record carries the original wire bytes (framing
+    # included), so it is replayable -- not the frame-stripped payload
+    assert value == obj_bytes
+    assert dict(headers)[DlqAction.RULE_MODE] == b'READ'
+
+
+async def test_json_dlq_encryption_write_redaction():
+    FieldEncryptionExecutor.register_with_clock(FakeClock())
+    producer = _register_dlq_action()
+
+    conf = {'url': _BASE_URL}
+    client = AsyncSchemaRegistryClient.new_client(conf)
+    ser_conf = {'auto.register.schemas': False, 'use.latest.version': True}
+    rule_conf = {'secret': 'mysecret'}
+    schema = {
+        "type": "object",
+        "properties": {
+            "intField": {"type": "integer"},
+            "doubleField": {"type": "number"},
+            "stringField": {"type": "string", "confluent:tags": ["PII"]},
+            "booleanField": {"type": "boolean"},
+            "bytesField": {"type": "string", "contentEncoding": "base64", "confluent:tags": ["PII"]},
+        },
+    }
+    rule = _encrypt_rule(kms_type='bad-kms', on_failure="DLQ,NONE")
+    await client.register_schema(_SUBJECT, Schema(json.dumps(schema), "JSON", [], None, RuleSet(None, [rule])))
+
+    obj = {
+        'intField': 123,
+        'doubleField': 45.67,
+        'stringField': 'hi',
+        'booleanField': True,
+        'bytesField': base64.b64encode(b'foobar').decode('utf-8'),
+    }
+    ser = await AsyncJSONSerializer(json.dumps(schema), client, conf=ser_conf, rule_conf=rule_conf)
+    with pytest.raises(SerializationError, match="Rule failed: test-encrypt"):
+        await ser(obj, SerializationContext(_TOPIC, MessageField.VALUE))
+
+    assert len(producer.records) == 1
+    value = producer.records[0][2]
+    dlq_value = json.loads(value)
+    assert dlq_value['stringField'] == FieldRedactionExecutor.REDACTED_STRING
+    assert dlq_value['bytesField'] == FieldRedactionExecutor.REDACTED_STRING
+    assert b'"hi"' not in value
+    assert base64.b64encode(b'foobar') not in value
+    assert dlq_value['intField'] == 123
+
+
+async def test_proto_dlq_encryption_write_redaction():
+    FieldEncryptionExecutor.register_with_clock(FakeClock())
+    producer = _register_dlq_action()
+
+    conf = {'url': _BASE_URL}
+    client = AsyncSchemaRegistryClient.new_client(conf)
+    ser_conf = {'auto.register.schemas': False, 'use.latest.version': True, 'use.deprecated.format': False}
+    rule_conf = {'secret': 'mysecret'}
+    rule = _encrypt_rule(kms_type='bad-kms', on_failure="DLQ,NONE")
+    await client.register_schema(
+        _SUBJECT,
+        Schema(_schema_to_str(example_pb2.Author.DESCRIPTOR.file), "PROTOBUF", [], None, RuleSet(None, [rule])),
+    )
+
+    obj = example_pb2.Author(
+        name='Kafka', id=123, picture=b'foobar', works=['The Castle', 'The Trial'], oneof_string='oneof'
+    )
+    ser = await AsyncProtobufSerializer(example_pb2.Author, client, conf=ser_conf, rule_conf=rule_conf)
+    with pytest.raises(SerializationError, match="Rule failed: test-encrypt"):
+        await ser(obj, SerializationContext(_TOPIC, MessageField.VALUE))
+
+    assert len(producer.records) == 1
+    value = producer.records[0][2]
+    # the protobuf message is JSON-encoded with tagged fields redacted
+    assert b'Kafka' not in value
+    assert base64.b64encode(b'foobar') not in value
+    assert b'<REDACTED>' in value
+    assert b'The Castle' in value
+    # redaction mutates the failed message in place, as in Java
+    assert obj.name == FieldRedactionExecutor.REDACTED_STRING

--- a/tests/schema_registry/_async/test_dlq_serdes.py
+++ b/tests/schema_registry/_async/test_dlq_serdes.py
@@ -202,7 +202,7 @@ async def test_avro_dlq_encryption_write_redaction():
     assert headers_dict[DlqAction.RULE_SUBJECT] == _SUBJECT.encode('utf-8')
     assert headers_dict[DlqAction.RULE_TOPIC] == _TOPIC.encode('utf-8')
     assert DlqAction.RULE_EXCEPTION in headers_dict
-    # redaction mutates the failed message in place, as in Java
+    # redaction mutates the failed message in place
     assert obj['stringField'] == FieldRedactionExecutor.REDACTED_STRING
 
 
@@ -494,7 +494,7 @@ async def test_avro_dlq_payload_encryption_write():
     assert len(producer.records) == 1
     topic, key, value, headers = producer.records[0]
     # payload-level rules carry no field tags, so the plaintext serialized bytes
-    # are sent verbatim, matching Java
+    # are sent verbatim
     assert b'hi' in value
     assert b'foobar' in value
     assert dict(headers)[DlqAction.RULE_MODE] == b'WRITE'
@@ -604,5 +604,5 @@ async def test_proto_dlq_encryption_write_redaction():
     assert base64.b64encode(b'foobar') not in value
     assert b'<REDACTED>' in value
     assert b'The Castle' in value
-    # redaction mutates the failed message in place, as in Java
+    # redaction mutates the failed message in place
     assert obj.name == FieldRedactionExecutor.REDACTED_STRING

--- a/tests/schema_registry/_sync/test_dlq_serdes.py
+++ b/tests/schema_registry/_sync/test_dlq_serdes.py
@@ -202,7 +202,7 @@ def test_avro_dlq_encryption_write_redaction():
     assert headers_dict[DlqAction.RULE_SUBJECT] == _SUBJECT.encode('utf-8')
     assert headers_dict[DlqAction.RULE_TOPIC] == _TOPIC.encode('utf-8')
     assert DlqAction.RULE_EXCEPTION in headers_dict
-    # redaction mutates the failed message in place, as in Java
+    # redaction mutates the failed message in place
     assert obj['stringField'] == FieldRedactionExecutor.REDACTED_STRING
 
 
@@ -490,7 +490,7 @@ def test_avro_dlq_payload_encryption_write():
     assert len(producer.records) == 1
     topic, key, value, headers = producer.records[0]
     # payload-level rules carry no field tags, so the plaintext serialized bytes
-    # are sent verbatim, matching Java
+    # are sent verbatim
     assert b'hi' in value
     assert b'foobar' in value
     assert dict(headers)[DlqAction.RULE_MODE] == b'WRITE'
@@ -598,5 +598,5 @@ def test_proto_dlq_encryption_write_redaction():
     assert base64.b64encode(b'foobar') not in value
     assert b'<REDACTED>' in value
     assert b'The Castle' in value
-    # redaction mutates the failed message in place, as in Java
+    # redaction mutates the failed message in place
     assert obj.name == FieldRedactionExecutor.REDACTED_STRING

--- a/tests/schema_registry/_sync/test_dlq_serdes.py
+++ b/tests/schema_registry/_sync/test_dlq_serdes.py
@@ -1,0 +1,602 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Copyright 2026 Confluent Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+import base64
+import json
+import os
+import sys
+import time
+
+import pytest
+
+from confluent_kafka.schema_registry import Schema, SchemaRegistryClient
+from confluent_kafka.schema_registry._sync.json_schema import JSONSerializer
+from confluent_kafka.schema_registry._sync.protobuf import ProtobufSerializer
+from confluent_kafka.schema_registry.avro import AvroDeserializer, AvroSerializer
+from confluent_kafka.schema_registry.common.serde import clear_original_key, get_original_key
+from confluent_kafka.schema_registry.protobuf import _schema_to_str
+from confluent_kafka.schema_registry.rule_registry import RuleOverride, RuleRegistry
+from confluent_kafka.schema_registry.rules.cel.cel_executor import CelExecutor
+from confluent_kafka.schema_registry.rules.dlq.dlq_action import DlqAction, FieldRedactionExecutor
+from confluent_kafka.schema_registry.rules.encryption.encrypt_executor import (
+    Clock,
+    EncryptionExecutor,
+    FieldEncryptionExecutor,
+)
+from confluent_kafka.schema_registry.rules.encryption.localkms.local_driver import LocalKmsDriver
+from confluent_kafka.schema_registry.schema_registry_client import Rule, RuleKind, RuleMode, RuleParams, RuleSet
+from confluent_kafka.serialization import MessageField, SerializationContext, SerializationError
+
+# Add proto directory to sys.path to resolve protobuf import dependencies
+proto_path = os.path.join(os.path.dirname(os.path.dirname(__file__)), 'data', 'proto')
+if proto_path not in sys.path:
+    sys.path.insert(0, proto_path)
+
+from tests.schema_registry.data.proto import example_pb2  # noqa: E402
+
+
+class FakeClock(Clock):
+
+    def __init__(self):
+        self.fixed_now = int(round(time.time() * 1000))
+
+    def now(self) -> int:
+        return self.fixed_now
+
+
+class RecordingProducer:
+    def __init__(self):
+        self.records = []
+        self.flush_count = 0
+
+    def produce(self, topic, value=None, key=None, headers=None, on_delivery=None, **kwargs):
+        self.records.append((topic, key, value, headers))
+
+    def poll(self, timeout=0):
+        return 0
+
+    def flush(self, timeout=None):
+        self.flush_count += 1
+        return 0
+
+
+_BASE_URL = "mock://"
+_TOPIC = "topic1"
+_SUBJECT = _TOPIC + "-value"
+_DLQ_TOPIC = "dlq-topic"
+
+_AVRO_SCHEMA = {
+    'type': 'record',
+    'name': 'test',
+    'fields': [
+        {'name': 'intField', 'type': 'int'},
+        {'name': 'doubleField', 'type': 'double'},
+        {'name': 'stringField', 'type': 'string', 'confluent:tags': ['PII']},
+        {'name': 'booleanField', 'type': 'boolean'},
+        {'name': 'bytesField', 'type': 'bytes', 'confluent:tags': ['PII']},
+    ],
+}
+
+
+def _avro_obj():
+    return {
+        'intField': 123,
+        'doubleField': 45.67,
+        'stringField': 'hi',
+        'booleanField': True,
+        'bytesField': b'foobar',
+    }
+
+
+def _encrypt_rule(kms_type='local-kms', rule_type='ENCRYPT', tags=None, on_failure="ERROR,NONE", extra_params=None):
+    params = {"encrypt.kek.name": "kek1", "encrypt.kms.type": kms_type, "encrypt.kms.key.id": "mykey"}
+    if extra_params:
+        params.update(extra_params)
+    if tags is None and rule_type == 'ENCRYPT':
+        tags = ["PII"]
+    return Rule(
+        "test-encrypt",
+        "",
+        RuleKind.TRANSFORM,
+        RuleMode.WRITEREAD,
+        rule_type,
+        tags,
+        RuleParams(params),
+        None,
+        None,
+        on_failure,
+        False,
+    )
+
+
+def _cel_fail_rule(mode, on_failure, params=None):
+    return Rule(
+        "test-cel",
+        "",
+        RuleKind.CONDITION,
+        mode,
+        "CEL",
+        None,
+        RuleParams(params) if params is not None else None,
+        "message.stringField != 'hi'",
+        None,
+        on_failure,
+        False,
+    )
+
+
+def _register_dlq_action(topic=_DLQ_TOPIC):
+    producer = RecordingProducer()
+    conf = {'producer': producer}
+    if topic is not None:
+        conf['dlq.topic'] = topic
+    DlqAction.register(conf)
+    return producer
+
+
+@pytest.fixture(autouse=True)
+def run_before_and_after_tests(tmpdir):
+    """Fixture to execute asserts before and after a test is run"""
+    CelExecutor.register()
+    LocalKmsDriver.register()
+
+    yield  # this is where the testing happens
+
+    conf = {'url': _BASE_URL}
+    client = SchemaRegistryClient.new_client(conf)
+    subjects = client.get_subjects()
+    for subject in subjects:
+        try:
+            client.delete_subject(subject, True)
+        except Exception:
+            pass
+
+
+def test_avro_dlq_encryption_write_redaction():
+    FieldEncryptionExecutor.register_with_clock(FakeClock())
+    producer = _register_dlq_action()
+
+    conf = {'url': _BASE_URL}
+    client = SchemaRegistryClient.new_client(conf)
+    ser_conf = {'auto.register.schemas': False, 'use.latest.version': True}
+    rule_conf = {'secret': 'mysecret'}
+    rule = _encrypt_rule(kms_type='bad-kms', on_failure="DLQ,NONE")
+    client.register_schema(_SUBJECT, Schema(json.dumps(_AVRO_SCHEMA), "AVRO", [], None, RuleSet(None, [rule])))
+
+    obj = _avro_obj()
+    ser = AvroSerializer(client, schema_str=None, conf=ser_conf, rule_conf=rule_conf)
+    ser_ctx = SerializationContext(_TOPIC, MessageField.VALUE)
+    with pytest.raises(SerializationError, match="Rule failed: test-encrypt"):
+        ser(obj, ser_ctx)
+
+    assert len(producer.records) == 1
+    topic, key, value, headers = producer.records[0]
+    assert topic == _DLQ_TOPIC
+    assert key is None
+    # tagged fields are redacted, so no plaintext leaks to the DLQ
+    dlq_value = json.loads(value)
+    assert dlq_value['stringField'] == FieldRedactionExecutor.REDACTED_STRING
+    assert dlq_value['bytesField'] == FieldRedactionExecutor.REDACTED_STRING
+    assert b'"hi"' not in value
+    assert b'foobar' not in value
+    # untagged fields are passed through
+    assert dlq_value['intField'] == 123
+    assert dlq_value['booleanField'] is True
+    headers_dict = dict(headers)
+    assert headers_dict[DlqAction.RULE_NAME] == b'test-encrypt'
+    assert headers_dict[DlqAction.RULE_MODE] == b'WRITE'
+    assert headers_dict[DlqAction.RULE_SUBJECT] == _SUBJECT.encode('utf-8')
+    assert headers_dict[DlqAction.RULE_TOPIC] == _TOPIC.encode('utf-8')
+    assert DlqAction.RULE_EXCEPTION in headers_dict
+    # redaction mutates the failed message in place, as in Java
+    assert obj['stringField'] == FieldRedactionExecutor.REDACTED_STRING
+
+
+def test_avro_dlq_encryption_read_ciphertext_and_replay_skip():
+    FieldEncryptionExecutor.register_with_clock(FakeClock())
+    producer = _register_dlq_action()
+
+    conf = {'url': _BASE_URL}
+    client = SchemaRegistryClient.new_client(conf)
+    ser_conf = {'auto.register.schemas': False, 'use.latest.version': True}
+    rule_conf = {'secret': 'mysecret'}
+    rule = _encrypt_rule(on_failure="ERROR,DLQ")
+    client.register_schema(_SUBJECT, Schema(json.dumps(_AVRO_SCHEMA), "AVRO", [], None, RuleSet(None, [rule])))
+
+    obj = _avro_obj()
+    ser = AvroSerializer(client, schema_str=None, conf=ser_conf, rule_conf=rule_conf)
+    ser_ctx = SerializationContext(_TOPIC, MessageField.VALUE)
+    obj_bytes = ser(obj, ser_ctx)
+    # encryption succeeded, so nothing went to the DLQ
+    assert producer.records == []
+
+    # a fresh executor (as in a separate consumer process) has an empty DEK
+    # registry, so decryption fails
+    FieldEncryptionExecutor.register_with_clock(FakeClock())
+    deser = AvroDeserializer(client, rule_conf=rule_conf)
+    with pytest.raises(SerializationError, match="Rule failed: test-encrypt"):
+        deser(obj_bytes, ser_ctx)
+
+    assert len(producer.records) == 1
+    topic, key, value, headers = producer.records[0]
+    assert key is None
+    # the original wire bytes (ciphertext) are sent verbatim, so the DLQ record is replayable
+    assert value == obj_bytes
+    assert dict(headers)[DlqAction.RULE_MODE] == b'READ'
+
+    # a record consumed from the DLQ carries a __rule.name header, which skips
+    # the previously failed rule so the replay does not fail again
+    replay_ctx = SerializationContext(_TOPIC, MessageField.VALUE, [(DlqAction.RULE_NAME, b'test-encrypt')])
+    obj2 = deser(obj_bytes, replay_ctx)
+    assert obj2['intField'] == 123
+    # the rule was skipped, so the tagged fields still hold ciphertext
+    assert obj2['stringField'] != 'hi'
+
+    # dict-shaped headers are also supported
+    replay_ctx = SerializationContext(_TOPIC, MessageField.VALUE, {DlqAction.RULE_NAME: b'test-encrypt'})
+    obj3 = deser(obj_bytes, replay_ctx)
+    assert obj3['intField'] == 123
+
+
+def test_avro_dlq_with_key():
+    FieldEncryptionExecutor.register_with_clock(FakeClock())
+    producer = _register_dlq_action()
+
+    conf = {'url': _BASE_URL}
+    client = SchemaRegistryClient.new_client(conf)
+    ser_conf = {'auto.register.schemas': False, 'use.latest.version': True}
+    rule_conf = {'secret': 'mysecret'}
+    rule = _encrypt_rule(kms_type='bad-kms', on_failure="DLQ,NONE")
+    client.register_schema(_SUBJECT, Schema(json.dumps(_AVRO_SCHEMA), "AVRO", [], None, RuleSet(None, [rule])))
+
+    key_ser = AvroSerializer(client, schema_str='"string"', conf={'auto.register.schemas': True})
+    key_bytes = key_ser('mykey', SerializationContext(_TOPIC, MessageField.KEY))
+    assert key_bytes is not None
+
+    obj = _avro_obj()
+    ser = AvroSerializer(client, schema_str=None, conf=ser_conf, rule_conf=rule_conf)
+    with pytest.raises(SerializationError, match="Rule failed: test-encrypt"):
+        ser(obj, SerializationContext(_TOPIC, MessageField.VALUE))
+
+    assert len(producer.records) == 1
+    topic, key, value, headers = producer.records[0]
+    # the key serde stashed the original key for the value-side DLQ record
+    assert key == b'mykey'
+    assert json.loads(value)['stringField'] == FieldRedactionExecutor.REDACTED_STRING
+
+
+def test_avro_dlq_tombstone_clears_original_key():
+    FieldEncryptionExecutor.register_with_clock(FakeClock())
+    producer = _register_dlq_action()
+
+    conf = {'url': _BASE_URL}
+    client = SchemaRegistryClient.new_client(conf)
+    ser_conf = {'auto.register.schemas': False, 'use.latest.version': True}
+    rule_conf = {'secret': 'mysecret'}
+    rule = _encrypt_rule(kms_type='bad-kms', on_failure="DLQ,NONE")
+    client.register_schema(_SUBJECT, Schema(json.dumps(_AVRO_SCHEMA), "AVRO", [], None, RuleSet(None, [rule])))
+
+    clear_original_key()
+    key_ser = AvroSerializer(client, schema_str='"string"', conf={'auto.register.schemas': True})
+    key_ser('keyA', SerializationContext(_TOPIC, MessageField.KEY))
+    # the key serde stashed the original key for a subsequent value-side DLQ record
+    assert get_original_key() == 'keyA'
+
+    value_ser = AvroSerializer(client, schema_str=None, conf=ser_conf, rule_conf=rule_conf)
+    # a tombstone (value=None) must still clear the stashed key rather than leak it
+    assert value_ser(None, SerializationContext(_TOPIC, MessageField.VALUE)) is None
+    assert get_original_key() is None
+
+    # a subsequent keyless failing value must produce a DLQ record with key=None,
+    # not the stale key from the earlier key serialization
+    with pytest.raises(SerializationError, match="Rule failed: test-encrypt"):
+        value_ser(_avro_obj(), SerializationContext(_TOPIC, MessageField.VALUE))
+    assert len(producer.records) == 1
+    topic, key, value, headers = producer.records[0]
+    assert key is None
+
+
+def test_serializer_close_flushes_dlq_and_closes_executors():
+    conf = {'url': _BASE_URL}
+    client = SchemaRegistryClient.new_client(conf)
+
+    producer = RecordingProducer()
+    registry = RuleRegistry()
+
+    class _SpyExecutor(FieldRedactionExecutor):
+        def __init__(self):
+            self.closed = False
+
+        def close(self):
+            self.closed = True
+
+    spy = _SpyExecutor()
+    registry.register_executor(spy)
+    registry.register_action(DlqAction({'dlq.topic': _DLQ_TOPIC, 'producer': producer}))
+
+    ser = AvroSerializer(client, schema_str='"string"', conf={'auto.register.schemas': True}, rule_registry=registry)
+    # closing the serde flushes the DLQ producer and closes each registered executor
+    ser.close()
+    assert producer.flush_count == 1
+    assert spy.closed is True
+
+
+def test_serializer_close_does_not_close_shared_global_registry():
+    # Closing a serde bound to the shared global RuleRegistry must NOT tear down
+    # executors/actions still in use by other default-configured serdes.
+    conf = {'url': _BASE_URL}
+    client = SchemaRegistryClient.new_client(conf)
+
+    registry = RuleRegistry.get_global_instance()
+    registry.clear()
+
+    producer = RecordingProducer()
+
+    class _SpyExecutor(FieldRedactionExecutor):
+        def __init__(self):
+            self.closed = False
+
+        def close(self):
+            self.closed = True
+
+    spy = _SpyExecutor()
+    registry.register_executor(spy)
+    action = DlqAction({'dlq.topic': _DLQ_TOPIC, 'producer': producer})
+    registry.register_action(action)
+
+    # a default serde (no rule_registry) shares the global instance
+    ser = AvroSerializer(client, schema_str='"string"', conf={'auto.register.schemas': True})
+    assert ser._rule_registry is registry
+    ser.close()
+
+    # the shared action's producer is untouched and the shared executor is not closed,
+    # so a still-live sibling serde keeps working
+    assert producer.flush_count == 0
+    assert action._producer is producer
+    assert spy.closed is False
+
+    registry.clear()
+
+
+def test_avro_dlq_cel_condition_read():
+    producer = _register_dlq_action()
+
+    conf = {'url': _BASE_URL}
+    client = SchemaRegistryClient.new_client(conf)
+    ser_conf = {'auto.register.schemas': False, 'use.latest.version': True}
+    rule = _cel_fail_rule(RuleMode.READ, "DLQ")
+    schema = dict(_AVRO_SCHEMA)
+    client.register_schema(_SUBJECT, Schema(json.dumps(schema), "AVRO", [], None, RuleSet(None, [rule])))
+
+    obj = _avro_obj()
+    ser = AvroSerializer(client, schema_str=None, conf=ser_conf)
+    ser_ctx = SerializationContext(_TOPIC, MessageField.VALUE)
+    obj_bytes = ser(obj, ser_ctx)
+    assert producer.records == []
+
+    deser = AvroDeserializer(client)
+    with pytest.raises(SerializationError, match="Rule failed: test-cel"):
+        deser(obj_bytes, ser_ctx)
+
+    assert len(producer.records) == 1
+    topic, key, value, headers = producer.records[0]
+    # on the read path the original wire bytes are sent verbatim
+    assert value == obj_bytes
+    headers_dict = dict(headers)
+    assert headers_dict[DlqAction.RULE_MODE] == b'READ'
+    assert headers_dict[DlqAction.RULE_EXCEPTION] == b"Rule expr failed: message.stringField != 'hi'"
+
+
+def test_avro_dlq_on_failure_from_override():
+    conf = {'url': _BASE_URL}
+    client = SchemaRegistryClient.new_client(conf)
+    ser_conf = {'auto.register.schemas': False, 'use.latest.version': True}
+    rule = _cel_fail_rule(RuleMode.WRITE, None)
+    client.register_schema(_SUBJECT, Schema(json.dumps(_AVRO_SCHEMA), "AVRO", [], None, RuleSet(None, [rule])))
+
+    producer = RecordingProducer()
+    registry = RuleRegistry()
+    registry.register_rule_executor(CelExecutor())
+    registry.register_action(DlqAction({'dlq.topic': _DLQ_TOPIC, 'producer': producer}))
+    registry.register_override(RuleOverride("CEL", None, "DLQ", None))
+
+    ser = AvroSerializer(client, schema_str=None, conf=ser_conf, rule_registry=registry)
+    with pytest.raises(SerializationError, match="Rule failed: test-cel"):
+        ser(_avro_obj(), SerializationContext(_TOPIC, MessageField.VALUE))
+    assert len(producer.records) == 1
+    assert producer.records[0][0] == _DLQ_TOPIC
+
+
+def test_avro_dlq_disabled_from_override():
+    conf = {'url': _BASE_URL}
+    client = SchemaRegistryClient.new_client(conf)
+    ser_conf = {'auto.register.schemas': False, 'use.latest.version': True}
+    rule = _cel_fail_rule(RuleMode.WRITE, "DLQ")
+    client.register_schema(_SUBJECT, Schema(json.dumps(_AVRO_SCHEMA), "AVRO", [], None, RuleSet(None, [rule])))
+
+    producer = RecordingProducer()
+    registry = RuleRegistry()
+    registry.register_rule_executor(CelExecutor())
+    registry.register_action(DlqAction({'dlq.topic': _DLQ_TOPIC, 'producer': producer}))
+    registry.register_override(RuleOverride("CEL", None, None, True))
+
+    ser = AvroSerializer(client, schema_str=None, conf=ser_conf, rule_registry=registry)
+    obj_bytes = ser(_avro_obj(), SerializationContext(_TOPIC, MessageField.VALUE))
+    assert obj_bytes is not None
+    assert producer.records == []
+
+
+def test_avro_dlq_topic_from_rule_params():
+    producer = _register_dlq_action(topic=None)
+
+    conf = {'url': _BASE_URL}
+    client = SchemaRegistryClient.new_client(conf)
+    ser_conf = {'auto.register.schemas': False, 'use.latest.version': True}
+    rule = _cel_fail_rule(RuleMode.WRITE, "DLQ", params={'dlq.topic': 'param-dlq'})
+    client.register_schema(_SUBJECT, Schema(json.dumps(_AVRO_SCHEMA), "AVRO", [], None, RuleSet(None, [rule])))
+
+    ser = AvroSerializer(client, schema_str=None, conf=ser_conf)
+    with pytest.raises(SerializationError, match="Rule failed: test-cel"):
+        ser(_avro_obj(), SerializationContext(_TOPIC, MessageField.VALUE))
+    assert len(producer.records) == 1
+    assert producer.records[0][0] == 'param-dlq'
+
+
+def test_avro_dlq_no_topic_configured():
+    producer = _register_dlq_action(topic=None)
+
+    conf = {'url': _BASE_URL}
+    client = SchemaRegistryClient.new_client(conf)
+    ser_conf = {'auto.register.schemas': False, 'use.latest.version': True}
+    rule = _cel_fail_rule(RuleMode.WRITE, "DLQ")
+    client.register_schema(_SUBJECT, Schema(json.dumps(_AVRO_SCHEMA), "AVRO", [], None, RuleSet(None, [rule])))
+
+    ser = AvroSerializer(client, schema_str=None, conf=ser_conf)
+    with pytest.raises(SerializationError, match="Could not send to DLQ as no topic is configured"):
+        ser(_avro_obj(), SerializationContext(_TOPIC, MessageField.VALUE))
+    assert producer.records == []
+
+
+def test_avro_dlq_payload_encryption_write():
+    EncryptionExecutor.register_with_clock(FakeClock())
+    producer = _register_dlq_action()
+
+    conf = {'url': _BASE_URL}
+    client = SchemaRegistryClient.new_client(conf)
+    ser_conf = {'auto.register.schemas': False, 'use.latest.version': True}
+    rule_conf = {'secret': 'mysecret'}
+    rule = _encrypt_rule(kms_type='bad-kms', rule_type='ENCRYPT_PAYLOAD', on_failure="DLQ,NONE")
+    client.register_schema(_SUBJECT, Schema(json.dumps(_AVRO_SCHEMA), "AVRO", [], None, RuleSet(None, None, [rule])))
+
+    obj = _avro_obj()
+    ser = AvroSerializer(client, schema_str=None, conf=ser_conf, rule_conf=rule_conf)
+    with pytest.raises(SerializationError, match="Rule failed: test-encrypt"):
+        ser(obj, SerializationContext(_TOPIC, MessageField.VALUE))
+
+    assert len(producer.records) == 1
+    topic, key, value, headers = producer.records[0]
+    # payload-level rules carry no field tags, so the plaintext serialized bytes
+    # are sent verbatim, matching Java
+    assert b'hi' in value
+    assert b'foobar' in value
+    assert dict(headers)[DlqAction.RULE_MODE] == b'WRITE'
+
+
+def test_avro_dlq_payload_encryption_read_ciphertext():
+    EncryptionExecutor.register_with_clock(FakeClock())
+    producer = _register_dlq_action()
+
+    conf = {'url': _BASE_URL}
+    client = SchemaRegistryClient.new_client(conf)
+    ser_conf = {'auto.register.schemas': False, 'use.latest.version': True}
+    rule_conf = {'secret': 'mysecret'}
+    rule = _encrypt_rule(rule_type='ENCRYPT_PAYLOAD', on_failure="ERROR,DLQ")
+    client.register_schema(_SUBJECT, Schema(json.dumps(_AVRO_SCHEMA), "AVRO", [], None, RuleSet(None, None, [rule])))
+
+    obj = _avro_obj()
+    ser = AvroSerializer(client, schema_str=None, conf=ser_conf, rule_conf=rule_conf)
+    ser_ctx = SerializationContext(_TOPIC, MessageField.VALUE)
+    obj_bytes = ser(obj, ser_ctx)
+    # payload encryption succeeded on write, so nothing went to the DLQ
+    assert producer.records == []
+
+    # a fresh executor (as in a separate consumer process) cannot decrypt
+    EncryptionExecutor.register_with_clock(FakeClock())
+    deser = AvroDeserializer(client, rule_conf=rule_conf)
+    with pytest.raises(SerializationError, match="Rule failed: test-encrypt"):
+        deser(obj_bytes, ser_ctx)
+
+    assert len(producer.records) == 1
+    topic, key, value, headers = producer.records[0]
+    # the encoding-phase read DLQ record carries the original wire bytes (framing
+    # included), so it is replayable -- not the frame-stripped payload
+    assert value == obj_bytes
+    assert dict(headers)[DlqAction.RULE_MODE] == b'READ'
+
+
+def test_json_dlq_encryption_write_redaction():
+    FieldEncryptionExecutor.register_with_clock(FakeClock())
+    producer = _register_dlq_action()
+
+    conf = {'url': _BASE_URL}
+    client = SchemaRegistryClient.new_client(conf)
+    ser_conf = {'auto.register.schemas': False, 'use.latest.version': True}
+    rule_conf = {'secret': 'mysecret'}
+    schema = {
+        "type": "object",
+        "properties": {
+            "intField": {"type": "integer"},
+            "doubleField": {"type": "number"},
+            "stringField": {"type": "string", "confluent:tags": ["PII"]},
+            "booleanField": {"type": "boolean"},
+            "bytesField": {"type": "string", "contentEncoding": "base64", "confluent:tags": ["PII"]},
+        },
+    }
+    rule = _encrypt_rule(kms_type='bad-kms', on_failure="DLQ,NONE")
+    client.register_schema(_SUBJECT, Schema(json.dumps(schema), "JSON", [], None, RuleSet(None, [rule])))
+
+    obj = {
+        'intField': 123,
+        'doubleField': 45.67,
+        'stringField': 'hi',
+        'booleanField': True,
+        'bytesField': base64.b64encode(b'foobar').decode('utf-8'),
+    }
+    ser = JSONSerializer(json.dumps(schema), client, conf=ser_conf, rule_conf=rule_conf)
+    with pytest.raises(SerializationError, match="Rule failed: test-encrypt"):
+        ser(obj, SerializationContext(_TOPIC, MessageField.VALUE))
+
+    assert len(producer.records) == 1
+    value = producer.records[0][2]
+    dlq_value = json.loads(value)
+    assert dlq_value['stringField'] == FieldRedactionExecutor.REDACTED_STRING
+    assert dlq_value['bytesField'] == FieldRedactionExecutor.REDACTED_STRING
+    assert b'"hi"' not in value
+    assert base64.b64encode(b'foobar') not in value
+    assert dlq_value['intField'] == 123
+
+
+def test_proto_dlq_encryption_write_redaction():
+    FieldEncryptionExecutor.register_with_clock(FakeClock())
+    producer = _register_dlq_action()
+
+    conf = {'url': _BASE_URL}
+    client = SchemaRegistryClient.new_client(conf)
+    ser_conf = {'auto.register.schemas': False, 'use.latest.version': True, 'use.deprecated.format': False}
+    rule_conf = {'secret': 'mysecret'}
+    rule = _encrypt_rule(kms_type='bad-kms', on_failure="DLQ,NONE")
+    client.register_schema(
+        _SUBJECT,
+        Schema(_schema_to_str(example_pb2.Author.DESCRIPTOR.file), "PROTOBUF", [], None, RuleSet(None, [rule])),
+    )
+
+    obj = example_pb2.Author(
+        name='Kafka', id=123, picture=b'foobar', works=['The Castle', 'The Trial'], oneof_string='oneof'
+    )
+    ser = ProtobufSerializer(example_pb2.Author, client, conf=ser_conf, rule_conf=rule_conf)
+    with pytest.raises(SerializationError, match="Rule failed: test-encrypt"):
+        ser(obj, SerializationContext(_TOPIC, MessageField.VALUE))
+
+    assert len(producer.records) == 1
+    value = producer.records[0][2]
+    # the protobuf message is JSON-encoded with tagged fields redacted
+    assert b'Kafka' not in value
+    assert base64.b64encode(b'foobar') not in value
+    assert b'<REDACTED>' in value
+    assert b'The Castle' in value
+    # redaction mutates the failed message in place, as in Java
+    assert obj.name == FieldRedactionExecutor.REDACTED_STRING

--- a/tests/schema_registry/_sync/test_dlq_serdes.py
+++ b/tests/schema_registry/_sync/test_dlq_serdes.py
@@ -202,8 +202,8 @@ def test_avro_dlq_encryption_write_redaction():
     assert headers_dict[DlqAction.RULE_SUBJECT] == _SUBJECT.encode('utf-8')
     assert headers_dict[DlqAction.RULE_TOPIC] == _TOPIC.encode('utf-8')
     assert DlqAction.RULE_EXCEPTION in headers_dict
-    # redaction mutates the failed message in place
-    assert obj['stringField'] == FieldRedactionExecutor.REDACTED_STRING
+    # redaction runs on a copy: the caller's object keeps its original value
+    assert obj['stringField'] == 'hi'
 
 
 def test_avro_dlq_encryption_read_ciphertext_and_replay_skip():
@@ -333,6 +333,52 @@ def test_serializer_close_flushes_dlq_and_closes_executors():
     ser.close()
     assert producer.flush_count == 1
     assert spy.closed is True
+
+
+def test_field_encryption_executor_close_does_not_raise():
+    # Regression: FieldEncryptionExecutor.close() used to reference a
+    # non-existent self.client and raise AttributeError; it must delegate to the
+    # wrapped EncryptionExecutor. An unconfigured executor closes cleanly.
+    FieldEncryptionExecutor().close()  # must not raise
+
+
+def test_serializer_close_with_real_encryption_executor_flushes_dlq():
+    # The DLQ_DESIGN "durable shutdown" path: a dedicated registry holding a real
+    # FieldEncryptionExecutor plus a DlqAction. Closing the serde must close the
+    # encryption executor without raising AND still flush the DLQ producer.
+    conf = {'url': _BASE_URL}
+    client = SchemaRegistryClient.new_client(conf)
+
+    producer = RecordingProducer()
+    registry = RuleRegistry()
+    registry.register_executor(FieldEncryptionExecutor(FakeClock()))
+    registry.register_action(DlqAction({'dlq.topic': _DLQ_TOPIC, 'producer': producer}))
+
+    ser = AvroSerializer(client, schema_str='"string"', conf={'auto.register.schemas': True}, rule_registry=registry)
+    ser.close()  # must not raise
+    assert producer.flush_count == 1
+
+
+def test_close_isolates_failing_executor_and_still_flushes_dlq():
+    # Regression: a failing executor.close() must not abort shutdown before the
+    # DlqAction is flushed. Actions are flushed first and every close is isolated,
+    # so buffered DLQ records survive a buggy executor.
+    conf = {'url': _BASE_URL}
+    client = SchemaRegistryClient.new_client(conf)
+
+    producer = RecordingProducer()
+    registry = RuleRegistry()
+
+    class _BoomExecutor(FieldRedactionExecutor):
+        def close(self):
+            raise RuntimeError("boom")
+
+    registry.register_executor(_BoomExecutor())
+    registry.register_action(DlqAction({'dlq.topic': _DLQ_TOPIC, 'producer': producer}))
+
+    ser = AvroSerializer(client, schema_str='"string"', conf={'auto.register.schemas': True}, rule_registry=registry)
+    ser.close()  # must not raise despite the failing executor
+    assert producer.flush_count == 1
 
 
 def test_serializer_close_does_not_close_shared_global_registry():
@@ -598,5 +644,5 @@ def test_proto_dlq_encryption_write_redaction():
     assert base64.b64encode(b'foobar') not in value
     assert b'<REDACTED>' in value
     assert b'The Castle' in value
-    # redaction mutates the failed message in place
-    assert obj.name == FieldRedactionExecutor.REDACTED_STRING
+    # redaction runs on a copy: the caller's object keeps its original value
+    assert obj.name == 'Kafka'

--- a/tests/schema_registry/test_dlq_action.py
+++ b/tests/schema_registry/test_dlq_action.py
@@ -129,7 +129,7 @@ def test_convert_to_bytes_matrix():
     assert convert(ctx, 'str') == b'str'
     u = uuid.uuid4()
     assert convert(ctx, u) == str(u).encode('utf-8')
-    # bool falls through to the JSON path, as in Java
+    # bool falls through to the JSON path
     assert convert(ctx, True) == b'true'
     assert convert(ctx, 7) == struct.pack('>q', 7)
     # signed int64 boundaries still take the fixed-width path
@@ -307,7 +307,7 @@ def test_redact_fields_no_matching_rule_type():
 
 
 def test_redact_fields_fail_open():
-    # redaction errors are fail-open, as in Java: the unredacted message is sent
+    # redaction errors are fail-open: the unredacted message is sent
     producer = RecordingProducer()
     action = DlqAction({'dlq.topic': 'dlq', 'producer': producer})
     rule = _make_rule(rule_type='ENCRYPT', kind=RuleKind.TRANSFORM, tags=['PII'])
@@ -332,7 +332,7 @@ def test_is_dlq_replay():
     assert is_dlq_replay(None, ctx_with([('__rule.name', 'my-rule')]), rule) is True
     assert is_dlq_replay(None, ctx_with([('__rule.name', b'other')]), rule) is False
     assert is_dlq_replay(None, ctx_with([('other', b'my-rule')]), rule) is False
-    # last occurrence wins, matching Java's Headers.lastHeader
+    # last occurrence wins when a header key repeats
     assert is_dlq_replay(None, ctx_with([('__rule.name', b'other'), ('__rule.name', b'my-rule')]), rule) is True
     assert is_dlq_replay(None, ctx_with([('__rule.name', b'my-rule'), ('__rule.name', b'other')]), rule) is False
     assert is_dlq_replay(None, ctx_with({'__rule.name': b'my-rule'}), rule) is True

--- a/tests/schema_registry/test_dlq_action.py
+++ b/tests/schema_registry/test_dlq_action.py
@@ -1,0 +1,344 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Copyright 2026 Confluent Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+import json
+import struct
+import uuid
+
+import pytest
+
+from confluent_kafka.schema_registry._sync.serde import BaseSerde
+from confluent_kafka.schema_registry.common.avro import get_inline_tags
+from confluent_kafka.schema_registry.common.avro import transform as avro_transform
+from confluent_kafka.schema_registry.common.schema_registry_client import Metadata, MetadataTags
+from confluent_kafka.schema_registry.rules.dlq.dlq_action import DlqAction, FieldRedactionExecutor
+from confluent_kafka.schema_registry.schema_registry_client import Rule, RuleKind, RuleMode, RuleParams, Schema
+from confluent_kafka.schema_registry.serde import RuleContext
+from confluent_kafka.serialization import MessageField, SerializationContext, SerializationError
+
+_TOPIC = "topic1"
+_SUBJECT = _TOPIC + "-value"
+
+
+class RecordingProducer:
+    def __init__(self, produce_error=None):
+        self.records = []
+        self.flush_count = 0
+        self.poll_count = 0
+        self.produce_error = produce_error
+
+    def produce(self, topic, value=None, key=None, headers=None, on_delivery=None, **kwargs):
+        if self.produce_error is not None:
+            raise self.produce_error
+        self.records.append((topic, key, value, headers))
+
+    def poll(self, timeout=0):
+        self.poll_count += 1
+        return 0
+
+    def flush(self, timeout=None):
+        self.flush_count += 1
+        return 0
+
+
+def _make_rule(
+    name='myrule',
+    rule_type='CEL',
+    kind=RuleKind.CONDITION,
+    mode=RuleMode.WRITE,
+    tags=None,
+    params=None,
+    on_failure=None,
+):
+    return Rule(
+        name,
+        "",
+        kind,
+        mode,
+        rule_type,
+        tags,
+        RuleParams(params) if params is not None else None,
+        None,
+        None,
+        on_failure,
+        False,
+    )
+
+
+def _make_ctx(
+    rule=None,
+    rules=None,
+    rule_mode=RuleMode.WRITE,
+    ser_ctx=None,
+    target=None,
+    inline_tags=None,
+    field_transformer=None,
+    original_key=None,
+    original_value=None,
+):
+    if rule is None:
+        rule = _make_rule()
+    if rules is None:
+        rules = [rule]
+    if ser_ctx is None:
+        ser_ctx = SerializationContext(_TOPIC, MessageField.VALUE)
+    return RuleContext(
+        None,
+        ser_ctx,
+        None,
+        target,
+        _SUBJECT,
+        rule_mode,
+        rule,
+        0,
+        rules,
+        inline_tags,
+        field_transformer,
+        original_key,
+        original_value,
+    )
+
+
+def _headers_dict(record):
+    return {k: v for k, v in record[3]}
+
+
+def test_convert_to_bytes_matrix():
+    action = DlqAction({'dlq.topic': 'dlq'})
+    ctx = _make_ctx()
+    convert = action._convert_to_bytes
+
+    assert convert(ctx, None) is None
+    assert convert(ctx, b'raw') == b'raw'
+    assert convert(ctx, bytearray(b'raw')) == b'raw'
+    assert convert(ctx, memoryview(b'raw')) == b'raw'
+    assert convert(ctx, 'str') == b'str'
+    u = uuid.uuid4()
+    assert convert(ctx, u) == str(u).encode('utf-8')
+    # bool falls through to the JSON path, as in Java
+    assert convert(ctx, True) == b'true'
+    assert convert(ctx, 7) == struct.pack('>q', 7)
+    # signed int64 boundaries still take the fixed-width path
+    assert convert(ctx, 2**63 - 1) == struct.pack('>q', 2**63 - 1)
+    assert convert(ctx, -(2**63)) == struct.pack('>q', -(2**63))
+    # ints outside the signed int64 range fall through to the JSON path instead
+    # of raising struct.error and dropping the whole DLQ record
+    assert convert(ctx, 2**63) == b'9223372036854775808'
+    assert convert(ctx, -(2**63) - 1) == b'-9223372036854775809'
+    assert convert(ctx, -1.5) == struct.pack('>d', -1.5)
+    assert convert(ctx, [1, 2]) == b'[1, 2]'
+    # bytes values inside structured messages are rendered as latin-1 strings
+    assert json.loads(convert(ctx, {'a': b'\xe9', 'b': 1})) == {'a': '\xe9', 'b': 1}
+
+
+def test_topic_resolution_precedence():
+    producer = RecordingProducer()
+    ctx = _make_ctx()
+
+    # topic from the constructor conf
+    action = DlqAction({'dlq.topic': 'conf-topic', 'producer': producer})
+    with pytest.raises(SerializationError):
+        action.run(ctx, None, None)
+    assert producer.records[-1][0] == 'conf-topic'
+
+    # rule_conf overrides the constructor conf; non-dlq keys are not merged
+    action.configure({'url': 'mock://'}, {'dlq.topic': 'rule-conf-topic', 'secret': 'mysecret'})
+    with pytest.raises(SerializationError):
+        action.run(ctx, None, None)
+    assert producer.records[-1][0] == 'rule-conf-topic'
+    assert 'secret' not in action._conf
+
+    # rule params via ctx.get_parameter when no topic is configured
+    action = DlqAction({'producer': producer})
+    rule = _make_rule(params={'dlq.topic': 'param-topic'})
+    with pytest.raises(SerializationError):
+        action.run(_make_ctx(rule=rule), None, None)
+    assert producer.records[-1][0] == 'param-topic'
+
+    # no topic anywhere
+    action = DlqAction({'producer': producer})
+    with pytest.raises(SerializationError, match="Could not send to DLQ as no topic is configured"):
+        action.run(ctx, None, None)
+
+
+def test_populate_headers():
+    producer = RecordingProducer()
+    action = DlqAction({'dlq.topic': 'dlq', 'producer': producer})
+    incoming = [('h1', b'v1')]
+    ser_ctx = SerializationContext(_TOPIC, MessageField.VALUE, incoming)
+    rule = _make_rule(name='my-rule')
+    ctx = _make_ctx(rule=rule, ser_ctx=ser_ctx, original_value='payload')
+
+    with pytest.raises(SerializationError):
+        action.run(ctx, None, ValueError("boom"))
+
+    topic, key, value, headers = producer.records[0]
+    assert key is None
+    assert value == b'payload'
+    assert headers[0] == ('h1', b'v1')
+    headers_dict = dict(headers)
+    assert headers_dict[DlqAction.RULE_NAME] == b'my-rule'
+    assert headers_dict[DlqAction.RULE_MODE] == b'WRITE'
+    assert headers_dict[DlqAction.RULE_SUBJECT] == _SUBJECT.encode('utf-8')
+    assert headers_dict[DlqAction.RULE_TOPIC] == _TOPIC.encode('utf-8')
+    assert headers_dict[DlqAction.RULE_EXCEPTION] == b'boom'
+    # the caller's headers are copied, not mutated
+    assert incoming == [('h1', b'v1')]
+
+    # dict headers are normalized, and no exception header without an exception
+    ser_ctx = SerializationContext(_TOPIC, MessageField.VALUE, {'h1': 'v1'})
+    with pytest.raises(SerializationError):
+        action.run(_make_ctx(rule=rule, ser_ctx=ser_ctx), None, None)
+    headers = producer.records[1][3]
+    assert ('h1', b'v1') in headers
+    assert DlqAction.RULE_EXCEPTION not in dict(headers)
+
+
+def test_always_raises_and_chains_cause():
+    producer = RecordingProducer()
+    action = DlqAction({'dlq.topic': 'dlq', 'producer': producer})
+    cause = ValueError("boom")
+
+    with pytest.raises(SerializationError, match="Rule failed: myrule") as exc_info:
+        action.run(_make_ctx(original_value='v'), None, cause)
+    assert exc_info.value.__cause__ is cause
+    assert len(producer.records) == 1
+
+    with pytest.raises(SerializationError, match="Rule failed: myrule") as exc_info:
+        action.run(_make_ctx(original_value='v'), None, None)
+    assert exc_info.value.__cause__ is None
+
+
+def test_produce_failure_is_swallowed():
+    producer = RecordingProducer(produce_error=RuntimeError("kafka down"))
+    action = DlqAction({'dlq.topic': 'dlq', 'producer': producer})
+    # the produce failure is logged, and the rule failure is still raised
+    with pytest.raises(SerializationError, match="Rule failed: myrule"):
+        action.run(_make_ctx(original_value='v'), None, None)
+    assert producer.records == []
+
+
+def test_auto_flush():
+    producer = RecordingProducer()
+    action = DlqAction({'dlq.topic': 'dlq', 'dlq.auto.flush': 'true', 'producer': producer})
+    with pytest.raises(SerializationError):
+        action.run(_make_ctx(original_value='v'), None, None)
+    assert producer.flush_count == 1
+
+    producer = RecordingProducer()
+    action = DlqAction({'dlq.topic': 'dlq', 'producer': producer})
+    with pytest.raises(SerializationError):
+        action.run(_make_ctx(original_value='v'), None, None)
+    assert producer.flush_count == 0
+
+
+_REDACTION_SCHEMA = {
+    'type': 'record',
+    'name': 'test',
+    'fields': [
+        {'name': 'stringField', 'type': 'string', 'confluent:tags': ['PII']},
+        {'name': 'bytesField', 'type': 'bytes', 'confluent:tags': ['PII']},
+        {'name': 'lastName', 'type': 'string'},
+        {'name': 'intField', 'type': 'int'},
+    ],
+}
+
+
+def _redaction_ctx(rule, target=None):
+    def field_transformer(rule_ctx, field_transform, message):
+        return avro_transform(rule_ctx, _REDACTION_SCHEMA, message, field_transform)
+
+    return _make_ctx(
+        rule=rule,
+        target=target if target is not None else Schema(json.dumps(_REDACTION_SCHEMA), 'AVRO'),
+        inline_tags=get_inline_tags(_REDACTION_SCHEMA),
+        field_transformer=field_transformer,
+    )
+
+
+def _redaction_message():
+    return {'stringField': 'John', 'bytesField': b'secret', 'lastName': 'Smith', 'intField': 42}
+
+
+def test_redact_fields_simple():
+    action = DlqAction({'dlq.topic': 'dlq'})
+    rule = _make_rule(rule_type='ENCRYPT', kind=RuleKind.TRANSFORM, tags=['PII'])
+    result = action._redact_fields(_redaction_ctx(rule), _redaction_message())
+    assert result['stringField'] == FieldRedactionExecutor.REDACTED_STRING
+    assert result['bytesField'] == FieldRedactionExecutor.REDACTED_BYTES
+    assert result['lastName'] == 'Smith'
+    assert result['intField'] == 42
+
+
+def test_redact_fields_wildcard_metadata_tags():
+    action = DlqAction({'dlq.topic': 'dlq'})
+    rule = _make_rule(rule_type='ENCRYPT', kind=RuleKind.TRANSFORM, tags=['PII2'])
+    target = Schema(
+        json.dumps(_REDACTION_SCHEMA), 'AVRO', [], Metadata(MetadataTags({'**.lastName': ['PII2']}), None, None), None
+    )
+    result = action._redact_fields(_redaction_ctx(rule, target=target), _redaction_message())
+    assert result['lastName'] == FieldRedactionExecutor.REDACTED_STRING
+    # tags of the rule (PII2) are disjoint from the inline tags (PII)
+    assert result['stringField'] == 'John'
+
+
+def test_redact_fields_no_matching_rule_type():
+    action = DlqAction({'dlq.topic': 'dlq'})
+    rule = _make_rule(rule_type='CEL', kind=RuleKind.CONDITION)
+    message = _redaction_message()
+    result = action._redact_fields(_redaction_ctx(rule), message)
+    assert result is message
+    assert result['stringField'] == 'John'
+    assert result['bytesField'] == b'secret'
+
+
+def test_redact_fields_fail_open():
+    # redaction errors are fail-open, as in Java: the unredacted message is sent
+    producer = RecordingProducer()
+    action = DlqAction({'dlq.topic': 'dlq', 'producer': producer})
+    rule = _make_rule(rule_type='ENCRYPT', kind=RuleKind.TRANSFORM, tags=['PII'])
+    # no field transformer is available, so redaction blows up
+    ctx = _make_ctx(rule=rule, original_value={'stringField': 'hi'})
+    with pytest.raises(SerializationError):
+        action.run(ctx, None, None)
+    assert len(producer.records) == 1
+    assert b'"hi"' in producer.records[0][2]
+
+
+def test_is_dlq_replay():
+    is_dlq_replay = BaseSerde._is_dlq_replay
+    rule = _make_rule(name='my-rule')
+
+    def ctx_with(headers):
+        return _make_ctx(rule=rule, ser_ctx=SerializationContext(_TOPIC, MessageField.VALUE, headers))
+
+    assert is_dlq_replay(None, ctx_with(None), rule) is False
+    assert is_dlq_replay(None, ctx_with([]), rule) is False
+    assert is_dlq_replay(None, ctx_with([('__rule.name', b'my-rule')]), rule) is True
+    assert is_dlq_replay(None, ctx_with([('__rule.name', 'my-rule')]), rule) is True
+    assert is_dlq_replay(None, ctx_with([('__rule.name', b'other')]), rule) is False
+    assert is_dlq_replay(None, ctx_with([('other', b'my-rule')]), rule) is False
+    # last occurrence wins, matching Java's Headers.lastHeader
+    assert is_dlq_replay(None, ctx_with([('__rule.name', b'other'), ('__rule.name', b'my-rule')]), rule) is True
+    assert is_dlq_replay(None, ctx_with([('__rule.name', b'my-rule'), ('__rule.name', b'other')]), rule) is False
+    assert is_dlq_replay(None, ctx_with({'__rule.name': b'my-rule'}), rule) is True
+    assert is_dlq_replay(None, ctx_with({'__rule.name': None}), rule) is False
+    # undecodable header values do not match
+    assert is_dlq_replay(None, ctx_with([('__rule.name', b'\xff\xfe')]), rule) is False
+
+    nameless = _make_rule(name=None)
+    assert is_dlq_replay(None, ctx_with([('__rule.name', b'my-rule')]), nameless) is False

--- a/tests/test_DeserializingConsumer.py
+++ b/tests/test_DeserializingConsumer.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Copyright 2026 Confluent Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""Unit tests for DeserializingConsumer.
+
+Broker-free: the deserialization logic (``DeserializingConsumer._deserialize``)
+is exercised by constructing ``confluent_kafka.cimpl.Message`` objects directly.
+The key is deserialized before the value so a key deserializer can stash the
+original key for the value deserializer (used by the Schema Registry
+dead-letter-queue rule action).
+"""
+
+import pytest
+
+from confluent_kafka import DeserializingConsumer
+from confluent_kafka.cimpl import Message
+from confluent_kafka.error import KeyDeserializationError, ValueDeserializationError
+from confluent_kafka.serialization import MessageField, StringDeserializer
+
+
+def _make_message(value=None, key=None, topic='t', partition=0, offset=0, headers=None):
+    # Positional signature matches tests/test_message.py.
+    return Message(topic, partition, offset, key, value, headers, None, (0, 0), -1.0, -1)
+
+
+class _RecordingDeserializer:
+    """Deserializer double; records ``(data, ctx.field)`` at call time."""
+
+    def __init__(self, result):
+        self._result = result
+        self.calls = []
+
+    def __call__(self, data, ctx):
+        self.calls.append((data, ctx.field))
+        return self._result
+
+
+def _boom(_data, _ctx):
+    raise ValueError('cannot deserialize')
+
+
+@pytest.fixture
+def make_dc():
+    """Factory for offline DeserializingConsumers (construction does not connect)."""
+
+    def _make(key_deserializer=None, value_deserializer=None):
+        conf = {'group.id': 'test-dc', 'bootstrap.servers': 'localhost:9092', 'socket.timeout.ms': 10}
+        if key_deserializer is not None:
+            conf['key.deserializer'] = key_deserializer
+        if value_deserializer is not None:
+            conf['value.deserializer'] = value_deserializer
+        return DeserializingConsumer(conf)
+
+    return _make
+
+
+def test_deserialize_both(make_dc):
+    dc = make_dc(key_deserializer=StringDeserializer(), value_deserializer=StringDeserializer())
+    msg = dc._deserialize(_make_message(value=b'v', key=b'k'))
+    assert msg.key() == 'k'
+    assert msg.value() == 'v'
+
+
+def test_deserialize_processes_key_before_value(make_dc):
+    # the key must be deserialized before the value so a key deserializer can
+    # stash the original key for the value deserializer (e.g. the SR DLQ action).
+    order = []
+
+    def kd(_data, _ctx):
+        order.append('key')
+        return 'K'
+
+    def vd(_data, _ctx):
+        order.append('value')
+        return 'V'
+
+    dc = make_dc(key_deserializer=kd, value_deserializer=vd)
+    dc._deserialize(_make_message(value=b'v', key=b'k'))
+    assert order == ['key', 'value']
+
+
+def test_deserialize_serialization_context_fields(make_dc):
+    kd = _RecordingDeserializer('K')
+    vd = _RecordingDeserializer('V')
+    dc = make_dc(key_deserializer=kd, value_deserializer=vd)
+    dc._deserialize(_make_message(value=b'v', key=b'k'))
+    assert kd.calls == [(b'k', MessageField.KEY)]
+    assert vd.calls == [(b'v', MessageField.VALUE)]
+
+
+def test_key_failure_short_circuits_value(make_dc):
+    # the key is deserialized first, so a key failure bails before the value.
+    vd = _RecordingDeserializer('V')
+    dc = make_dc(key_deserializer=_boom, value_deserializer=vd)
+    with pytest.raises(KeyDeserializationError):
+        dc._deserialize(_make_message(value=b'v', key=b'k'))
+    assert vd.calls == []
+
+
+def test_value_failure_raises(make_dc):
+    dc = make_dc(key_deserializer=StringDeserializer(), value_deserializer=_boom)
+    with pytest.raises(ValueDeserializationError):
+        dc._deserialize(_make_message(value=b'v', key=b'k'))
+
+
+def test_none_topic_raises_type_error(make_dc):
+    dc = make_dc(value_deserializer=StringDeserializer())
+    with pytest.raises(TypeError, match='Message topic is None'):
+        dc._deserialize(_make_message(value=b'v', topic=None))

--- a/tests/test_DeserializingShareConsumer.py
+++ b/tests/test_DeserializingShareConsumer.py
@@ -55,8 +55,8 @@ class _RecordingDeserializer:
     """Deserializer double; records ``(data, topic, field, headers)`` at call time.
 
     The field is captured eagerly because ``_deserialize`` reuses a single
-    :class:`SerializationContext` and flips ``.field`` from VALUE to KEY between
-    the value and key calls.
+    :class:`SerializationContext` and flips ``.field`` from KEY to VALUE between
+    the key and value calls.
     """
 
     def __init__(self, result):
@@ -272,8 +272,8 @@ def test_failure_preserves_coordinates(make_dsc, explicit):
 
 @pytest.mark.parametrize("explicit", [False, True])
 def test_key_failure_does_not_write_back_value(make_dsc, explicit):
-    # value decodes but key fails; both are written back only after both succeed,
-    # so value() must stay raw.
+    # the key fails before the value is deserialized; both are written back only
+    # after both succeed, so value() must stay raw.
     dsc = make_dsc(explicit=explicit, value_deserializer=StringDeserializer(), key_deserializer=_boom)
     msg = _make_message(value=b'hello', key=b'k')
     dsc._deserialize(msg)
@@ -283,14 +283,35 @@ def test_key_failure_does_not_write_back_value(make_dsc, explicit):
 
 
 @pytest.mark.parametrize("explicit", [False, True])
-def test_value_failure_short_circuits_key(make_dsc, explicit):
-    # a value failure should bail before touching the key deserializer.
-    kd = _RecordingDeserializer('K')
-    dsc = make_dsc(explicit=explicit, value_deserializer=_boom, key_deserializer=kd)
+def test_key_failure_short_circuits_value(make_dsc, explicit):
+    # the key is deserialized first, so a key failure should bail before
+    # touching the value deserializer.
+    vd = _RecordingDeserializer('V')
+    dsc = make_dsc(explicit=explicit, key_deserializer=_boom, value_deserializer=vd)
     msg = _make_message(value=b'v', key=b'k')
     dsc._deserialize(msg)
-    assert msg.error().code() == KafkaError._VALUE_DESERIALIZATION
-    assert kd.calls == []
+    assert msg.error().code() == KafkaError._KEY_DESERIALIZATION
+    assert vd.calls == []
+
+
+@pytest.mark.parametrize("explicit", [False, True])
+def test_deserialize_processes_key_before_value(make_dsc, explicit):
+    # the key must be deserialized before the value so a key deserializer can
+    # stash the original key for the value deserializer (e.g. the SR DLQ action).
+    order = []
+
+    def kd(_data, _ctx):
+        order.append('key')
+        return 'K'
+
+    def vd(_data, _ctx):
+        order.append('value')
+        return 'V'
+
+    dsc = make_dsc(explicit=explicit, key_deserializer=kd, value_deserializer=vd)
+    msg = _make_message(value=b'v', key=b'k')
+    dsc._deserialize(msg)
+    assert order == ['key', 'value']
 
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
Port the Java client's DlqAction to confluent-kafka-python. When a data-contract rule (CSFLE encryption, CEL condition, etc.) fails during serialize/deserialize and the rule's onFailure is set to "DLQ", the record is teed to a dead-letter-queue topic and a SerializationError is still raised (tee, not swallow).

- DlqAction + FieldRedactionExecutor under rules/dlq/
- Capture original key/value for the DLQ record via a contextvar (thread- and task-safe), mirroring the Java client's ThreadLocal
- Redact fields tagged by encryption rules before JSON-encoding so plaintext does not leak to the DLQ
- Skip a rule on replay when the record carries the matching __rule.name header
- Configure registered rule actions in each serde; close owns non-global registries

<!--
Suggested PR template: Fill/delete/add sections as needed. Optionally delete any commented block.
-->
What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include implementation strategy.
-->

Checklist
------------------
- [x] Contains customer facing changes? Including API/behavior changes <!-- This can help identify if it has introduced any breaking changes -->
- [ ] Did you add sufficient unit test and/or integration test coverage for this PR?
  - If not, please explain why it is not required

References
----------
JIRA: 
<!--
Copy&paste links: to Jira ticket, other PRs, issues, Slack conversations...
For code bumps: link to PR, tag or GitHub `/compare/master...master`
-->

DGS-14069

Test & Review
------------
<!--
Has it been tested? how?
Copy&paste any handy instructions, steps or requirements that can save time to the reviewer or any reader.
-->

Open questions / Follow-ups
--------------------------
<!--
Optional: anything open to discussion for the reviewer, out of scope, or follow-ups.
-->

<!--
Review stakeholders
------------------
<!--
Optional: mention stakeholders or if special context that is required to review.
-->
