### PR TITLE
[NOGIL] Declare cimpl free-threaded on CPython 3.14t

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ for a worked example.
 ### Enhancements
 
 - Add support for union-of-pools and auto pool mapping for Schema Registry (#2182)
+- Add free-threaded CPython 3.14 support to the core C extension.
 
 ### Fixes
 

--- a/src/confluent_kafka/src/ShareConsumer.c
+++ b/src/confluent_kafka/src/ShareConsumer.c
@@ -328,6 +328,26 @@ static PyObject *ShareConsumer_subscription(ShareConsumerHandle *self,
  * @brief Poll for a batch of messages from the share consumer.
  *
  */
+static PyObject *ShareConsumer_get_messages_type(void) {
+        static PyObject *messages_type = NULL;
+#ifdef Py_GIL_DISABLED
+        static PyMutex messages_type_mutex = {0};
+
+        PyMutex_Lock(&messages_type_mutex);
+#endif
+
+        if (!messages_type)
+                messages_type =
+                    cfl_PyObject_lookup("confluent_kafka._model", "Messages");
+
+#ifdef Py_GIL_DISABLED
+        PyMutex_Unlock(&messages_type_mutex);
+#endif
+
+        return messages_type;
+}
+
+
 static PyObject *ShareConsumer_poll(ShareConsumerHandle *self,
                                     PyObject *args,
                                     PyObject *kwargs) {
@@ -337,9 +357,8 @@ static PyObject *ShareConsumer_poll(ShareConsumerHandle *self,
         size_t rkmessages_size          = 0;
         rd_kafka_error_t *error         = NULL;
         PyObject *msglist;
+        PyObject *messages_type;
         PyObject *records;
-        /* Cached for the process lifetime; see the lazy lookup below. */
-        static PyObject *Messages_type = NULL;
         CallState cs;
         const int CHUNK_TIMEOUT_MS = 200; /* 200ms chunks for signal checking */
         int total_timeout_ms;
@@ -445,26 +464,19 @@ static PyObject *ShareConsumer_poll(ShareConsumerHandle *self,
 
         rd_kafka_messages_destroy(rkmessages);
 
-        /* Wrap the plain list in Messages so callers get records() /
-         * count() / is_empty(). The class object is the same for the whole
-         * process, so look it up on the first poll and hold that reference
-         * forever -- this is on the hot path and the per-call import+attr
-         * lookup isn't free. The GIL serializes this first init. */
-        if (!Messages_type) {
-                Messages_type =
-                    cfl_PyObject_lookup("confluent_kafka._model", "Messages");
-                if (!Messages_type) {
-                        Py_DECREF(msglist);
-                        return NULL;
-                }
-                /* Kept for the process lifetime, so it's intentionally never
-                 * DECREF'd. */
+        /* The class object is cached for the process lifetime. Free-threaded
+         * builds synchronize the first lookup because the GIL no longer
+         * serializes concurrent poll calls. */
+        messages_type = ShareConsumer_get_messages_type();
+        if (!messages_type) {
+                Py_DECREF(msglist);
+                return NULL;
         }
 
         /* _from_list takes over msglist as-is (no copy) -- we built it for
          * this and don't touch it again. */
         records =
-            PyObject_CallMethod(Messages_type, "_from_list", "O", msglist);
+            PyObject_CallMethod(messages_type, "_from_list", "O", msglist);
         Py_DECREF(msglist);
 
         return records;

--- a/src/confluent_kafka/src/confluent_kafka.c
+++ b/src/confluent_kafka/src/confluent_kafka.c
@@ -3926,6 +3926,10 @@ static PyObject *_init_cimpl(void) {
         if (!m)
                 return NULL;
 
+#ifdef Py_GIL_DISABLED
+        PyUnstable_Module_SetGIL(m, Py_MOD_GIL_NOT_USED);
+#endif
+
         Py_INCREF(&KafkaErrorType);
         KafkaErrorType.tp_doc =
             KafkaError_add_errs(KafkaErrorType.tp_dict, KafkaErrorType.tp_doc);

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -35,16 +35,12 @@ if FREE_THREADED_BUILD:
         at the test file whose imports or tests re-enabled the GIL; the
         interpreter's own RuntimeWarning names the offending extension module.
 
-        TODO NOGIL: replace the warnings with the commented asserts in the same
-        PR that declares Py_MOD_GIL_NOT_USED in cimpl. Until then a re-enable
-        is expected (cimpl itself triggers it) and must not fail the suite.
+        The full suite imports optional compiled dependencies that may still
+        re-enable the GIL. Strict cimpl checks run in an isolated process via
+        tests/test_free_threading.py.
         """
         if sys._is_gil_enabled():
             warnings.warn("the GIL was re-enabled before this test module started", RuntimeWarning)
-        # assert not sys._is_gil_enabled(), \
-        #     "the GIL was re-enabled before this test module started"
         yield
         if sys._is_gil_enabled():
             warnings.warn("the GIL was re-enabled by this test module", RuntimeWarning)
-        # assert not sys._is_gil_enabled(), \
-        #     "the GIL was re-enabled by this test module"

--- a/tests/integration/test_free_threading_shared_clients.py
+++ b/tests/integration/test_free_threading_shared_clients.py
@@ -1,5 +1,22 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Copyright 2026 Confluent Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 import concurrent.futures
-import os
 import sys
 import sysconfig
 import threading
@@ -9,39 +26,31 @@ import uuid
 import pytest
 
 from confluent_kafka import Consumer, Producer
-from confluent_kafka.admin import AdminClient, NewTopic
+from confluent_kafka.admin import AdminClient
 
 FREE_THREADED_BUILD = bool(sysconfig.get_config_var("Py_GIL_DISABLED"))
-BOOTSTRAP_SERVERS = os.environ.get("TEST_FREE_THREADED_BROKER")
 
-pytestmark = [
-    pytest.mark.skipif(
-        not FREE_THREADED_BUILD,
-        reason="requires a free-threaded CPython build",
-    ),
-    pytest.mark.skipif(
-        not BOOTSTRAP_SERVERS,
-        reason="TEST_FREE_THREADED_BROKER is not set",
-    ),
-]
+pytestmark = pytest.mark.skipif(
+    not FREE_THREADED_BUILD,
+    reason="requires a free-threaded CPython build",
+)
 
 
-def test_shared_clients_against_real_broker():
-    topic = f"confluent-kafka-nogil-{uuid.uuid4().hex}"
-    admin = AdminClient({"bootstrap.servers": BOOTSTRAP_SERVERS})
+def test_shared_clients_against_real_broker(kafka_cluster):
+    assert not sys._is_gil_enabled()
 
-    admin.create_topics([NewTopic(topic, 1, 1)])[topic].result(15)
+    topic = kafka_cluster.create_topic_and_wait_propogation(
+        "confluent-kafka-nogil",
+        {"num_partitions": 1, "replication_factor": 1},
+    )
+    admin = AdminClient(kafka_cluster.client_conf())
+
     try:
         with concurrent.futures.ThreadPoolExecutor(max_workers=8) as executor:
             metadata = list(executor.map(lambda _: admin.list_topics(timeout=5), range(32)))
         assert all(topic in item.topics for item in metadata)
 
-        producer = Producer(
-            {
-                "bootstrap.servers": BOOTSTRAP_SERVERS,
-                "queue.buffering.max.messages": 100_000,
-            }
-        )
+        producer = Producer(kafka_cluster.client_conf({"queue.buffering.max.messages": 100_000}))
         delivered = 0
         delivered_lock = threading.Lock()
 
@@ -69,12 +78,13 @@ def test_shared_clients_against_real_broker():
         assert delivered == 2_000
 
         consumer = Consumer(
-            {
-                "bootstrap.servers": BOOTSTRAP_SERVERS,
-                "group.id": f"confluent-kafka-nogil-{uuid.uuid4().hex}",
-                "auto.offset.reset": "earliest",
-                "enable.auto.commit": False,
-            }
+            kafka_cluster.client_conf(
+                {
+                    "group.id": f"confluent-kafka-nogil-{uuid.uuid4().hex}",
+                    "auto.offset.reset": "earliest",
+                    "enable.auto.commit": False,
+                }
+            )
         )
         consumer.subscribe([topic])
         seen = set()
@@ -100,4 +110,4 @@ def test_shared_clients_against_real_broker():
         assert len(seen) == 2_000
         assert not sys._is_gil_enabled()
     finally:
-        admin.delete_topics([topic], operation_timeout=10)[topic].result(15)
+        kafka_cluster.delete_topic(topic)

--- a/tests/test_free_threading.py
+++ b/tests/test_free_threading.py
@@ -1,0 +1,81 @@
+import concurrent.futures
+import sys
+import sysconfig
+import threading
+
+import pytest
+
+from confluent_kafka import Producer
+
+FREE_THREADED_BUILD = bool(sysconfig.get_config_var("Py_GIL_DISABLED"))
+
+pytestmark = pytest.mark.skipif(
+    not FREE_THREADED_BUILD,
+    reason="requires a free-threaded CPython build",
+)
+
+
+def producer_config():
+    return {
+        "bootstrap.servers": "127.0.0.1:1",
+        "message.timeout.ms": 50,
+        "socket.timeout.ms": 10,
+        "queue.buffering.max.messages": 100_000,
+    }
+
+
+def test_cimpl_keeps_gil_disabled():
+    assert not sys._is_gil_enabled()
+
+
+def test_independent_producers_from_multiple_threads():
+    def produce(thread_id):
+        delivered = 0
+
+        def on_delivery(_error, _message):
+            nonlocal delivered
+            delivered += 1
+
+        producer = Producer(producer_config())
+        for index in range(200):
+            producer.produce(
+                "free-threading-independent",
+                value=f"{thread_id}:{index}",
+                callback=on_delivery,
+            )
+        assert producer.flush(5.0) == 0
+        return delivered
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=8) as executor:
+        delivered = list(executor.map(produce, range(8)))
+
+    assert delivered == [200] * 8
+    assert not sys._is_gil_enabled()
+
+
+def test_shared_producer_from_multiple_threads():
+    producer = Producer(producer_config())
+    delivered = 0
+    delivered_lock = threading.Lock()
+
+    def on_delivery(_error, _message):
+        nonlocal delivered
+        with delivered_lock:
+            delivered += 1
+
+    def produce(thread_id):
+        for index in range(500):
+            producer.produce(
+                "free-threading-shared",
+                value=f"{thread_id}:{index}",
+                callback=on_delivery,
+            )
+            if index % 25 == 0:
+                producer.poll(0)
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=8) as executor:
+        list(executor.map(produce, range(8)))
+
+    assert producer.flush(10.0) == 0
+    assert delivered == 4_000
+    assert not sys._is_gil_enabled()

--- a/tests/test_free_threading.py
+++ b/tests/test_free_threading.py
@@ -1,3 +1,21 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Copyright 2026 Confluent Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 import concurrent.futures
 import sys
 import sysconfig

--- a/tests/test_free_threading_shared_clients.py
+++ b/tests/test_free_threading_shared_clients.py
@@ -1,0 +1,103 @@
+import concurrent.futures
+import os
+import sys
+import sysconfig
+import threading
+import time
+import uuid
+
+import pytest
+
+from confluent_kafka import Consumer, Producer
+from confluent_kafka.admin import AdminClient, NewTopic
+
+FREE_THREADED_BUILD = bool(sysconfig.get_config_var("Py_GIL_DISABLED"))
+BOOTSTRAP_SERVERS = os.environ.get("TEST_FREE_THREADED_BROKER")
+
+pytestmark = [
+    pytest.mark.skipif(
+        not FREE_THREADED_BUILD,
+        reason="requires a free-threaded CPython build",
+    ),
+    pytest.mark.skipif(
+        not BOOTSTRAP_SERVERS,
+        reason="TEST_FREE_THREADED_BROKER is not set",
+    ),
+]
+
+
+def test_shared_clients_against_real_broker():
+    topic = f"confluent-kafka-nogil-{uuid.uuid4().hex}"
+    admin = AdminClient({"bootstrap.servers": BOOTSTRAP_SERVERS})
+
+    admin.create_topics([NewTopic(topic, 1, 1)])[topic].result(15)
+    try:
+        with concurrent.futures.ThreadPoolExecutor(max_workers=8) as executor:
+            metadata = list(executor.map(lambda _: admin.list_topics(timeout=5), range(32)))
+        assert all(topic in item.topics for item in metadata)
+
+        producer = Producer(
+            {
+                "bootstrap.servers": BOOTSTRAP_SERVERS,
+                "queue.buffering.max.messages": 100_000,
+            }
+        )
+        delivered = 0
+        delivered_lock = threading.Lock()
+
+        def on_delivery(error, _message):
+            nonlocal delivered
+            assert error is None
+            with delivered_lock:
+                delivered += 1
+
+        def produce(thread_id):
+            for index in range(250):
+                producer.produce(
+                    topic,
+                    key=f"{thread_id}:{index}",
+                    value=b"free-threaded",
+                    callback=on_delivery,
+                )
+                if index % 25 == 0:
+                    producer.poll(0)
+
+        with concurrent.futures.ThreadPoolExecutor(max_workers=8) as executor:
+            list(executor.map(produce, range(8)))
+
+        assert producer.flush(20) == 0
+        assert delivered == 2_000
+
+        consumer = Consumer(
+            {
+                "bootstrap.servers": BOOTSTRAP_SERVERS,
+                "group.id": f"confluent-kafka-nogil-{uuid.uuid4().hex}",
+                "auto.offset.reset": "earliest",
+                "enable.auto.commit": False,
+            }
+        )
+        consumer.subscribe([topic])
+        seen = set()
+        seen_lock = threading.Lock()
+        stop = threading.Event()
+        deadline = time.monotonic() + 30
+
+        def consume():
+            while not stop.is_set() and time.monotonic() < deadline:
+                message = consumer.poll(0.2)
+                if message is None:
+                    continue
+                assert message.error() is None
+                with seen_lock:
+                    seen.add(message.key())
+                    if len(seen) == 2_000:
+                        stop.set()
+
+        with concurrent.futures.ThreadPoolExecutor(max_workers=4) as executor:
+            list(executor.map(lambda _: consume(), range(4)))
+
+        consumer.close()
+        assert len(seen) == 2_000
+        assert not sys._is_gil_enabled()
+    finally:
+        admin.delete_topics([topic], operation_timeout=10)[topic].result(15)

--- a/tools/source-package-verification.sh
+++ b/tools/source-package-verification.sh
@@ -14,7 +14,7 @@ if [[ $FREE_THREADED == "1" ]]; then
     uv pip install -r requirements/requirements-tests-install-nogil.txt
     FREE_THREADED_PYTEST_ARGS=(
         --ignore=tests/test_free_threading.py
-        --ignore=tests/test_free_threading_shared_clients.py
+        --ignore=tests/integration/test_free_threading_shared_clients.py
     )
 else
     uv pip install -r requirements/requirements-tests-install.txt
@@ -33,9 +33,9 @@ run_free_threaded_tests() {
     if [[ $FREE_THREADED == "1" ]]; then
         # Keep this in a separate process so optional compiled test dependencies
         # cannot re-enable the GIL before cimpl is verified.
-        python -m pytest --timeout 1200 \
-            tests/test_free_threading.py \
-            tests/test_free_threading_shared_clients.py
+        python -m pytest --timeout 1200 tests/test_free_threading.py
+        PYTHON_GIL=0 python -m pytest --timeout 1200 \
+            tests/integration/test_free_threading_shared_clients.py
     fi
 }
 

--- a/tools/source-package-verification.sh
+++ b/tools/source-package-verification.sh
@@ -12,6 +12,10 @@ if [[ $FREE_THREADED == "1" ]]; then
     # orjson) ship no free-threaded wheels and their source builds fail
     # (e.g. tink needs protoc), so install the supported subset.
     uv pip install -r requirements/requirements-tests-install-nogil.txt
+    FREE_THREADED_PYTEST_ARGS=(
+        --ignore=tests/test_free_threading.py
+        --ignore=tests/test_free_threading_shared_clients.py
+    )
 else
     uv pip install -r requirements/requirements-tests-install.txt
     # Install orjson (CI-only) so the test suite exercises the orjson fast-path
@@ -21,8 +25,19 @@ else
     # the default test deps. The stdlib fallback is covered by
     # tests/schema_registry/test_json_codec.py regardless.
     uv pip install -r requirements/requirements-json-fast.txt
+    FREE_THREADED_PYTEST_ARGS=()
 fi
 uv pip install -U build
+
+run_free_threaded_tests() {
+    if [[ $FREE_THREADED == "1" ]]; then
+        # Keep this in a separate process so optional compiled test dependencies
+        # cannot re-enable the GIL before cimpl is verified.
+        python -m pytest --timeout 1200 \
+            tests/test_free_threading.py \
+            tests/test_free_threading_shared_clients.py
+    fi
+}
 
 # Cache trivup Apache Kafka versions
 
@@ -52,8 +67,10 @@ if [[ $RUN_COVERAGE == true ]]; then
       # Example: ".tox/cover/lib/python3.11/site-packages/confluent_kafka/__init__.py"
       #   instead of "src/confluent_kafka/__init__.py"
   uv pip install -e .
+  run_free_threaded_tests
   python -m pytest --cov confluent_kafka --cov-report term --cov-report html --cov-report xml \
-      --cov-branch --junitxml=test-report.xml tests/ --timeout 1200 --ignore=dest
+      --cov-branch --junitxml=test-report.xml tests/ --timeout 1200 --ignore=dest \
+      "${FREE_THREADED_PYTEST_ARGS[@]}"
   exit 0
 fi
 
@@ -95,7 +112,10 @@ if missing:
 print(f'All required extras present: {required}')
 "
     fi
-    python -m pytest --timeout 1200 --ignore=dest
+    run_free_threaded_tests
+    python -m pytest --timeout 1200 --ignore=dest "${FREE_THREADED_PYTEST_ARGS[@]}"
 else
-    python -m pytest --timeout 1200 --ignore=dest --ignore=tests/integration
+    run_free_threaded_tests
+    python -m pytest --timeout 1200 --ignore=dest --ignore=tests/integration \
+        "${FREE_THREADED_PYTEST_ARGS[@]}"
 fi


### PR DESCRIPTION
Relates to #2092

## What

Declare the CPython 3.14t `cimpl` extension as free-threaded and protect the
lazy `ShareConsumer` `Messages` type cache when the GIL is disabled.

This is based on `dev_thread_free_support`, which already provides the 3.14t
build and test dependency preparation.

## Changes

- Call `PyUnstable_Module_SetGIL(m, Py_MOD_GIL_NOT_USED)` for free-threaded
  builds.
- Protect the process-lifetime `Messages` type initialization with `PyMutex`
  on free-threaded builds.
- Add isolated free-threading tests for independent and shared Producer use.
- Add an integration test using the existing `kafka_cluster` fixture to cover
  shared AdminClient, Producer, and Consumer operations.
- Run the strict free-threading tests in a separate process before the full
  regression suite. The full suite still reports warnings when optional
  third-party extensions, such as `fastavro`, re-enable the GIL.

## Validation

Validated on CPython 3.14.6 free-threading at `/opt/python314t` on 10.2:

- Formatting, shell syntax, and diff checks passed.
- Isolated no-GIL tests: `3 passed, 1 skipped` without a broker.
- Real-broker no-GIL tests: `4 passed` against `127.0.0.1:19092` before wiring
  the test into the project integration fixture.
- Final `kafka_cluster` integration test against the same broker:
  `1 passed in 1.42s` with `PYTHON_GIL=0`.
- Core regression tests: `108 passed`.
- `pip check`: no broken requirements.
- Earlier 60-second real-broker soak: 99 rounds, approximately 198,000
  messages, zero failures, and no leftover temporary topics.

The integration test is run in a separate `PYTHON_GIL=0` process because the
full test process imports optional extensions such as `fastavro` that can
re-enable the GIL. The existing source verification job already prepares the
Kafka artifact used by the `kafka_cluster` fixture.

## Scope

This change does not claim concurrent `close` while another thread is still
calling `poll` or `consume`. Callers must stop worker threads before closing a
shared client.
