### PR TITLE
Fix 64-bit offset/timestamp truncation on Windows in Admin/Uuid marshalling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 
 ### Fixes
 
+- Fixed `AdminClient.list_offsets()` and `AdminClient.delete_records()` returning a wrapped-around, negative offset/timestamp on Windows for values above 2^31. The 64-bit values from librdkafka were being marshalled into Python through a helper that took a C `long`, which is only 32 bits on Windows (LLP64), truncating the value; `Uuid.most_significant_bits()`/`least_significant_bits()` had the same issue. Fixes Issue [#1696](https://github.com/confluentinc/confluent-kafka-python/issues/1696).
 - Fixed memory leak in `Producer.produce()` when called with headers and raises `BufferError` (queue full) or `RuntimeError` (producer closed). The allocated `rd_headers` memory is now properly freed in error paths before returning. Fixes Issue [#2167](https://github.com/confluentinc/confluent-kafka-python/issues/2167).
 - Fixed type hinting of `KafkaError` class, `Consumer.__init()__`, `Producer.__init()__`, `Producer.produce()` and `Consumer.commit()` and introduced a script in tools directory to keep error codes up to date. Fixes Issue [#2168](https://github.com/confluentinc/confluent-kafka-python/issues/2168).
 

--- a/src/confluent_kafka/src/Admin.c
+++ b/src/confluent_kafka/src/Admin.c
@@ -4948,9 +4948,10 @@ static PyObject *Admin_c_ListOffsetsResultInfos_to_py(
                         PyObject *args   = NULL;
                         PyObject *kwargs = NULL;
                         kwargs           = PyDict_New();
-                        cfl_PyDict_SetLong(kwargs, "offset",
-                                           c_topic_partition->offset);
-                        cfl_PyDict_SetLong(kwargs, "timestamp", c_timestamp);
+                        cfl_PyDict_SetLongLong(kwargs, "offset",
+                                               c_topic_partition->offset);
+                        cfl_PyDict_SetLongLong(kwargs, "timestamp",
+                                               c_timestamp);
                         cfl_PyDict_SetInt(
                             kwargs, "leader_epoch",
                             rd_kafka_topic_partition_get_leader_epoch(
@@ -5006,8 +5007,8 @@ static PyObject *Admin_c_DeletedRecords_to_py(
                         PyObject *args   = NULL;
                         PyObject *kwargs = NULL;
                         kwargs           = PyDict_New();
-                        cfl_PyDict_SetLong(kwargs, "low_watermark",
-                                           c_topic_partition->offset);
+                        cfl_PyDict_SetLongLong(kwargs, "low_watermark",
+                                               c_topic_partition->offset);
                         args = PyTuple_New(0);
                         value =
                             PyObject_Call(DeletedRecords_type, args, kwargs);

--- a/src/confluent_kafka/src/confluent_kafka.c
+++ b/src/confluent_kafka/src/confluent_kafka.c
@@ -1098,7 +1098,7 @@ PyObject *Message_new0(const Handle *handle, const rd_kafka_message_t *rkm) {
  ****************************************************************************/
 static PyObject *Uuid_most_significant_bits(Uuid *self, PyObject *ignore) {
         if (self->cUuid) {
-                return cfl_PyLong_FromLong(
+                return cfl_PyLong_FromLongLong(
                     rd_kafka_Uuid_most_significant_bits(self->cUuid));
         }
         Py_RETURN_NONE;
@@ -1106,7 +1106,7 @@ static PyObject *Uuid_most_significant_bits(Uuid *self, PyObject *ignore) {
 
 static PyObject *Uuid_least_significant_bits(Uuid *self, PyObject *ignore) {
         if (self->cUuid) {
-                return cfl_PyLong_FromLong(
+                return cfl_PyLong_FromLongLong(
                     rd_kafka_Uuid_least_significant_bits(self->cUuid));
         }
         Py_RETURN_NONE;
@@ -1958,10 +1958,10 @@ PyObject *c_Uuid_to_py(const rd_kafka_Uuid_t *c_uuid) {
 
         kwargs = PyDict_New();
 
-        cfl_PyDict_SetLong(kwargs, "most_significant_bits",
-                           rd_kafka_Uuid_most_significant_bits(c_uuid));
-        cfl_PyDict_SetLong(kwargs, "least_significant_bits",
-                           rd_kafka_Uuid_least_significant_bits(c_uuid));
+        cfl_PyDict_SetLongLong(kwargs, "most_significant_bits",
+                               rd_kafka_Uuid_most_significant_bits(c_uuid));
+        cfl_PyDict_SetLongLong(kwargs, "least_significant_bits",
+                               rd_kafka_Uuid_least_significant_bits(c_uuid));
 
         args = PyTuple_New(0);
 
@@ -3033,6 +3033,12 @@ void cfl_PyDict_SetInt(PyObject *dict, const char *name, int val) {
 
 void cfl_PyDict_SetLong(PyObject *dict, const char *name, long val) {
         PyObject *vo = cfl_PyLong_FromLong(val);
+        PyDict_SetItemString(dict, name, vo);
+        Py_DECREF(vo);
+}
+
+void cfl_PyDict_SetLongLong(PyObject *dict, const char *name, long long val) {
+        PyObject *vo = cfl_PyLong_FromLongLong(val);
         PyDict_SetItemString(dict, name, vo);
         Py_DECREF(vo);
 }

--- a/src/confluent_kafka/src/confluent_kafka.h
+++ b/src/confluent_kafka/src/confluent_kafka.h
@@ -377,12 +377,20 @@ void CallState_crash(CallState *cs);
 #define cfl_PyLong_Check(o)    PyLong_Check(o)
 #define cfl_PyLong_AsLong(o)   (int)PyLong_AsLong(o)
 #define cfl_PyLong_FromLong(v) PyLong_FromLong(v)
+#define cfl_PyLong_FromLongLong(v) PyLong_FromLongLong(v)
 
 PyObject *cfl_PyObject_lookup(const char *modulename, const char *typename);
 
 void cfl_PyDict_SetString(PyObject *dict, const char *name, const char *val);
 void cfl_PyDict_SetInt(PyObject *dict, const char *name, int val);
+/* Marshals a C `long`, which is only 32 bits on Windows (LLP64). Do not use
+ * this for values wider than 32 bits, such as Kafka offsets, timestamps, or
+ * UUID halves -- use cfl_PyDict_SetLongLong for those. */
 void cfl_PyDict_SetLong(PyObject *dict, const char *name, long val);
+/* 64-bit-safe on every platform, including Windows. Use this for any value
+ * sourced from an int64_t, e.g. rd_kafka_topic_partition_t.offset,
+ * ListOffsets timestamps, watermark offsets, or rd_kafka_Uuid_t halves. */
+void cfl_PyDict_SetLongLong(PyObject *dict, const char *name, long long val);
 int cfl_PyObject_SetString(PyObject *o, const char *name, const char *val);
 int cfl_PyObject_SetInt(PyObject *o, const char *name, int val);
 int cfl_PyObject_GetAttr(PyObject *object,


### PR DESCRIPTION
### What does this PR do?

Fixes a Windows-only bug where `AdminClient.list_offsets()` / `AdminClient.delete_records()` results, and `Uuid.most_significant_bits()` / `Uuid.least_significant_bits()`, silently truncate any value above `2^31 - 1` and can return a negative number.

Root cause: `cfl_PyDict_SetLong()` marshals a value into a Python dict via a parameter typed `long`. On Linux/macOS (LP64), `long` is 64 bits, so this is harmless there. On Windows (LLP64), `long` is always 32 bits, even in a 64-bit build. Every current call site passes a genuinely 64-bit `int64_t` value straight from librdkafka (`rd_kafka_topic_partition_t.offset`, `ListOffsets` timestamps, `rd_kafka_Uuid_t` halves) through this 32-bit-only helper, so on Windows the value wraps modulo `2**32` and gets reinterpreted as signed.

### Fix

Adds `cfl_PyDict_SetLongLong()` (backed by `PyLong_FromLongLong`, correctly 64-bit on every platform) and switches all five `cfl_PyDict_SetLong()` call sites that carry a 64-bit value, plus the two direct `cfl_PyLong_FromLong()` calls in the `Uuid` getters, to the new helper. `cfl_PyDict_SetLong()` itself is left as-is (doc comment added) in case a genuinely 32-bit-safe caller is ever needed; nothing currently calls it for a value that needs to be 64-bit.

### Motivation

A production incident: a Windows host on kafka_consumer (a Datadog Agent integration) reported `broker_offset = -1533701557` where the true high-watermark offset was `2761265739` — exactly `true - 2**32`. `TopicPartition.offset` (a separate, already 64-bit-safe code path using `PyLong_FromLongLong`, see `confluent_kafka.c:513`) reported the correct value in the same run, which is what localized the defect to this one marshalling helper.

This also affects `Uuid.most_significant_bits()`/`least_significant_bits()`, `AdminClient.list_offsets()` timestamps, and `delete_records()`'s `low_watermark` — any consumer of these on Windows can silently receive corrupted data above ~2.1 billion.

Relates to #1696, which reports the same symptom (a negative `ListOffsets` timestamp on Windows) but was never triaged to a root cause.

### Reproduction

The bug only manifests where `sizeof(long) == 4` (Windows LLP64, or any ILP32 platform). It doesn't reproduce on the Linux x64 / macOS CI this project runs functional tests on, which is presumably why it shipped unnoticed — the Windows CI job only builds wheels, it doesn't execute the test suite (`.semaphore/semaphore.yml`, "Wheels: Windows" job).

To reproduce without a Windows machine, the two files below extract the exact `cfl_PyDict_SetLong()` implementation from `confluent_kafka.c` (before) and the new `cfl_PyDict_SetLongLong()` (after) verbatim, feed in the real incident offset (`2761265739`), and run them in a 32-bit-`long` environment (i386 Debian container — same ABI class as Windows x64 for this purpose):

```c
// repro.c -- pre-fix, using the exact original cfl_PyDict_SetLong()
#include <Python.h>
#include <stdint.h>
#include <inttypes.h>

#define cfl_PyLong_FromLong(v) PyLong_FromLong(v)

void cfl_PyDict_SetLong(PyObject *dict, const char *name, long val) {
        PyObject *vo = cfl_PyLong_FromLong(val);
        PyDict_SetItemString(dict, name, vo);
        Py_DECREF(vo);
}

int main(void) {
        Py_Initialize();
        int64_t c_topic_partition_offset = 2761265739LL; /* AGENT-16736 */
        PyObject *kwargs = PyDict_New();
        cfl_PyDict_SetLong(kwargs, "offset", c_topic_partition_offset);
        long observed = PyLong_AsLong(PyDict_GetItemString(kwargs, "offset"));
        printf("sizeof(long)=%zu true=%" PRId64 " observed=%ld\n",
               sizeof(long), c_topic_partition_offset, observed);
        return 0;
}
```

```dockerfile
# Dockerfile.i386
FROM i386/debian:bookworm
RUN apt-get update && apt-get install -y --no-install-recommends gcc python3-dev python3
WORKDIR /repro
COPY repro.c .
RUN gcc -o repro repro.c $(python3-config --cflags --ldflags --embed) -lpython3.11
CMD ["./repro"]
```

```
$ docker build --platform linux/386 -f Dockerfile.i386 -t cfk-repro .
$ docker run --rm --platform linux/386 cfk-repro
sizeof(long)=4 true=2761265739 observed=-1533701557
```

`-1533701557` is an exact match for the incident report. Running the same offset through the patched `cfl_PyDict_SetLongLong()` (backed by `PyLong_FromLongLong`) in the identical i386 container:

```
sizeof(long)=4 sizeof(long long)=8 true=2761265739 observed=2761265739
FIX VERIFIED: offset survives the C->Python boundary intact.
```

I'm attaching a zip with both repro files (`repro.c`, `repro_fixed.c`) and their Dockerfiles so this can be re-run directly. Happy to also open a separate suggestion issue about adding an actual test-execution step to the Windows CI job, since that's the gap that let this ship — didn't want to bundle that into this fix.

### Checklist

- [x] Verified the exact truncation and the fix against the real incident offset, in an environment where `sizeof(long) == 4` (see above)
- [x] Verified no behavior change on `sizeof(long) == 8` (native macOS run, unaffected)
- [x] Updated CHANGELOG.md
- [ ] No new automated regression test — the defect is only observable when `sizeof(long) == 4`, which none of this project's CI targets exercise a test run on (see Reproduction section); a Python-level unit test on the existing Linux/macOS CI would pass identically before and after this fix and wouldn't guard against a regression
