### PR TITLE
Fix segfault after delete_records() on Python 3.14 (reference-counting bug)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@
 ### Fixes
 
 - Fix race conditions (#2315)
+- Fix segmentation fault after calling `AdminClient.delete_records()` followed
+  by another Admin API call (e.g. `list_topics()`) on Python 3.14.
 
 
 ## v2.15.0

--- a/src/confluent_kafka/src/Admin.c
+++ b/src/confluent_kafka/src/Admin.c
@@ -3272,7 +3272,6 @@ PyObject *Admin_delete_records(Handle *self, PyObject *args, PyObject *kwargs) {
         free(c_obj);
 
         rd_kafka_topic_partition_list_destroy(c_topic_partition_offsets);
-        Py_XDECREF(topic_partition_offsets);
 
         Py_RETURN_NONE;
 err:
@@ -3288,7 +3287,6 @@ err:
                 rd_kafka_topic_partition_list_destroy(
                     c_topic_partition_offsets);
         }
-        Py_XDECREF(topic_partition_offsets);
         return NULL;
 }
 

--- a/tests/test_Admin.py
+++ b/tests/test_Admin.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 import concurrent.futures
+import sys
 
 import pytest
 
@@ -1175,6 +1176,31 @@ def test_delete_records():
 
     with pytest.raises(ValueError):
         a.delete_records([TopicPartition("test-topic1")])
+
+
+def test_delete_records_does_not_corrupt_argument_refcount():
+    """
+    Regression test for #2275.
+    delete_records() must not decref the 'topic_partition_offsets' argument it only borrows.
+    """
+    a = AdminClient({"socket.timeout.ms": 10})
+    request = [TopicPartition("test-topic1", 0, 1)]
+
+    refcount_before = sys.getrefcount(request)
+    a.delete_records(request)
+    refcount_after = sys.getrefcount(request)
+
+    assert refcount_after == refcount_before
+
+    # The original bug corrupted the heap rather than crashing immediately,
+    # so a later, unrelated call is what actually segfaulted (list_topics()
+    # in the reported issue).
+    # With no broker configured this call can't succeed, but it must fail cleanly
+    # instead of crashing the interpreter.
+    try:
+        a.list_topics(timeout=0.2)
+    except KafkaException as e:
+        assert e.args[0].code() in (KafkaError._TIMED_OUT, KafkaError._TRANSPORT)
 
 
 def test_elect_leaders():


### PR DESCRIPTION
Fixes #2275 

Removed the two spurious Py_XDECREF(topic_partition_offsets) calls. The function should not touch the refcount of an argument it doesn't own.





What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include implementation strategy.
-->

Checklist
------------------
- [ ] Contains customer facing changes? Including API/behavior changes <!-- This can help identify if it has introduced any breaking changes -->
- [ ] Did you add sufficient unit test and/or integration test coverage for this PR?
  - If not, please explain why it is not required

References
----------
JIRA: 
<!--
Copy&paste links: to Jira ticket, other PRs, issues, Slack conversations...
For code bumps: link to PR, tag or GitHub `/compare/master...master`
-->

Test & Review
------------
<!--
Has it been tested? how?
Copy&paste any handy instructions, steps or requirements that can save time to the reviewer or any reader.
-->

Open questions / Follow-ups
--------------------------
<!--
Optional: anything open to discussion for the reviewer, out of scope, or follow-ups.
-->

<!--
Review stakeholders
------------------
<!--
Optional: mention stakeholders or if special context that is required to review.
-->
