### PR TITLE
Fix KafkaError error strings raising/garbling on non-UTF-8 locales (#448)

### DIFF
--- a/src/confluent_kafka/src/confluent_kafka.c
+++ b/src/confluent_kafka/src/confluent_kafka.c
@@ -96,9 +96,9 @@ static PyObject *KafkaError_code(KafkaError *self, PyObject *ignore) {
 
 static PyObject *KafkaError_str(KafkaError *self, PyObject *ignore) {
         if (self->str)
-                return cfl_PyUnistr(_FromString(self->str));
+                return cfl_PyUnistr_FromStringSafe(self->str);
         else
-                return cfl_PyUnistr(_FromString(rd_kafka_err2str(self->code)));
+                return cfl_PyUnistr_FromStringSafe(rd_kafka_err2str(self->code));
 }
 
 static PyObject *KafkaError_name(KafkaError *self, PyObject *ignore) {

--- a/src/confluent_kafka/src/confluent_kafka.h
+++ b/src/confluent_kafka/src/confluent_kafka.h
@@ -175,6 +175,20 @@ static __inline const char *cfl_PyUnistr_AsUTF8(PyObject *o, PyObject **uobjp) {
 #endif
 
 
+/**
+ * @returns a Unicode object from a NUL-terminated C string, decoding it as
+ *          UTF-8 with the "replace" error handler.
+ *
+ * Unlike PyUnicode_FromString(), which assumes strict UTF-8 and raises
+ * UnicodeDecodeError on invalid input, this never raises. Use it for strings
+ * that may come from librdkafka or the OS in the system locale encoding rather
+ * than UTF-8 (e.g. error strings on non-English Windows). See issue #448.
+ */
+static __inline PyObject *cfl_PyUnistr_FromStringSafe (const char *s) {
+        return PyUnicode_DecodeUTF8(s, (Py_ssize_t)strlen(s), "replace");
+}
+
+
 /****************************************************************************
  *
  *

--- a/tests/test_error.py
+++ b/tests/test_error.py
@@ -64,3 +64,12 @@ def test_new_produce_error_custom_message():
     assert pe.code == KafkaError._KEY_SERIALIZATION
     assert pe.name == u'_KEY_SERIALIZATION'
     assert pe.args[0].str() == "Unable to serialize key"
+
+
+def test_kafka_error_non_ascii_str():
+    msg = u"Ошибка: недопустимое значение"
+    err = KafkaError(KafkaError._KEY_SERIALIZATION, msg)
+
+    assert err.str() == msg
+    assert msg in str(err)
+    assert repr(err)


### PR DESCRIPTION
Superseded — reopening cleanly.