### PR TITLE
Fix KafkaError error strings raising/garbling on non-UTF-8 locales (#448)

### DIFF
--- a/src/confluent_kafka/src/confluent_kafka.c
+++ b/src/confluent_kafka/src/confluent_kafka.c
@@ -96,9 +96,9 @@ static PyObject *KafkaError_code(KafkaError *self, PyObject *ignore) {
 
 static PyObject *KafkaError_str(KafkaError *self, PyObject *ignore) {
         if (self->str)
-                return cfl_PyUnistr(_FromString(self->str));
+                return cfl_PyUnistr_FromStringSafe(self->str);
         else
-                return cfl_PyUnistr(_FromString(rd_kafka_err2str(self->code)));
+                return cfl_PyUnistr_FromStringSafe(rd_kafka_err2str(self->code));
 }
 
 static PyObject *KafkaError_name(KafkaError *self, PyObject *ignore) {
@@ -136,7 +136,7 @@ static PyObject *KafkaError_reduce(KafkaError *self,
             cfl_PyObject_lookup("confluent_kafka.cimpl", "KafkaError");
 
         if (self->str) {
-                reason = cfl_PyUnistr(_FromString(self->str));
+                reason = cfl_PyUnistr_FromStringSafe(self->str);
         } else {
                 reason = NULL;
         }

--- a/src/confluent_kafka/src/confluent_kafka.h
+++ b/src/confluent_kafka/src/confluent_kafka.h
@@ -175,6 +175,20 @@ static __inline const char *cfl_PyUnistr_AsUTF8(PyObject *o, PyObject **uobjp) {
 #endif
 
 
+/**
+ * @returns a Unicode object from a NUL-terminated C string, decoding it as
+ *          UTF-8 with the "replace" error handler.
+ *
+ * Unlike PyUnicode_FromString(), which assumes strict UTF-8 and raises
+ * UnicodeDecodeError on invalid input, this never raises. Use it for strings
+ * that may come from librdkafka or the OS in the system locale encoding rather
+ * than UTF-8 (e.g. error strings on non-English Windows). See issue #448.
+ */
+static __inline PyObject *cfl_PyUnistr_FromStringSafe(const char *s) {
+        return PyUnicode_DecodeUTF8(s, (Py_ssize_t)strlen(s), "replace");
+}
+
+
 /****************************************************************************
  *
  *

--- a/tests/test_error.py
+++ b/tests/test_error.py
@@ -64,3 +64,16 @@ def test_new_produce_error_custom_message():
     assert pe.code == KafkaError._KEY_SERIALIZATION
     assert pe.name == u'_KEY_SERIALIZATION'
     assert pe.args[0].str() == "Unable to serialize key"
+
+
+def test_kafka_error_non_ascii_str():
+    # Covers the valid-UTF-8 non-ASCII path only: that the "replace" decode
+    # doesn't mangle legitimate non-English text. The public constructor can't
+    # inject invalid bytes, so the actual #448 invalid-byte case (reachable only
+    # from C or a genuinely non-UTF-8 locale) is not exercised here.
+    msg = u"Ошибка: недопустимое значение"
+    err = KafkaError(KafkaError._KEY_SERIALIZATION, msg)
+
+    assert err.str() == msg
+    assert msg in str(err)
+    assert repr(err)


### PR DESCRIPTION
Fixes #448.

## Problem
`KafkaError.str()` decodes the underlying C error string with `PyUnicode_FromString()`, which assumes strict UTF-8. When librdkafka or the OS returns an error string in the system locale encoding rather than UTF-8 — e.g. on a non-English Windows install — this raises `UnicodeDecodeError` or produces garbled output, as reported in #448.

## Fix
Add a small helper `cfl_PyUnistr_FromStringSafe()` that decodes via `PyUnicode_DecodeUTF8(s, len, "replace")`. Invalid bytes degrade to U+FFFD (`�`) instead of raising, so error reporting never blows up on a locale-encoded string. Both the custom-message and `rd_kafka_err2str()` paths in `KafkaError_str()` now use it.

This is intentionally the minimal, non-raising fix: it guarantees a usable string in all locales rather than attempting full locale-encoding detection.

## Test
Added `test_kafka_error_non_ascii_str` covering a non-ASCII (Cyrillic) error message. Full `tests/test_error.py` passes locally (7 passed) against a fresh build.