### PR TITLE
Clear latest schema caches after schema registration

### DIFF
--- a/src/confluent_kafka/schema_registry/_async/schema_registry_client.py
+++ b/src/confluent_kafka/schema_registry/_async/schema_registry_client.py
@@ -796,6 +796,7 @@ class AsyncSchemaRegistryClient(object):
         # The registered schema may not be fully populated
         s = registered_schema.schema if registered_schema.schema.schema_str is not None else schema
         self._cache.set_schema(subject_name, registered_schema.schema_id, registered_schema.guid, s)
+        await self.clear_latest_caches(subject=subject_name)
 
         return registered_schema
 
@@ -1613,10 +1614,17 @@ class AsyncSchemaRegistryClient(object):
         result = await self._rest_client.get('contexts', query={'offset': offset, 'limit': limit})
         return result
 
-    async def clear_latest_caches(self):
+    async def clear_latest_caches(self, subject: Optional[str] = None) -> None:
+        """Clear latest-version and latest-with-metadata caches, optionally for one subject."""
         async with self._latest_lock:
-            self._latest_version_cache.clear()
-            self._latest_with_metadata_cache.clear()
+            if subject is None:
+                self._latest_version_cache.clear()
+                self._latest_with_metadata_cache.clear()
+            else:
+                self._latest_version_cache.pop(subject, None)
+                for cache_key in list(self._latest_with_metadata_cache):
+                    if cache_key[0] == subject:
+                        del self._latest_with_metadata_cache[cache_key]
 
     async def clear_caches(self):
         async with self._latest_lock:

--- a/src/confluent_kafka/schema_registry/_sync/schema_registry_client.py
+++ b/src/confluent_kafka/schema_registry/_sync/schema_registry_client.py
@@ -793,6 +793,7 @@ class SchemaRegistryClient(object):
         # The registered schema may not be fully populated
         s = registered_schema.schema if registered_schema.schema.schema_str is not None else schema
         self._cache.set_schema(subject_name, registered_schema.schema_id, registered_schema.guid, s)
+        self.clear_latest_caches(subject=subject_name)
 
         return registered_schema
 
@@ -1600,10 +1601,17 @@ class SchemaRegistryClient(object):
         result = self._rest_client.get('contexts', query={'offset': offset, 'limit': limit})
         return result
 
-    def clear_latest_caches(self):
+    def clear_latest_caches(self, subject: Optional[str] = None) -> None:
+        """Clear latest-version and latest-with-metadata caches, optionally for one subject."""
         with self._latest_lock:
-            self._latest_version_cache.clear()
-            self._latest_with_metadata_cache.clear()
+            if subject is None:
+                self._latest_version_cache.clear()
+                self._latest_with_metadata_cache.clear()
+            else:
+                self._latest_version_cache.pop(subject, None)
+                for cache_key in list(self._latest_with_metadata_cache):
+                    if cache_key[0] == subject:
+                        del self._latest_with_metadata_cache[cache_key]
 
     def clear_caches(self):
         with self._latest_lock:

--- a/tests/schema_registry/_async/test_api_client.py
+++ b/tests/schema_registry/_async/test_api_client.py
@@ -20,7 +20,7 @@ from concurrent.futures import ThreadPoolExecutor, wait
 
 import pytest
 
-from confluent_kafka.schema_registry.common.schema_registry_client import SchemaVersion
+from confluent_kafka.schema_registry.common.schema_registry_client import RegisteredSchema, SchemaVersion
 from confluent_kafka.schema_registry.error import SchemaRegistryError
 from confluent_kafka.schema_registry.schema_registry_client import AsyncSchemaRegistryClient, Schema
 from tests.schema_registry.conftest import COUNTER, SCHEMA, SCHEMA_ID, SUBJECTS, USERINFO, VERSION, VERSIONS
@@ -92,6 +92,60 @@ async def test_register_schema_full_response_recall(mock_schema_registry, load_a
 
     result = await sr.register_schema_full_response('test-key', schema)
     assert result.schema_id == SCHEMA_ID
+
+
+async def test_register_schema_clears_latest_caches(mock_schema_registry, load_avsc):
+    sr = AsyncSchemaRegistryClient({'url': TEST_URL})
+    schema = Schema(load_avsc('basic_schema.avsc'), schema_type='AVRO')
+    cached = RegisteredSchema('test-key', VERSION - 1, SCHEMA_ID, None, schema)
+    sr._latest_version_cache['test-key'] = cached
+    sr._latest_with_metadata_cache[('test-key', frozenset({('owner', 'team')}), False)] = cached
+    other_cache_key = ('other-key', frozenset({('owner', 'other-team')}), False)
+    sr._latest_with_metadata_cache[other_cache_key] = cached
+
+    await sr.register_schema('test-key', schema)
+
+    assert 'test-key' not in sr._latest_version_cache
+    assert ('test-key', frozenset({('owner', 'team')}), False) not in sr._latest_with_metadata_cache
+    assert sr._latest_with_metadata_cache[other_cache_key] == cached
+
+
+async def test_register_schema_cache_hit_keeps_latest_caches(mock_schema_registry, load_avsc):
+    sr = AsyncSchemaRegistryClient({'url': TEST_URL})
+    schema = Schema(load_avsc('basic_schema.avsc'), schema_type='AVRO')
+    cached = RegisteredSchema('test-key', VERSION, SCHEMA_ID, None, schema)
+    cache_key = ('test-key', frozenset({('owner', 'team')}), False)
+
+    await sr.register_schema('test-key', schema)
+    sr._latest_version_cache['test-key'] = cached
+    sr._latest_with_metadata_cache[cache_key] = cached
+
+    await sr.register_schema('test-key', schema)
+
+    assert sr._latest_version_cache['test-key'] == cached
+    assert sr._latest_with_metadata_cache[cache_key] == cached
+
+
+async def test_clear_latest_caches(mock_schema_registry, load_avsc):
+    sr = AsyncSchemaRegistryClient({'url': TEST_URL})
+    schema = Schema(load_avsc('basic_schema.avsc'), schema_type='AVRO')
+    cached = RegisteredSchema('test-key', VERSION, SCHEMA_ID, None, schema)
+    sr._latest_version_cache['test-key'] = cached
+    sr._latest_version_cache['other-key'] = cached
+    sr._latest_with_metadata_cache[('test-key', frozenset(), False)] = cached
+    sr._latest_with_metadata_cache[('other-key', frozenset(), False)] = cached
+
+    await sr.clear_latest_caches(subject='test-key')
+
+    assert 'test-key' not in sr._latest_version_cache
+    assert ('test-key', frozenset(), False) not in sr._latest_with_metadata_cache
+    assert sr._latest_version_cache['other-key'] == cached
+    assert sr._latest_with_metadata_cache[('other-key', frozenset(), False)] == cached
+
+    await sr.clear_latest_caches()
+
+    assert not sr._latest_version_cache
+    assert not sr._latest_with_metadata_cache
 
 
 async def test_register_schema_incompatible(mock_schema_registry, load_avsc):

--- a/tests/schema_registry/_sync/test_api_client.py
+++ b/tests/schema_registry/_sync/test_api_client.py
@@ -20,7 +20,7 @@ from concurrent.futures import ThreadPoolExecutor, wait
 
 import pytest
 
-from confluent_kafka.schema_registry.common.schema_registry_client import SchemaVersion
+from confluent_kafka.schema_registry.common.schema_registry_client import RegisteredSchema, SchemaVersion
 from confluent_kafka.schema_registry.error import SchemaRegistryError
 from confluent_kafka.schema_registry.schema_registry_client import Schema, SchemaRegistryClient
 from tests.schema_registry.conftest import COUNTER, SCHEMA, SCHEMA_ID, SUBJECTS, USERINFO, VERSION, VERSIONS
@@ -92,6 +92,60 @@ def test_register_schema_full_response_recall(mock_schema_registry, load_avsc):
 
     result = sr.register_schema_full_response('test-key', schema)
     assert result.schema_id == SCHEMA_ID
+
+
+def test_register_schema_clears_latest_caches(mock_schema_registry, load_avsc):
+    sr = SchemaRegistryClient({'url': TEST_URL})
+    schema = Schema(load_avsc('basic_schema.avsc'), schema_type='AVRO')
+    cached = RegisteredSchema('test-key', VERSION - 1, SCHEMA_ID, None, schema)
+    sr._latest_version_cache['test-key'] = cached
+    sr._latest_with_metadata_cache[('test-key', frozenset({('owner', 'team')}), False)] = cached
+    other_cache_key = ('other-key', frozenset({('owner', 'other-team')}), False)
+    sr._latest_with_metadata_cache[other_cache_key] = cached
+
+    sr.register_schema('test-key', schema)
+
+    assert 'test-key' not in sr._latest_version_cache
+    assert ('test-key', frozenset({('owner', 'team')}), False) not in sr._latest_with_metadata_cache
+    assert sr._latest_with_metadata_cache[other_cache_key] == cached
+
+
+def test_register_schema_cache_hit_keeps_latest_caches(mock_schema_registry, load_avsc):
+    sr = SchemaRegistryClient({'url': TEST_URL})
+    schema = Schema(load_avsc('basic_schema.avsc'), schema_type='AVRO')
+    cached = RegisteredSchema('test-key', VERSION, SCHEMA_ID, None, schema)
+    cache_key = ('test-key', frozenset({('owner', 'team')}), False)
+
+    sr.register_schema('test-key', schema)
+    sr._latest_version_cache['test-key'] = cached
+    sr._latest_with_metadata_cache[cache_key] = cached
+
+    sr.register_schema('test-key', schema)
+
+    assert sr._latest_version_cache['test-key'] == cached
+    assert sr._latest_with_metadata_cache[cache_key] == cached
+
+
+def test_clear_latest_caches(mock_schema_registry, load_avsc):
+    sr = SchemaRegistryClient({'url': TEST_URL})
+    schema = Schema(load_avsc('basic_schema.avsc'), schema_type='AVRO')
+    cached = RegisteredSchema('test-key', VERSION, SCHEMA_ID, None, schema)
+    sr._latest_version_cache['test-key'] = cached
+    sr._latest_version_cache['other-key'] = cached
+    sr._latest_with_metadata_cache[('test-key', frozenset(), False)] = cached
+    sr._latest_with_metadata_cache[('other-key', frozenset(), False)] = cached
+
+    sr.clear_latest_caches(subject='test-key')
+
+    assert 'test-key' not in sr._latest_version_cache
+    assert ('test-key', frozenset(), False) not in sr._latest_with_metadata_cache
+    assert sr._latest_version_cache['other-key'] == cached
+    assert sr._latest_with_metadata_cache[('other-key', frozenset(), False)] == cached
+
+    sr.clear_latest_caches()
+
+    assert not sr._latest_version_cache
+    assert not sr._latest_with_metadata_cache
 
 
 def test_register_schema_incompatible(mock_schema_registry, load_avsc):


### PR DESCRIPTION
What
----
When a schema is registered invalidate that subject's entries in the latest-version and latest-with-metadata caches. Re-use the existing `clear_latest_caches()` method to do this.

Checklist
------------------
- [x] Contains customer facing changes? Including API/behavior changes <!-- This can help identify if it has introduced any breaking changes -->
- [x] Did you add sufficient unit test and/or integration test coverage for this PR?
  - If not, please explain why it is not required

References
----------
This addresses the second bug reported in https://github.com/confluentinc/confluent-kafka-python/issues/1950

Test & Review
------------
Added unit tests and did some manual testing locally.

Open questions / Follow-ups
--------------------------
<!--
Optional: anything open to discussion for the reviewer, out of scope, or follow-ups.
-->

<!--
Review stakeholders
------------------
<!--
Optional: mention stakeholders or if special context that is required to review.
-->
