### PR TITLE
[NOGIL] Exclude Avro tests from running on free threaded python builds

### DIFF
--- a/requirements/requirements-avro-nogil.txt
+++ b/requirements/requirements-avro-nogil.txt
@@ -1,0 +1,8 @@
+# Free-threaded (no-GIL) variant of requirements-avro.txt.
+# Excludes fastavro: it ships a free-threaded wheel but has not declared
+# itself GIL-safe (see https://github.com/fastavro/fastavro/issues/873), so
+# merely importing it silently re-enables the GIL for the rest of the
+# process.
+# Keep in sync with requirements-avro.txt when adding new includes.
+requests
+avro>=1.11.1,<2

--- a/requirements/requirements-avro.txt
+++ b/requirements/requirements-avro.txt
@@ -1,3 +1,4 @@
+# Keep requirements-avro-nogil.txt in sync when adding includes.
 fastavro >= 1.5.4, < 1.8.0; python_version == "3.7"
 fastavro >= 1.5.4, < 2; python_version > "3.7"
 requests

--- a/requirements/requirements-tests-install-nogil.txt
+++ b/requirements/requirements-tests-install-nogil.txt
@@ -1,10 +1,14 @@
 # Free-threaded (no-GIL) variant of requirements-tests-install.txt.
-# Excludes extras whose compiled deps ship no free-threaded wheels:
-#   rules (tink, google-re2, grpcio via google-cloud-kms) and json-fast (orjson).
+# Excludes extras that don't work on a free-threaded interpreter:
+#   rules (tink, google-re2, grpcio via google-cloud-kms) and json-fast (orjson)
+#     ship no free-threaded wheels at all, so installing them fails outright;
+#   avro (fastavro) ships a free-threaded wheel but has not declared itself
+#     GIL-safe (see https://github.com/fastavro/fastavro/issues/873), so
+#     merely importing it silently re-enables the GIL for the rest of the
+#     process.
 # Keep in sync with requirements-tests-install.txt when adding new includes.
 -r requirements-tests.txt
 -r requirements-schemaregistry.txt
--r requirements-avro.txt
 -r requirements-protobuf.txt
 -r requirements-json.txt
 -r requirements-oauthbearer-aws.txt

--- a/requirements/requirements-tests-install-nogil.txt
+++ b/requirements/requirements-tests-install-nogil.txt
@@ -1,14 +1,13 @@
 # Free-threaded (no-GIL) variant of requirements-tests-install.txt.
-# Excludes extras that don't work on a free-threaded interpreter:
-#   rules (tink, google-re2, grpcio via google-cloud-kms) and json-fast (orjson)
-#     ship no free-threaded wheels at all, so installing them fails outright;
-#   avro (fastavro) ships a free-threaded wheel but has not declared itself
-#     GIL-safe (see https://github.com/fastavro/fastavro/issues/873), so
-#     merely importing it silently re-enables the GIL for the rest of the
-#     process.
+# Excludes extras whose compiled deps ship no free-threaded wheels at all,
+# so installing them fails outright: rules (tink, google-re2, grpcio via
+# google-cloud-kms) and json-fast (orjson). avro is replaced with
+# requirements-avro-nogil.txt, which drops only fastavro (see that file for
+# why) and keeps its other, safe deps.
 # Keep in sync with requirements-tests-install.txt when adding new includes.
 -r requirements-tests.txt
 -r requirements-schemaregistry.txt
+-r requirements-avro-nogil.txt
 -r requirements-protobuf.txt
 -r requirements-json.txt
 -r requirements-oauthbearer-aws.txt

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,7 +18,6 @@
 
 import sys
 import sysconfig
-import warnings
 
 import pytest
 
@@ -31,20 +30,12 @@ if FREE_THREADED_BUILD:
     def gil_stays_disabled():
         """
         Runs in adaptive GIL mode (PYTHON_GIL unset) so the suite tests the
-        configuration users actually run. Module-scoped so the warning points
-        at the test file whose imports or tests re-enabled the GIL; the
-        interpreter's own RuntimeWarning names the offending extension module.
+        configuration users actually run. Module-scoped so a failure points at
+        the test file whose imports or tests re-enabled the GIL.
 
-        TODO NOGIL: replace the warnings with the commented asserts in the same
-        PR that declares Py_MOD_GIL_NOT_USED in cimpl. Until then a re-enable
-        is expected (cimpl itself triggers it) and must not fail the suite.
+        cimpl declares Py_MOD_GIL_NOT_USED, so a re-enable here is a real
+        regression, not expected behavior.
         """
-        if sys._is_gil_enabled():
-            warnings.warn("the GIL was re-enabled before this test module started", RuntimeWarning)
-        # assert not sys._is_gil_enabled(), \
-        #     "the GIL was re-enabled before this test module started"
+        assert not sys._is_gil_enabled(), "the GIL was re-enabled before this test module started"
         yield
-        if sys._is_gil_enabled():
-            warnings.warn("the GIL was re-enabled by this test module", RuntimeWarning)
-        # assert not sys._is_gil_enabled(), \
-        #     "the GIL was re-enabled by this test module"
+        assert not sys._is_gil_enabled(), "the GIL was re-enabled by this test module"

--- a/tests/integration/schema_registry/conftest.py
+++ b/tests/integration/schema_registry/conftest.py
@@ -18,23 +18,23 @@
 import sysconfig
 import warnings
 
-# test_dlq.py imports celpy (via CelExecutor) at the top of the file. celpy
-# ships no free-threaded wheel, so it is not installed on free-threaded
-# builds (see requirements-tests-install-nogil.txt) and importing this
-# module would fail at collection; exclude it there. On regular builds the
-# dep is expected to be installed, so a missing dep stays a loud collection
-# error instead of a silent skip.
+# test_dlq.py imports celpy; test_avro_serializers.py imports fastavro.
+# celpy ships no free-threaded wheel; fastavro ships one but has not declared
+# itself GIL-safe. Neither is installed on free-threaded builds (see
+# requirements-tests-install-nogil.txt), so both are excluded here.
 FREE_THREADED_BUILD = bool(sysconfig.get_config_var("Py_GIL_DISABLED"))
 
 collect_ignore = []
 if FREE_THREADED_BUILD:
     collect_ignore = [
+        "_async/test_avro_serializers.py",
         "_async/test_dlq.py",
+        "_sync/test_avro_serializers.py",
         "_sync/test_dlq.py",
     ]
     warnings.warn(
         "free-threaded build: skipping collection of {} schema_registry "
-        "integration test modules requiring celpy, which ships no "
-        "free-threaded wheel".format(len(collect_ignore)),
+        "integration test modules requiring celpy (no free-threaded wheel) "
+        "or fastavro (not declared GIL-safe)".format(len(collect_ignore)),
         RuntimeWarning,
     )

--- a/tests/integration/share_consumer/conftest.py
+++ b/tests/integration/share_consumer/conftest.py
@@ -1,8 +1,27 @@
 """Per-directory pytest fixtures for share consumer integration tests."""
 
 import sys
+import sysconfig
+import warnings
 
 import pytest
+
+# test_share_consumer_deserialization.py imports fastavro.
+# fastavro does ship a free-threaded wheel, but has not declared itself GIL-safe
+# so it is not installed on free-threaded builds (see requirements-tests-install-nogil.txt)
+FREE_THREADED_BUILD = bool(sysconfig.get_config_var("Py_GIL_DISABLED"))
+
+collect_ignore = []
+if FREE_THREADED_BUILD:
+    collect_ignore = [
+        "test_share_consumer_deserialization.py",
+    ]
+    warnings.warn(
+        "free-threaded build: skipping collection of {} share_consumer "
+        "integration test module(s) requiring fastavro, which has not "
+        "declared itself GIL-safe".format(len(collect_ignore)),
+        RuntimeWarning,
+    )
 
 
 @pytest.fixture(scope='module', autouse=True)

--- a/tests/schema_registry/conftest.py
+++ b/tests/schema_registry/conftest.py
@@ -27,14 +27,16 @@ import pytest
 import respx
 from httpx import Response
 
-# The modules below import optional dependencies (tink/celpy from the rules
-# extra, orjson from json-fast) at the top of the file. None of those deps
-# ship free-threaded wheels, so they are not installed on free-threaded
-# builds (see requirements-tests-install-nogil.txt) and importing these
-# modules would fail at collection; exclude them there. On regular builds the
-# deps are expected to be installed, so a missing dep stays a loud collection
-# error instead of a silent skip. The stdlib JSON codec path stays covered by
-# test_json_codec.py.
+# The modules below import optional dependencies at the top of the file:
+# tink/celpy (rules extra) and orjson (json-fast) ship no free-threaded
+# wheels at all, so they are not installed on free-threaded builds (see
+# requirements-tests-install-nogil.txt) and importing these modules would
+# fail at collection; exclude them there. fastavro (avro extra) does ship a
+# free-threaded wheel, but has not declared itself GIL-safe (see
+# https://github.com/fastavro/fastavro/issues/873), so it is excluded from
+# the free-threaded install too. On regular builds the deps are expected to be
+# installed, so a missing dep stays a loud collection error instead of a
+# silent skip.
 FREE_THREADED_BUILD = bool(sysconfig.get_config_var("Py_GIL_DISABLED"))
 
 collect_ignore = []
@@ -43,13 +45,18 @@ if FREE_THREADED_BUILD:
         "test_azure_aead.py",
         "test_azure_client.py",
         "test_azure_driver.py",
+        "test_dlq_action.py",
         "test_encrypt_executor.py",
         "test_hcvault_driver.py",
+        "_async/test_avro.py",
+        "_async/test_avro_serdes.py",
         "_async/test_avro_serdes_rules.py",
         "_async/test_config_rules.py",
         "_async/test_dlq_serdes.py",
         "_async/test_json_serdes_rules.py",
         "_async/test_proto_serdes_rules.py",
+        "_sync/test_avro.py",
+        "_sync/test_avro_serdes.py",
         "_sync/test_avro_serdes_rules.py",
         "_sync/test_config_rules.py",
         "_sync/test_dlq_serdes.py",
@@ -58,8 +65,9 @@ if FREE_THREADED_BUILD:
     ]
     warnings.warn(
         "free-threaded build: skipping collection of {} schema_registry "
-        "test modules requiring optional deps (tink/celpy/orjson) that ship "
-        "no free-threaded wheels".format(len(collect_ignore)),
+        "test modules requiring optional deps (tink/celpy/orjson/fastavro) "
+        "that ship no free-threaded wheels, or have not "
+        "declared themselves GIL-safe".format(len(collect_ignore)),
         RuntimeWarning,
     )
 

--- a/tools/source-package-verification.sh
+++ b/tools/source-package-verification.sh
@@ -81,7 +81,22 @@ if [[ $OS_NAME == linux && $ARCH == x64 ]]; then
         python3 -m mypy src/confluent_kafka
 
         uv pip install -r requirements/requirements-docs.txt
+        if [[ $FREE_THREADED == "1" ]]; then
+            # Sphinx autodoc imports confluent_kafka.schema_registry.avro (and
+            # the legacy confluent_kafka.avro) to document AvroSerializer/
+            # AvroDeserializer, which needs fastavro. fastavro is deliberately
+            # excluded from the free-threaded test install (see
+            # requirements-avro-nogil.txt) because importing it silently
+            # re-enables the GIL -- that only matters for the free-threading
+            # behavior the pytest run below is testing, not for this one-shot
+            # doc build, so install it just for `make docs` and remove it
+            # again immediately after so pytest stays GIL-clean.
+            uv pip install fastavro
+        fi
         make docs
+        if [[ $FREE_THREADED == "1" ]]; then
+            uv pip uninstall -y fastavro
+        fi
 
         echo "Testing extra dependencies ..."
         python3 -c "


### PR DESCRIPTION
`fastavro` provides a wheel for Python 3.14t but does not declare itself to be safe without GIL (https://github.com/fastavro/fastavro/issues/873). So on importing fastavro, the GIL gets re-enabled. We need to exclude the test cases that use this dependency from running on free threaded Python in the same way as we did for `rules` related test cases.



What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include implementation strategy.
-->

Checklist
------------------
- [ ] Contains customer facing changes? Including API/behavior changes <!-- This can help identify if it has introduced any breaking changes -->
- [ ] Did you add sufficient unit test and/or integration test coverage for this PR?
  - If not, please explain why it is not required

References
----------
JIRA: 
<!--
Copy&paste links: to Jira ticket, other PRs, issues, Slack conversations...
For code bumps: link to PR, tag or GitHub `/compare/master...master`
-->

Test & Review
------------
<!--
Has it been tested? how?
Copy&paste any handy instructions, steps or requirements that can save time to the reviewer or any reader.
-->

Open questions / Follow-ups
--------------------------
<!--
Optional: anything open to discussion for the reviewer, out of scope, or follow-ups.
-->

<!--
Review stakeholders
------------------
<!--
Optional: mention stakeholders or if special context that is required to review.
-->
