### PR TITLE
[internal PR] fix(aio): use get_running_loop() instead of get_event_loop() in AIOConsumer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 - Fix race conditions (#2315)
 - Fix segmentation fault after calling `AdminClient.delete_records()` followed
   by another Admin API call (e.g. `list_topics()`) on Python 3.14.
+- Use `asyncio.get_running_loop()` instead of `asyncio.get_event_loop()` to avoid creating a new event loop and raise an error in case a loop isn't available (@AlexCai26, #2336).
 
 
 ## v2.15.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@
 - Fix race conditions (#2315)
 - Fix segmentation fault after calling `AdminClient.delete_records()` followed
   by another Admin API call (e.g. `list_topics()`) on Python 3.14.
-- Use `asyncio.get_running_loop()` instead of `asyncio.get_event_loop()` to avoid creating a new event loop and raise an error in case a loop isn't available (@AlexCai26, #2336).
+- Use `asyncio.get_running_loop()` instead of `asyncio.get_event_loop()` to avoid creating a new event loop and raise an error in case a loop isn't available (@AlexCai26, #2339).
 
 
 ## v2.15.0

--- a/src/confluent_kafka/aio/_AIOConsumer.py
+++ b/src/confluent_kafka/aio/_AIOConsumer.py
@@ -44,7 +44,7 @@ class AIOConsumer:
                 raise ValueError("max_workers must be at least 1")
             self.executor = concurrent.futures.ThreadPoolExecutor(max_workers=max_workers)
 
-        loop = asyncio.get_event_loop()
+        loop = asyncio.get_running_loop()
         wrap_common_callbacks = _common.wrap_common_callbacks
         wrap_conf_callback = _common.wrap_conf_callback
         wrap_common_callbacks(loop, consumer_conf)
@@ -115,7 +115,7 @@ class AIOConsumer:
         return tuple(args_list)
 
     async def subscribe(self, *args: Any, **kwargs: Any) -> Any:
-        loop = asyncio.get_event_loop()
+        loop = asyncio.get_running_loop()
         for callback in ['on_assign', 'on_revoke', 'on_lost']:
             if callback in kwargs:
                 kwargs[callback] = self._wrap_callback(


### PR DESCRIPTION
continuation of #2212