### PR TITLE
Fix async→sync codegen check failing under isort 9.0.0

### DIFF
--- a/tools/style-format.sh
+++ b/tools/style-format.sh
@@ -110,9 +110,9 @@ for f in $*; do
             # First, create a backup to compare
             cp "$f" _styletmp_orig
             # Run isort to sort imports
-            python3 -m isort "$f" > /dev/null 2>&1 || true
+            isort "$f" > /dev/null 2>&1 || true
             # Run black to format the file
-            python3 -m black "$f" > /dev/null 2>&1 || true
+            black "$f" > /dev/null 2>&1 || true
             # Compare to see if changes were made
             if ! cmp -s "$f" _styletmp_orig; then
                 echo "[$file_num/$file_count] $f: style fixed (isort + black)"
@@ -160,7 +160,7 @@ for f in $*; do
         elif [[ $lang == py ]]; then
             # Check with isort first
             set +e
-            isort_check=$(python3 -m isort --check-only --diff "$f" 2>&1)
+            isort_check=$(isort --check-only --diff "$f" 2>&1)
             isort_exit=$?
             set -e
             if [[ $isort_exit -ne 0 ]]; then
@@ -171,7 +171,7 @@ for f in $*; do
             fi
             # Check with black
             set +e
-            black_check=$(python3 -m black --check --diff "$f" 2>&1)
+            black_check=$(black --check --diff "$f" 2>&1)
             black_exit=$?
             set -e
             if [[ $black_exit -ne 0 ]]; then
@@ -182,7 +182,7 @@ for f in $*; do
             fi
             # Also run flake8 for linting (not formatting)
             set +e
-            flake8_output=$(python3 -m flake8 "$f" 2>&1)
+            flake8_output=$(flake8 "$f" 2>&1)
             flake8_exit=$?
             set -e
             if [[ $flake8_exit -ne 0 ]]; then

--- a/tools/unasync.py
+++ b/tools/unasync.py
@@ -4,6 +4,7 @@ import argparse
 import difflib
 import os
 import re
+import shutil
 import subprocess
 import sys
 import tempfile
@@ -135,8 +136,24 @@ def unasync_file_check(in_path, out_path):
             # Format using isort and black (same as style-format.sh does)
             # Use relative path from project root so pyproject.toml config is found
             tmp_rel_path = os.path.relpath(tmp_path, project_root)
-            subprocess.run(['python3', '-m', 'isort', tmp_rel_path], cwd=project_root, capture_output=True, check=False)
-            subprocess.run(['python3', '-m', 'black', tmp_rel_path], cwd=project_root, capture_output=True, check=False)
+            bindir = os.path.dirname(sys.executable)
+            for tool in ('isort', 'black'):
+                tool_exe = os.path.join(bindir, tool)
+                if not os.path.exists(tool_exe):
+                    tool_exe = shutil.which(tool)
+                if not tool_exe:
+                    raise ValueError(f"could not find {tool} to format {out_path}")
+                proc = subprocess.run(
+                    [tool_exe, tmp_rel_path],
+                    cwd=project_root,
+                    capture_output=True,
+                    text=True,
+                )
+                if proc.returncode != 0:
+                    raise ValueError(
+                        f"failed to run {tool} while checking {out_path}: "
+                        f"{proc.stderr.strip() or proc.stdout.strip()}"
+                    )
 
             with open(tmp_path, "r") as formatted_file:
                 expected_content = formatted_file.read()


### PR DESCRIPTION
isort 9.0.0 ships a compiled build whose __main__ isn't runnable via `python -m isort`, which tools/unasync.py and tools/style-format.sh both relied on. With the unbounded `isort>=5.13.0` pin, CI started resolving 9.0.0 and the invocation silently no-op'd, so the _sync files were compared unformatted and every commit failed the check.


Modified to use the isort/black console scripts instead and fail loudly if a formatter can't run.




What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include implementation strategy.
-->

Checklist
------------------
- [ ] Contains customer facing changes? Including API/behavior changes <!-- This can help identify if it has introduced any breaking changes -->
- [ ] Did you add sufficient unit test and/or integration test coverage for this PR?
  - If not, please explain why it is not required

References
----------
JIRA: 
<!--
Copy&paste links: to Jira ticket, other PRs, issues, Slack conversations...
For code bumps: link to PR, tag or GitHub `/compare/master...master`
-->

Test & Review
------------
<!--
Has it been tested? how?
Copy&paste any handy instructions, steps or requirements that can save time to the reviewer or any reader.
-->

Open questions / Follow-ups
--------------------------
<!--
Optional: anything open to discussion for the reviewer, out of scope, or follow-ups.
-->

<!--
Review stakeholders
------------------
<!--
Optional: mention stakeholders or if special context that is required to review.
-->
