### PR TITLE
Invoke isort as a binary, not via python -m, to support isort>=9.0.0

### DIFF
--- a/src/confluent_kafka/admin/__init__.py
+++ b/src/confluent_kafka/admin/__init__.py
@@ -53,9 +53,7 @@ from ..cimpl import (  # noqa: F401
     NewTopic,
 )
 from ..cimpl import TopicPartition as _TopicPartition
-from ..cimpl import (  # noqa: F401
-    _AdminClientImpl,
-)
+from ..cimpl import _AdminClientImpl
 from ._acl import AclOperation  # noqa: F401
 from ._acl import AclBinding, AclBindingFilter, AclPermissionType  # noqa: F401
 from ._cluster import DescribeClusterResult  # noqa: F401

--- a/tools/style-format.sh
+++ b/tools/style-format.sh
@@ -110,7 +110,7 @@ for f in $*; do
             # First, create a backup to compare
             cp "$f" _styletmp_orig
             # Run isort to sort imports
-            python3 -m isort "$f" > /dev/null 2>&1 || true
+            isort "$f" > /dev/null 2>&1 || true
             # Run black to format the file
             python3 -m black "$f" > /dev/null 2>&1 || true
             # Compare to see if changes were made
@@ -160,7 +160,7 @@ for f in $*; do
         elif [[ $lang == py ]]; then
             # Check with isort first
             set +e
-            isort_check=$(python3 -m isort --check-only --diff "$f" 2>&1)
+            isort_check=$(isort --check-only --diff "$f" 2>&1)
             isort_exit=$?
             set -e
             if [[ $isort_exit -ne 0 ]]; then

--- a/tools/unasync.py
+++ b/tools/unasync.py
@@ -135,7 +135,7 @@ def unasync_file_check(in_path, out_path):
             # Format using isort and black (same as style-format.sh does)
             # Use relative path from project root so pyproject.toml config is found
             tmp_rel_path = os.path.relpath(tmp_path, project_root)
-            subprocess.run(['python3', '-m', 'isort', tmp_rel_path], cwd=project_root, capture_output=True, check=False)
+            subprocess.run(['isort', tmp_rel_path], cwd=project_root, capture_output=True, check=False)
             subprocess.run(['python3', '-m', 'black', tmp_rel_path], cwd=project_root, capture_output=True, check=False)
 
             with open(tmp_path, "r") as formatted_file:


### PR DESCRIPTION
isort released a new major version a few days back which broke our style checks as we do not pin an isort version. In CI, we invoked isort using `python -m` which is no more supported. This PR now invokes isort using the command "isort" instead.


<!--
Suggested PR template: Fill/delete/add sections as needed. Optionally delete any commented block.
-->
What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include implementation strategy.
-->

Checklist
------------------
- [ ] Contains customer facing changes? Including API/behavior changes <!-- This can help identify if it has introduced any breaking changes -->
- [ ] Did you add sufficient unit test and/or integration test coverage for this PR?
  - If not, please explain why it is not required

References
----------
JIRA: 
<!--
Copy&paste links: to Jira ticket, other PRs, issues, Slack conversations...
For code bumps: link to PR, tag or GitHub `/compare/master...master`
-->

Test & Review
------------
<!--
Has it been tested? how?
Copy&paste any handy instructions, steps or requirements that can save time to the reviewer or any reader.
-->

Open questions / Follow-ups
--------------------------
<!--
Optional: anything open to discussion for the reviewer, out of scope, or follow-ups.
-->

<!--
Review stakeholders
------------------
<!--
Optional: mention stakeholders or if special context that is required to review.
-->
