### PR TITLE
Fix Producer.purge() ignoring boolean flags on big-endian platforms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,11 @@
 - Fix segmentation fault after calling `AdminClient.delete_records()` followed
   by another Admin API call (e.g. `list_topics()`) on Python 3.14.
 - Use `asyncio.get_running_loop()` instead of `asyncio.get_event_loop()` to avoid creating a new event loop and raise an error in case a loop isn't available (@AlexCai26, #2339).
+- Fix `Producer.purge()` ignoring its `in_queue`, `in_flight` and `blocking`
+  arguments on big-endian platforms (e.g. s390x). They were parsed with the
+  1-byte `"b"` format into 4-byte `int` targets, so on big-endian the value
+  landed on the high byte and the flags could not be cleared; for example
+  `purge(in_queue=False)` purged the queue anyway.
 
 
 ## v2.15.0

--- a/src/confluent_kafka/src/Producer.c
+++ b/src/confluent_kafka/src/Producer.c
@@ -1034,7 +1034,12 @@ static void *Producer_purge(Handle *self, PyObject *args, PyObject *kwargs) {
         rd_kafka_resp_err_t err;
         static char *kws[] = {"in_queue", "in_flight", "blocking", NULL};
 
-        if (!PyArg_ParseTupleAndKeywords(args, kwargs, "|bbb", kws, &in_queue,
+        /* Use "p" (bool predicate -> int), not "b" (one byte): the targets are
+         * 4-byte ints, so "b" stores a single byte, which lands on the low byte
+         * on little-endian but the high byte on big-endian. There the flags,
+         * pre-initialised to 1, could never be cleared, so e.g. in_queue=False
+         * was ignored and the queue was purged anyway. */
+        if (!PyArg_ParseTupleAndKeywords(args, kwargs, "|ppp", kws, &in_queue,
                                          &in_flight, &blocking))
                 return NULL;
 


### PR DESCRIPTION
Producer.purge() parsed its in_queue, in_flight and blocking arguments with PyArg_ParseTupleAndKeywords's "|bbb" format , which is the 1-byte "b" (unsigned char) format into 4-byte int targets pre-initialised to 1. "b" writes a single byte, which on little-endian lands on the low byte (so it happens to work) but on big-endian lands on the high byte, leaving the int as 0x00000001. The flags can therefore never be set to False on big-endian, so purge(in_queue=False) purges the queue anyway.
Fixed by using the "p" (boolean predicate → int) format, which is the correct format for these bool-typed arguments and produces identical results on little-endian. This is the only "b"-format PyArg call in the C sources.
The existing tests/test_Producer.py::test_purge already covers this: it asserts purge(in_queue=False) does not purge, which fails deterministically on big-endian before this change and passes after. Validated on a native s390x host (built against librdkafka.redist 2.15.0): before the fix test_purge fails, after it passes; little-endian behaviour is unchanged.