### PR TITLE
[NOGIL][Cherry Pick] Guard AdminClient against concurrent close() vs method-call races

### DIFF
--- a/src/confluent_kafka/src/Admin.c
+++ b/src/confluent_kafka/src/Admin.c
@@ -38,6 +38,9 @@
  *
  ****************************************************************************/
 
+static int Admin_rk_use_begin(Handle *self) {
+        return Handle_rk_use_begin(self, ERR_MSG_ADMIN_CLIENT_CLOSED);
+}
 
 
 static int Admin_clear(Handle *self) {
@@ -132,6 +135,9 @@ Admin_options_to_c(Handle *self,
         rd_kafka_error_t *err_obj = NULL;
         char errstr[512];
 
+        /* TODO NOGIL: Check if we can remove this as the caller would've
+         * acquired the lock on rk so this check should not be required.
+         */
         if (!self->rk) {
                 PyErr_SetString(PyExc_RuntimeError,
                                 ERR_MSG_ADMIN_CLIENT_CLOSED);
@@ -562,8 +568,10 @@ Admin_create_topics(Handle *self, PyObject *args, PyObject *kwargs) {
         int tcnt;
         int i;
         int topic_partition_count;
-        rd_kafka_NewTopic_t **c_objs;
-        rd_kafka_queue_t *rkqu;
+        rd_kafka_NewTopic_t **c_objs = NULL;
+        rd_kafka_queue_t *rkqu       = NULL;
+        PyObject *result             = NULL;
+        int future_incremented       = 0;
         CallState cs;
 
         /* topics is a list of NewTopic objects. */
@@ -584,21 +592,19 @@ Admin_create_topics(Handle *self, PyObject *args, PyObject *kwargs) {
                             &options.validate_only))
                 return NULL;
 
-        if (!self->rk) {
-                PyErr_SetString(PyExc_RuntimeError,
-                                ERR_MSG_ADMIN_CLIENT_CLOSED);
+        if (!Admin_rk_use_begin(self))
                 return NULL;
-        }
 
         c_options = Admin_options_to_c(self, RD_KAFKA_ADMIN_OP_CREATETOPICS,
                                        &options, future);
         if (!c_options)
-                return NULL; /* Exception raised by options_to_c() */
+                goto done; /* Exception raised by options_to_c() */
 
         /* options_to_c() sets future as the opaque, which is used in the
          * background_event_cb to set the results on the future as the
          * admin operation is finished, so we need to keep our own refcount. */
         Py_INCREF(future);
+        future_incremented = 1;
 
         /*
          * Parse the list of NewTopics and convert to corresponding C types.
@@ -613,11 +619,11 @@ Admin_create_topics(Handle *self, PyObject *args, PyObject *kwargs) {
                 r = PyObject_IsInstance((PyObject *)newt,
                                         (PyObject *)&NewTopicType);
                 if (r == -1)
-                        goto err; /* Exception raised by IsInstance() */
+                        goto done; /* Exception raised by IsInstance() */
                 else if (r == 0) {
                         PyErr_SetString(PyExc_ValueError,
                                         "Expected list of NewTopic objects");
-                        goto err;
+                        goto done;
                 }
 
                 c_objs[i] = rd_kafka_NewTopic_new(
@@ -627,7 +633,7 @@ Admin_create_topics(Handle *self, PyObject *args, PyObject *kwargs) {
                         PyErr_Format(PyExc_ValueError,
                                      "Invalid NewTopic(%s): %s", newt->topic,
                                      errstr);
-                        goto err;
+                        goto done;
                 }
 
                 if (newt->replica_assignment) {
@@ -637,7 +643,7 @@ Admin_create_topics(Handle *self, PyObject *args, PyObject *kwargs) {
                                                 "replica_assignment are "
                                                 "mutually exclusive");
                                 i++;
-                                goto err;
+                                goto done;
                         }
 
                         if (newt->num_partitions == -1) {
@@ -651,7 +657,7 @@ Admin_create_topics(Handle *self, PyObject *args, PyObject *kwargs) {
                                 newt->replica_assignment, topic_partition_count,
                                 topic_partition_count, "num_partitions")) {
                                 i++;
-                                goto err;
+                                goto done;
                         }
                 }
 
@@ -660,7 +666,7 @@ Admin_create_topics(Handle *self, PyObject *args, PyObject *kwargs) {
                                                     newt->config,
                                                     "newtopic_set_config")) {
                                 i++;
-                                goto err;
+                                goto done;
                         }
                 }
         }
@@ -680,20 +686,22 @@ Admin_create_topics(Handle *self, PyObject *args, PyObject *kwargs) {
         rd_kafka_CreateTopics(self->rk, c_objs, tcnt, c_options, rkqu);
         CallState_end(self, &cs);
 
-        rd_kafka_NewTopic_destroy_array(c_objs, tcnt);
-        rd_kafka_AdminOptions_destroy(c_options);
+        result = Py_None;
+        Py_INCREF(result);
+
+done:
+        if (c_objs)
+                rd_kafka_NewTopic_destroy_array(c_objs, i);
+        if (c_options)
+                rd_kafka_AdminOptions_destroy(c_options);
         free(c_objs);
-        rd_kafka_queue_destroy(rkqu); /* drop reference from get_background */
+        if (rkqu)
+                rd_kafka_queue_destroy(rkqu);
+        if (future_incremented && !result)
+                Py_DECREF(future);
 
-        Py_RETURN_NONE;
-
-err:
-        rd_kafka_NewTopic_destroy_array(c_objs, i);
-        rd_kafka_AdminOptions_destroy(c_options);
-        free(c_objs);
-        Py_DECREF(future); /* from options_to_c() */
-
-        return NULL;
+        Handle_rk_use_end(self);
+        return result;
 }
 
 
@@ -710,8 +718,10 @@ Admin_delete_topics(Handle *self, PyObject *args, PyObject *kwargs) {
         rd_kafka_AdminOptions_t *c_options = NULL;
         int tcnt;
         int i;
-        rd_kafka_DeleteTopic_t **c_objs;
-        rd_kafka_queue_t *rkqu;
+        rd_kafka_DeleteTopic_t **c_objs = NULL;
+        rd_kafka_queue_t *rkqu          = NULL;
+        PyObject *result                = NULL;
+        int future_incremented          = 0;
         CallState cs;
 
         /* topics is a list of strings. */
@@ -726,21 +736,19 @@ Admin_delete_topics(Handle *self, PyObject *args, PyObject *kwargs) {
                 return NULL;
         }
 
-        if (!self->rk) {
-                PyErr_SetString(PyExc_RuntimeError,
-                                ERR_MSG_ADMIN_CLIENT_CLOSED);
+        if (!Admin_rk_use_begin(self))
                 return NULL;
-        }
 
         c_options = Admin_options_to_c(self, RD_KAFKA_ADMIN_OP_DELETETOPICS,
                                        &options, future);
         if (!c_options)
-                return NULL; /* Exception raised by options_to_c() */
+                goto done; /* Exception raised by options_to_c() */
 
         /* options_to_c() sets opaque to the future object, which is used in the
          * background_event_cb to set the results on the future as the
          * admin operation is finished, so we need to keep our own refcount. */
         Py_INCREF(future);
+        future_incremented = 1;
 
         /*
          * Parse the list of strings and convert to corresponding C types.
@@ -759,7 +767,7 @@ Admin_delete_topics(Handle *self, PyObject *args, PyObject *kwargs) {
                             "Expected list of topic strings, "
                             "not %s",
                             ((PyTypeObject *)PyObject_Type(topic))->tp_name);
-                        goto err;
+                        goto done;
                 }
 
                 c_objs[i] = rd_kafka_DeleteTopic_new(
@@ -784,20 +792,24 @@ Admin_delete_topics(Handle *self, PyObject *args, PyObject *kwargs) {
         rd_kafka_DeleteTopics(self->rk, c_objs, tcnt, c_options, rkqu);
         CallState_end(self, &cs);
 
-        rd_kafka_DeleteTopic_destroy_array(c_objs, i);
-        rd_kafka_AdminOptions_destroy(c_options);
+        result = Py_None;
+        Py_INCREF(result);
+
+done:
+        if (c_objs)
+                rd_kafka_DeleteTopic_destroy_array(c_objs, i);
+        if (c_options)
+                rd_kafka_AdminOptions_destroy(c_options);
         free(c_objs);
-        rd_kafka_queue_destroy(rkqu); /* drop reference from get_background */
+        if (rkqu)
+                rd_kafka_queue_destroy(rkqu); /* drop ref from get_background */
+        /* Release our extra ref only on failure; on success the opaque keeps
+         * it (see options_to_c()). */
+        if (future_incremented && !result)
+                Py_DECREF(future);
 
-        Py_RETURN_NONE;
-
-err:
-        rd_kafka_DeleteTopic_destroy_array(c_objs, i);
-        rd_kafka_AdminOptions_destroy(c_options);
-        free(c_objs);
-        Py_DECREF(future); /* from options_to_c() */
-
-        return NULL;
+        Handle_rk_use_end(self);
+        return result;
 }
 
 
@@ -815,8 +827,10 @@ Admin_create_partitions(Handle *self, PyObject *args, PyObject *kwargs) {
         rd_kafka_AdminOptions_t *c_options = NULL;
         int tcnt;
         int i;
-        rd_kafka_NewPartitions_t **c_objs;
-        rd_kafka_queue_t *rkqu;
+        rd_kafka_NewPartitions_t **c_objs = NULL;
+        rd_kafka_queue_t *rkqu            = NULL;
+        PyObject *result                  = NULL;
+        int future_incremented            = 0;
         CallState cs;
 
         /* topics is a list of NewPartitions_t objects. */
@@ -838,21 +852,19 @@ Admin_create_partitions(Handle *self, PyObject *args, PyObject *kwargs) {
                             &options.validate_only))
                 return NULL;
 
-        if (!self->rk) {
-                PyErr_SetString(PyExc_RuntimeError,
-                                ERR_MSG_ADMIN_CLIENT_CLOSED);
+        if (!Admin_rk_use_begin(self))
                 return NULL;
-        }
 
         c_options = Admin_options_to_c(self, RD_KAFKA_ADMIN_OP_CREATEPARTITIONS,
                                        &options, future);
         if (!c_options)
-                return NULL; /* Exception raised by options_to_c() */
+                goto done; /* Exception raised by options_to_c() */
 
         /* options_to_c() sets future as the opaque, which is used in the
          * event_cb to set the results on the future as the admin operation
          * is finished, so we need to keep our own refcount. */
         Py_INCREF(future);
+        future_incremented = 1;
 
         /*
          * Parse the list of NewPartitions and convert to corresponding C types.
@@ -868,12 +880,12 @@ Admin_create_partitions(Handle *self, PyObject *args, PyObject *kwargs) {
                 r = PyObject_IsInstance((PyObject *)newp,
                                         (PyObject *)&NewPartitionsType);
                 if (r == -1)
-                        goto err; /* Exception raised by IsInstance() */
+                        goto done; /* Exception raised by IsInstance() */
                 else if (r == 0) {
                         PyErr_SetString(PyExc_ValueError,
                                         "Expected list of "
                                         "NewPartitions objects");
-                        goto err;
+                        goto done;
                 }
 
                 c_objs[i] = rd_kafka_NewPartitions_new(
@@ -882,7 +894,7 @@ Admin_create_partitions(Handle *self, PyObject *args, PyObject *kwargs) {
                         PyErr_Format(PyExc_ValueError,
                                      "Invalid NewPartitions(%s): %s",
                                      newp->topic, errstr);
-                        goto err;
+                        goto done;
                 }
 
                 if (newp->replica_assignment &&
@@ -892,7 +904,7 @@ Admin_create_partitions(Handle *self, PyObject *args, PyObject *kwargs) {
                         "new_total_count - "
                         "existing partition count")) {
                         i++;
-                        goto err; /* Exception raised by set_..() */
+                        goto done; /* Exception raised by set_..() */
                 }
         }
 
@@ -911,20 +923,24 @@ Admin_create_partitions(Handle *self, PyObject *args, PyObject *kwargs) {
         rd_kafka_CreatePartitions(self->rk, c_objs, tcnt, c_options, rkqu);
         CallState_end(self, &cs);
 
-        rd_kafka_NewPartitions_destroy_array(c_objs, tcnt);
-        rd_kafka_AdminOptions_destroy(c_options);
+        result = Py_None;
+        Py_INCREF(result);
+
+done:
+        if (c_objs)
+                rd_kafka_NewPartitions_destroy_array(c_objs, i);
+        if (c_options)
+                rd_kafka_AdminOptions_destroy(c_options);
         free(c_objs);
-        rd_kafka_queue_destroy(rkqu); /* drop reference from get_background */
+        if (rkqu)
+                rd_kafka_queue_destroy(rkqu); /* drop ref from get_background */
+        /* Release our extra ref only on failure; on success the opaque keeps
+         * it (see options_to_c()). */
+        if (future_incremented && !result)
+                Py_DECREF(future);
 
-        Py_RETURN_NONE;
-
-err:
-        rd_kafka_NewPartitions_destroy_array(c_objs, i);
-        rd_kafka_AdminOptions_destroy(c_options);
-        free(c_objs);
-        Py_DECREF(future); /* from options_to_c() */
-
-        return NULL;
+        Handle_rk_use_end(self);
+        return result;
 }
 
 
@@ -939,10 +955,12 @@ Admin_describe_configs(Handle *self, PyObject *args, PyObject *kwargs) {
                                         "request_timeout", "broker", NULL};
         struct Admin_options options = Admin_options_INITIALIZER;
         rd_kafka_AdminOptions_t *c_options = NULL;
-        PyObject *ConfigResource_type;
+        PyObject *ConfigResource_type      = NULL;
         int cnt, i;
-        rd_kafka_ConfigResource_t **c_objs;
-        rd_kafka_queue_t *rkqu;
+        rd_kafka_ConfigResource_t **c_objs = NULL;
+        rd_kafka_queue_t *rkqu             = NULL;
+        PyObject *result                   = NULL;
+        int future_incremented             = 0;
         CallState cs;
 
         /* resources is a list of ConfigResource objects. */
@@ -959,16 +977,13 @@ Admin_describe_configs(Handle *self, PyObject *args, PyObject *kwargs) {
                 return NULL;
         }
 
-        if (!self->rk) {
-                PyErr_SetString(PyExc_RuntimeError,
-                                ERR_MSG_ADMIN_CLIENT_CLOSED);
+        if (!Admin_rk_use_begin(self))
                 return NULL;
-        }
 
         c_options = Admin_options_to_c(self, RD_KAFKA_ADMIN_OP_DESCRIBECONFIGS,
                                        &options, future);
         if (!c_options)
-                return NULL; /* Exception raised by options_to_c() */
+                goto done; /* Exception raised by options_to_c() */
 
         /* Look up the ConfigResource class so we can check if the provided
          * topics are of correct type.
@@ -976,15 +991,14 @@ Admin_describe_configs(Handle *self, PyObject *args, PyObject *kwargs) {
          * to the luxury of looking up this for each call. */
         ConfigResource_type =
             cfl_PyObject_lookup("confluent_kafka.admin", "ConfigResource");
-        if (!ConfigResource_type) {
-                rd_kafka_AdminOptions_destroy(c_options);
-                return NULL; /* Exception raised by lookup() */
-        }
+        if (!ConfigResource_type)
+                goto done; /* Exception raised by lookup() */
 
         /* options_to_c() sets future as the opaque, which is used in the
          * event_cb to set the results on the future as the admin operation
          * is finished, so we need to keep our own refcount. */
         Py_INCREF(future);
+        future_incremented = 1;
 
         /*
          * Parse the list of ConfigResources and convert to
@@ -1000,19 +1014,19 @@ Admin_describe_configs(Handle *self, PyObject *args, PyObject *kwargs) {
 
                 r = PyObject_IsInstance(res, ConfigResource_type);
                 if (r == -1)
-                        goto err; /* Exception raised by IsInstance() */
+                        goto done; /* Exception raised by IsInstance() */
                 else if (r == 0) {
                         PyErr_SetString(PyExc_ValueError,
                                         "Expected list of "
                                         "ConfigResource objects");
-                        goto err;
+                        goto done;
                 }
 
                 if (!cfl_PyObject_GetInt(res, "restype_int", &restype, 0, 0))
-                        goto err;
+                        goto done;
 
                 if (!cfl_PyObject_GetString(res, "name", &resname, NULL, 0, 0))
-                        goto err;
+                        goto done;
 
                 c_objs[i] = rd_kafka_ConfigResource_new(
                     (rd_kafka_ResourceType_t)restype, resname);
@@ -1021,7 +1035,7 @@ Admin_describe_configs(Handle *self, PyObject *args, PyObject *kwargs) {
                                      "Invalid ConfigResource(%d,%s)", restype,
                                      resname);
                         free(resname);
-                        goto err;
+                        goto done;
                 }
                 free(resname);
         }
@@ -1041,23 +1055,25 @@ Admin_describe_configs(Handle *self, PyObject *args, PyObject *kwargs) {
         rd_kafka_DescribeConfigs(self->rk, c_objs, cnt, c_options, rkqu);
         CallState_end(self, &cs);
 
-        rd_kafka_ConfigResource_destroy_array(c_objs, cnt);
-        rd_kafka_AdminOptions_destroy(c_options);
+        result = Py_None;
+        Py_INCREF(result);
+
+done:
+        if (c_objs)
+                rd_kafka_ConfigResource_destroy_array(c_objs, i);
+        if (c_options)
+                rd_kafka_AdminOptions_destroy(c_options);
         free(c_objs);
-        rd_kafka_queue_destroy(rkqu); /* drop reference from get_background */
+        if (rkqu)
+                rd_kafka_queue_destroy(rkqu); /* drop ref from get_background */
+        Py_XDECREF(ConfigResource_type);      /* from lookup() */
+        /* Release our extra ref only on failure; on success the opaque keeps
+         * it (see options_to_c()). */
+        if (future_incremented && !result)
+                Py_DECREF(future);
 
-        Py_DECREF(ConfigResource_type); /* from lookup() */
-
-        Py_RETURN_NONE;
-
-err:
-        rd_kafka_ConfigResource_destroy_array(c_objs, i);
-        rd_kafka_AdminOptions_destroy(c_options);
-        free(c_objs);
-        Py_DECREF(ConfigResource_type); /* from lookup() */
-        Py_DECREF(future);              /* from options_to_c() */
-
-        return NULL;
+        Handle_rk_use_end(self);
+        return result;
 }
 
 static PyObject *Admin_incremental_alter_configs(Handle *self,
@@ -1071,10 +1087,13 @@ static PyObject *Admin_incremental_alter_configs(Handle *self,
                               NULL};
         struct Admin_options options       = Admin_options_INITIALIZER;
         rd_kafka_AdminOptions_t *c_options = NULL;
-        PyObject *ConfigResource_type, *ConfigEntry_type;
+        PyObject *ConfigResource_type      = NULL;
+        PyObject *ConfigEntry_type         = NULL;
         int cnt, i;
-        rd_kafka_ConfigResource_t **c_objs;
-        rd_kafka_queue_t *rkqu;
+        rd_kafka_ConfigResource_t **c_objs = NULL;
+        rd_kafka_queue_t *rkqu             = NULL;
+        PyObject *result                   = NULL;
+        int future_incremented             = 0;
         CallState cs;
 
         /* resources is a list of ConfigResource objects. */
@@ -1096,16 +1115,13 @@ static PyObject *Admin_incremental_alter_configs(Handle *self,
                             &options.validate_only))
                 return NULL;
 
-        if (!self->rk) {
-                PyErr_SetString(PyExc_RuntimeError,
-                                ERR_MSG_ADMIN_CLIENT_CLOSED);
+        if (!Admin_rk_use_begin(self))
                 return NULL;
-        }
 
         c_options = Admin_options_to_c(
             self, RD_KAFKA_ADMIN_OP_INCREMENTALALTERCONFIGS, &options, future);
         if (!c_options)
-                return NULL; /* Exception raised by options_to_c() */
+                goto done; /* Exception raised by options_to_c() */
 
         /* Look up the ConfigResource class so we can check if the provided
          * topics are of correct type.
@@ -1113,23 +1129,19 @@ static PyObject *Admin_incremental_alter_configs(Handle *self,
          * to the luxury of looking up this for each call. */
         ConfigResource_type =
             cfl_PyObject_lookup("confluent_kafka.admin", "ConfigResource");
-        if (!ConfigResource_type) {
-                rd_kafka_AdminOptions_destroy(c_options);
-                return NULL; /* Exception raised by find() */
-        }
+        if (!ConfigResource_type)
+                goto done; /* Exception raised by find() */
 
         ConfigEntry_type =
             cfl_PyObject_lookup("confluent_kafka.admin", "ConfigEntry");
-        if (!ConfigEntry_type) {
-                Py_DECREF(ConfigResource_type);
-                rd_kafka_AdminOptions_destroy(c_options);
-                return NULL; /* Exception raised by find() */
-        }
+        if (!ConfigEntry_type)
+                goto done; /* Exception raised by find() */
 
         /* options_to_c() sets future as the opaque, which is used in the
          * event_cb to set the results on the future as the admin operation
          * is finished, so we need to keep our own refcount. */
         Py_INCREF(future);
+        future_incremented = 1;
 
         /*
          * Parse the list of ConfigResources and convert to
@@ -1146,19 +1158,19 @@ static PyObject *Admin_incremental_alter_configs(Handle *self,
 
                 r = PyObject_IsInstance(res, ConfigResource_type);
                 if (r == -1)
-                        goto err; /* Exception raised by IsInstance() */
+                        goto done; /* Exception raised by IsInstance() */
                 else if (r == 0) {
                         PyErr_SetString(PyExc_ValueError,
                                         "Expected list of "
                                         "ConfigResource objects");
-                        goto err;
+                        goto done;
                 }
 
                 if (!cfl_PyObject_GetInt(res, "restype_int", &restype, 0, 0))
-                        goto err;
+                        goto done;
 
                 if (!cfl_PyObject_GetString(res, "name", &resname, NULL, 0, 0))
-                        goto err;
+                        goto done;
 
                 c_objs[i] = rd_kafka_ConfigResource_new(
                     (rd_kafka_ResourceType_t)restype, resname);
@@ -1167,7 +1179,7 @@ static PyObject *Admin_incremental_alter_configs(Handle *self,
                                      "Invalid ConfigResource(%d,%s)", restype,
                                      resname);
                         free(resname);
-                        goto err;
+                        goto done;
                 }
                 free(resname);
                 /*
@@ -1177,13 +1189,13 @@ static PyObject *Admin_incremental_alter_configs(Handle *self,
                                           &incremental_configs, &PyList_Type, 1,
                                           0)) {
                         i++;
-                        goto err;
+                        goto done;
                 }
                 if (!Admin_incremental_config_to_c(
                         incremental_configs, c_objs[i], ConfigEntry_type)) {
                         Py_DECREF(incremental_configs);
                         i++;
-                        goto err;
+                        goto done;
                 }
                 Py_DECREF(incremental_configs);
         }
@@ -1204,25 +1216,26 @@ static PyObject *Admin_incremental_alter_configs(Handle *self,
                                          rkqu);
         CallState_end(self, &cs);
 
-        rd_kafka_ConfigResource_destroy_array(c_objs, cnt);
-        rd_kafka_AdminOptions_destroy(c_options);
+        result = Py_None;
+        Py_INCREF(result);
+
+done:
+        if (c_objs)
+                rd_kafka_ConfigResource_destroy_array(c_objs, i);
+        if (c_options)
+                rd_kafka_AdminOptions_destroy(c_options);
         free(c_objs);
-        rd_kafka_queue_destroy(rkqu); /* drop reference from get_background */
+        if (rkqu)
+                rd_kafka_queue_destroy(rkqu); /* drop ref from get_background */
+        Py_XDECREF(ConfigResource_type);      /* from lookup() */
+        Py_XDECREF(ConfigEntry_type);         /* from lookup() */
+        /* Release our extra ref only on failure; on success the opaque keeps
+         * it (see options_to_c()). */
+        if (future_incremented && !result)
+                Py_DECREF(future);
 
-        Py_DECREF(ConfigResource_type); /* from lookup() */
-        Py_DECREF(ConfigEntry_type);    /* from lookup() */
-
-        Py_RETURN_NONE;
-
-err:
-        rd_kafka_ConfigResource_destroy_array(c_objs, i);
-        rd_kafka_AdminOptions_destroy(c_options);
-        free(c_objs);
-        Py_DECREF(ConfigResource_type); /* from lookup() */
-        Py_DECREF(ConfigEntry_type);    /* from lookup() */
-        Py_DECREF(future);              /* from options_to_c() */
-
-        return NULL;
+        Handle_rk_use_end(self);
+        return result;
 }
 
 
@@ -1239,10 +1252,12 @@ Admin_alter_configs(Handle *self, PyObject *args, PyObject *kwargs) {
                               NULL};
         struct Admin_options options       = Admin_options_INITIALIZER;
         rd_kafka_AdminOptions_t *c_options = NULL;
-        PyObject *ConfigResource_type;
+        PyObject *ConfigResource_type      = NULL;
         int cnt, i;
-        rd_kafka_ConfigResource_t **c_objs;
-        rd_kafka_queue_t *rkqu;
+        rd_kafka_ConfigResource_t **c_objs = NULL;
+        rd_kafka_queue_t *rkqu             = NULL;
+        PyObject *result                   = NULL;
+        int future_incremented             = 0;
         CallState cs;
 
         /* resources is a list of ConfigResource objects. */
@@ -1264,16 +1279,13 @@ Admin_alter_configs(Handle *self, PyObject *args, PyObject *kwargs) {
                             &options.validate_only))
                 return NULL;
 
-        if (!self->rk) {
-                PyErr_SetString(PyExc_RuntimeError,
-                                ERR_MSG_ADMIN_CLIENT_CLOSED);
+        if (!Admin_rk_use_begin(self))
                 return NULL;
-        }
 
         c_options = Admin_options_to_c(self, RD_KAFKA_ADMIN_OP_ALTERCONFIGS,
                                        &options, future);
         if (!c_options)
-                return NULL; /* Exception raised by options_to_c() */
+                goto done; /* Exception raised by options_to_c() */
 
         /* Look up the ConfigResource class so we can check if the provided
          * topics are of correct type.
@@ -1281,15 +1293,14 @@ Admin_alter_configs(Handle *self, PyObject *args, PyObject *kwargs) {
          * to the luxury of looking up this for each call. */
         ConfigResource_type =
             cfl_PyObject_lookup("confluent_kafka.admin", "ConfigResource");
-        if (!ConfigResource_type) {
-                rd_kafka_AdminOptions_destroy(c_options);
-                return NULL; /* Exception raised by find() */
-        }
+        if (!ConfigResource_type)
+                goto done; /* Exception raised by find() */
 
         /* options_to_c() sets future as the opaque, which is used in the
          * event_cb to set the results on the future as the admin operation
          * is finished, so we need to keep our own refcount. */
         Py_INCREF(future);
+        future_incremented = 1;
 
         /*
          * Parse the list of ConfigResources and convert to
@@ -1306,19 +1317,19 @@ Admin_alter_configs(Handle *self, PyObject *args, PyObject *kwargs) {
 
                 r = PyObject_IsInstance(res, ConfigResource_type);
                 if (r == -1)
-                        goto err; /* Exception raised by IsInstance() */
+                        goto done; /* Exception raised by IsInstance() */
                 else if (r == 0) {
                         PyErr_SetString(PyExc_ValueError,
                                         "Expected list of "
                                         "ConfigResource objects");
-                        goto err;
+                        goto done;
                 }
 
                 if (!cfl_PyObject_GetInt(res, "restype_int", &restype, 0, 0))
-                        goto err;
+                        goto done;
 
                 if (!cfl_PyObject_GetString(res, "name", &resname, NULL, 0, 0))
-                        goto err;
+                        goto done;
 
                 c_objs[i] = rd_kafka_ConfigResource_new(
                     (rd_kafka_ResourceType_t)restype, resname);
@@ -1327,7 +1338,7 @@ Admin_alter_configs(Handle *self, PyObject *args, PyObject *kwargs) {
                                      "Invalid ConfigResource(%d,%s)", restype,
                                      resname);
                         free(resname);
-                        goto err;
+                        goto done;
                 }
                 free(resname);
 
@@ -1337,12 +1348,12 @@ Admin_alter_configs(Handle *self, PyObject *args, PyObject *kwargs) {
                 if (!cfl_PyObject_GetAttr(res, "set_config_dict", &dict,
                                           &PyDict_Type, 1, 0)) {
                         i++;
-                        goto err;
+                        goto done;
                 }
                 if (!Admin_config_dict_to_c(c_objs[i], dict, "set_config")) {
                         Py_DECREF(dict);
                         i++;
-                        goto err;
+                        goto done;
                 }
                 Py_DECREF(dict);
         }
@@ -1362,23 +1373,25 @@ Admin_alter_configs(Handle *self, PyObject *args, PyObject *kwargs) {
         rd_kafka_AlterConfigs(self->rk, c_objs, cnt, c_options, rkqu);
         CallState_end(self, &cs);
 
-        rd_kafka_ConfigResource_destroy_array(c_objs, cnt);
-        rd_kafka_AdminOptions_destroy(c_options);
+        result = Py_None;
+        Py_INCREF(result);
+
+done:
+        if (c_objs)
+                rd_kafka_ConfigResource_destroy_array(c_objs, i);
+        if (c_options)
+                rd_kafka_AdminOptions_destroy(c_options);
         free(c_objs);
-        rd_kafka_queue_destroy(rkqu); /* drop reference from get_background */
+        if (rkqu)
+                rd_kafka_queue_destroy(rkqu); /* drop ref from get_background */
+        Py_XDECREF(ConfigResource_type);      /* from lookup() */
+        /* Release our extra ref only on failure; on success the opaque keeps
+         * it (see options_to_c()). */
+        if (future_incremented && !result)
+                Py_DECREF(future);
 
-        Py_DECREF(ConfigResource_type); /* from lookup() */
-
-        Py_RETURN_NONE;
-
-err:
-        rd_kafka_ConfigResource_destroy_array(c_objs, i);
-        rd_kafka_AdminOptions_destroy(c_options);
-        free(c_objs);
-        Py_DECREF(ConfigResource_type); /* from lookup() */
-        Py_DECREF(future);              /* from options_to_c() */
-
-        return NULL;
+        Handle_rk_use_end(self);
+        return result;
 }
 
 
@@ -1396,6 +1409,7 @@ Admin_create_acls(Handle *self, PyObject *args, PyObject *kwargs) {
         CallState cs;
         rd_kafka_queue_t *rkqu;
         char errstr[512];
+        int entered_rk_use = 0;
 
         static char *kws[] = {"acls", "future",
                               /* options */
@@ -1424,11 +1438,9 @@ Admin_create_acls(Handle *self, PyObject *args, PyObject *kwargs) {
                 goto err;
         }
 
-        if (!self->rk) {
-                PyErr_SetString(PyExc_RuntimeError,
-                                ERR_MSG_ADMIN_CLIENT_CLOSED);
+        if (!Admin_rk_use_begin(self))
                 goto err;
-        }
+        entered_rk_use = 1;
 
         c_options = Admin_options_to_c(self, RD_KAFKA_ADMIN_OP_CREATEACLS,
                                        &options, future);
@@ -1489,6 +1501,7 @@ Admin_create_acls(Handle *self, PyObject *args, PyObject *kwargs) {
         Py_DECREF(AclBinding_type); /* from lookup() */
         rd_kafka_AdminOptions_destroy(c_options);
 
+        Handle_rk_use_end(self);
         Py_RETURN_NONE;
 err:
         if (c_objs) {
@@ -1501,6 +1514,8 @@ err:
                 rd_kafka_AdminOptions_destroy(c_options);
                 Py_DECREF(future);
         }
+        if (entered_rk_use)
+                Handle_rk_use_end(self);
         return NULL;
 }
 
@@ -1528,6 +1543,7 @@ Admin_describe_acls(Handle *self, PyObject *args, PyObject *kwargs) {
         CallState cs;
         rd_kafka_queue_t *rkqu;
         char errstr[512];
+        int entered_rk_use = 0;
 
         static char *kws[] = {"acl_binding_filter", "future",
                               /* options */
@@ -1549,11 +1565,9 @@ Admin_describe_acls(Handle *self, PyObject *args, PyObject *kwargs) {
                 goto err;
         }
 
-        if (!self->rk) {
-                PyErr_SetString(PyExc_RuntimeError,
-                                ERR_MSG_ADMIN_CLIENT_CLOSED);
+        if (!Admin_rk_use_begin(self))
                 goto err;
-        }
+        entered_rk_use = 1;
 
         c_options = Admin_options_to_c(self, RD_KAFKA_ADMIN_OP_CREATEACLS,
                                        &options, future);
@@ -1604,6 +1618,7 @@ Admin_describe_acls(Handle *self, PyObject *args, PyObject *kwargs) {
         rd_kafka_AclBinding_destroy(c_obj);
         Py_DECREF(AclBindingFilter_type); /* from lookup() */
         rd_kafka_AdminOptions_destroy(c_options);
+        Handle_rk_use_end(self);
         Py_RETURN_NONE;
 err:
         if (AclBindingFilter_type)
@@ -1612,6 +1627,8 @@ err:
                 rd_kafka_AdminOptions_destroy(c_options);
                 Py_DECREF(future);
         }
+        if (entered_rk_use)
+                Handle_rk_use_end(self);
         return NULL;
 }
 
@@ -1639,6 +1656,7 @@ Admin_delete_acls(Handle *self, PyObject *args, PyObject *kwargs) {
         CallState cs;
         rd_kafka_queue_t *rkqu;
         char errstr[512];
+        int entered_rk_use = 0;
 
         static char *kws[] = {"acls", "future",
                               /* options */
@@ -1667,11 +1685,9 @@ Admin_delete_acls(Handle *self, PyObject *args, PyObject *kwargs) {
                 goto err;
         }
 
-        if (!self->rk) {
-                PyErr_SetString(PyExc_RuntimeError,
-                                ERR_MSG_ADMIN_CLIENT_CLOSED);
+        if (!Admin_rk_use_begin(self))
                 goto err;
-        }
+        entered_rk_use = 1;
 
         c_options = Admin_options_to_c(self, RD_KAFKA_ADMIN_OP_DELETEACLS,
                                        &options, future);
@@ -1732,6 +1748,7 @@ Admin_delete_acls(Handle *self, PyObject *args, PyObject *kwargs) {
         Py_DECREF(AclBindingFilter_type); /* from lookup() */
         rd_kafka_AdminOptions_destroy(c_options);
 
+        Handle_rk_use_end(self);
         Py_RETURN_NONE;
 err:
         if (c_objs) {
@@ -1744,6 +1761,8 @@ err:
                 rd_kafka_AdminOptions_destroy(c_options);
                 Py_DECREF(future);
         }
+        if (entered_rk_use)
+                Handle_rk_use_end(self);
         return NULL;
 }
 
@@ -1772,6 +1791,7 @@ Admin_list_consumer_groups(Handle *self, PyObject *args, PyObject *kwargs) {
         int states_cnt                            = 0;
         int types_cnt                             = 0;
         int i                                     = 0;
+        int entered_rk_use                        = 0;
 
         static char *kws[] = {"future",
                               /* options */
@@ -1842,11 +1862,9 @@ Admin_list_consumer_groups(Handle *self, PyObject *args, PyObject *kwargs) {
                 }
         }
 
-        if (!self->rk) {
-                PyErr_SetString(PyExc_RuntimeError,
-                                ERR_MSG_ADMIN_CLIENT_CLOSED);
+        if (!Admin_rk_use_begin(self))
                 goto err;
-        }
+        entered_rk_use = 1;
 
         c_options = Admin_options_to_c(
             self, RD_KAFKA_ADMIN_OP_LISTCONSUMERGROUPS, &options, future);
@@ -1881,6 +1899,7 @@ Admin_list_consumer_groups(Handle *self, PyObject *args, PyObject *kwargs) {
         }
         rd_kafka_queue_destroy(rkqu); /* drop reference from get_background */
         rd_kafka_AdminOptions_destroy(c_options);
+        Handle_rk_use_end(self);
         Py_RETURN_NONE;
 err:
         if (c_states) {
@@ -1893,6 +1912,8 @@ err:
                 rd_kafka_AdminOptions_destroy(c_options);
                 Py_DECREF(future);
         }
+        if (entered_rk_use)
+                Handle_rk_use_end(self);
         return NULL;
 }
 const char Admin_list_consumer_groups_doc[] = PyDoc_STR(
@@ -1919,7 +1940,9 @@ static PyObject *Admin_describe_user_scram_credentials(Handle *self,
         rd_kafka_AdminOptions_t *c_options = NULL;
         int user_cnt                       = 0, i;
         const char **c_users               = NULL;
-        rd_kafka_queue_t *rkqu;
+        rd_kafka_queue_t *rkqu             = NULL;
+        PyObject *result                   = NULL;
+        int future_incremented             = 0;
         CallState cs;
 
         /* users is a list of strings. */
@@ -1934,21 +1957,20 @@ static PyObject *Admin_describe_user_scram_credentials(Handle *self,
                 return NULL;
         }
 
-        if (!self->rk) {
-                PyErr_SetString(PyExc_RuntimeError,
-                                ERR_MSG_ADMIN_CLIENT_CLOSED);
+        if (!Admin_rk_use_begin(self))
                 return NULL;
-        }
 
         c_options = Admin_options_to_c(
             self, RD_KAFKA_ADMIN_OP_DESCRIBEUSERSCRAMCREDENTIALS, &options,
             future);
         if (!c_options)
-                return NULL; /* Exception raised by options_to_c() */
+                goto done; /* Exception raised by options_to_c() */
+
         /* options_to_c() sets future as the opaque, which is used in the
          * event_cb to set the results on the future as the admin operation
          * is finished, so we need to keep our own refcount. */
         Py_INCREF(future);
+        future_incremented = 1;
 
         if (users != Py_None) {
                 user_cnt = (int)PyList_Size(users);
@@ -1966,7 +1988,7 @@ static PyObject *Admin_describe_user_scram_credentials(Handle *self,
                                     "User %d in 'users' parameters must not "
                                     "be  None",
                                     i);
-                                goto err;
+                                goto done;
                         }
 
                         if (!(u_user = cfl_PyObject_Unistr(user))) {
@@ -1975,7 +1997,7 @@ static PyObject *Admin_describe_user_scram_credentials(Handle *self,
                                     "User %d in 'users' parameters must "
                                     " be convertible to str",
                                     i);
-                                goto err;
+                                goto done;
                         }
 
                         c_users[i] = cfl_PyUnistr_AsUTF8(u_user, &uo_user);
@@ -1998,19 +2020,22 @@ static PyObject *Admin_describe_user_scram_credentials(Handle *self,
                                               c_options, rkqu);
         CallState_end(self, &cs);
 
-        if (c_users)
-                free(c_users);
-        rd_kafka_queue_destroy(rkqu); /* drop reference from get_background */
-        rd_kafka_AdminOptions_destroy(c_options);
-        Py_RETURN_NONE;
-err:
-        if (c_users)
-                free(c_users);
-        if (c_options) {
+        result = Py_None;
+        Py_INCREF(result);
+
+done:
+        free(c_users);
+        if (rkqu)
+                rd_kafka_queue_destroy(rkqu); /* drop ref from get_background */
+        if (c_options)
                 rd_kafka_AdminOptions_destroy(c_options);
+        /* Release our extra ref only on failure; on success the opaque keeps
+         * it (see options_to_c()). */
+        if (future_incremented && !result)
                 Py_DECREF(future);
-        }
-        return NULL;
+
+        Handle_rk_use_end(self);
+        return result;
 }
 
 const char describe_user_scram_credentials_doc[] = PyDoc_STR(
@@ -2058,6 +2083,7 @@ static PyObject *Admin_alter_user_scram_credentials(Handle *self,
         PyObject *mechanism             = NULL;
         int32_t iterations;
         int c_mechanism;
+        int entered_rk_use = 0;
 
         if (!PyArg_ParseTupleAndKeywords(args, kwargs, "OO|f", kws,
                                          &alterations, &future,
@@ -2114,11 +2140,9 @@ static PyObject *Admin_alter_user_scram_credentials(Handle *self,
                 goto err;
         }
 
-        if (!self->rk) {
-                PyErr_SetString(PyExc_RuntimeError,
-                                ERR_MSG_ADMIN_CLIENT_CLOSED);
+        if (!Admin_rk_use_begin(self))
                 goto err;
-        }
+        entered_rk_use = 1;
 
         c_options = Admin_options_to_c(
             self, RD_KAFKA_ADMIN_OP_ALTERUSERSCRAMCREDENTIALS, &options,
@@ -2306,6 +2330,7 @@ static PyObject *Admin_alter_user_scram_credentials(Handle *self,
         Py_DECREF(UserScramCredentialDeletion_type);   /* from lookup() */
         Py_DECREF(ScramCredentialInfo_type);           /* from lookup() */
         Py_DECREF(ScramMechanism_type);                /* from lookup() */
+        Handle_rk_use_end(self);
         Py_RETURN_NONE;
 err:
 
@@ -2331,6 +2356,8 @@ err:
                 rd_kafka_AdminOptions_destroy(c_options);
                 Py_DECREF(future);
         }
+        if (entered_rk_use)
+                Handle_rk_use_end(self);
         return NULL;
 }
 
@@ -2358,6 +2385,7 @@ Admin_describe_consumer_groups(Handle *self, PyObject *args, PyObject *kwargs) {
         rd_kafka_queue_t *rkqu;
         int groups_cnt = 0;
         int i          = 0;
+        int entered_rk_use = 0;
 
         static char *kws[] = {"future", "group_ids",
                               /* options */
@@ -2407,11 +2435,9 @@ Admin_describe_consumer_groups(Handle *self, PyObject *args, PyObject *kwargs) {
                 Py_XDECREF(uogroup);
         }
 
-        if (!self->rk) {
-                PyErr_SetString(PyExc_RuntimeError,
-                                ERR_MSG_ADMIN_CLIENT_CLOSED);
+        if (!Admin_rk_use_begin(self))
                 goto err;
-        }
+        entered_rk_use = 1;
 
         c_options = Admin_options_to_c(
             self, RD_KAFKA_ADMIN_OP_DESCRIBECONSUMERGROUPS, &options, future);
@@ -2445,6 +2471,7 @@ Admin_describe_consumer_groups(Handle *self, PyObject *args, PyObject *kwargs) {
         rd_kafka_queue_destroy(rkqu); /* drop reference from get_background */
         rd_kafka_AdminOptions_destroy(c_options);
 
+        Handle_rk_use_end(self);
         Py_RETURN_NONE;
 err:
         if (c_groups) {
@@ -2454,6 +2481,8 @@ err:
                 rd_kafka_AdminOptions_destroy(c_options);
                 Py_DECREF(future);
         }
+        if (entered_rk_use)
+                Handle_rk_use_end(self);
         return NULL;
 }
 
@@ -2481,6 +2510,7 @@ Admin_describe_topics(Handle *self, PyObject *args, PyObject *kwargs) {
         rd_kafka_TopicCollection_t *c_topic_collection = NULL;
         int topics_cnt                                 = 0;
         int i                                          = 0;
+        int entered_rk_use                             = 0;
 
         static char *kws[] = {"future", "topic_names",
                               /* options */
@@ -2537,11 +2567,9 @@ Admin_describe_topics(Handle *self, PyObject *args, PyObject *kwargs) {
                 }
         }
 
-        if (!self->rk) {
-                PyErr_SetString(PyExc_RuntimeError,
-                                ERR_MSG_ADMIN_CLIENT_CLOSED);
+        if (!Admin_rk_use_begin(self))
                 goto err;
-        }
+        entered_rk_use = 1;
 
         c_topic_collection =
             rd_kafka_TopicCollection_of_topic_names(c_topics, topics_cnt);
@@ -2579,6 +2607,7 @@ Admin_describe_topics(Handle *self, PyObject *args, PyObject *kwargs) {
         rd_kafka_queue_destroy(rkqu); /* drop reference from get_background */
         rd_kafka_AdminOptions_destroy(c_options);
 
+        Handle_rk_use_end(self);
         Py_RETURN_NONE;
 err:
         if (c_topics) {
@@ -2591,6 +2620,8 @@ err:
                 rd_kafka_AdminOptions_destroy(c_options);
                 Py_DECREF(future);
         }
+        if (entered_rk_use)
+                Handle_rk_use_end(self);
         return NULL;
 }
 
@@ -2614,6 +2645,7 @@ Admin_describe_cluster(Handle *self, PyObject *args, PyObject *kwargs) {
         rd_kafka_AdminOptions_t *c_options = NULL;
         CallState cs;
         rd_kafka_queue_t *rkqu;
+        int entered_rk_use = 0;
 
         static char *kws[] = {"future",
                               /* options */
@@ -2633,11 +2665,9 @@ Admin_describe_cluster(Handle *self, PyObject *args, PyObject *kwargs) {
                             &options.include_authorized_operations))
                 goto err;
 
-        if (!self->rk) {
-                PyErr_SetString(PyExc_RuntimeError,
-                                ERR_MSG_ADMIN_CLIENT_CLOSED);
+        if (!Admin_rk_use_begin(self))
                 goto err;
-        }
+        entered_rk_use = 1;
 
         c_options = Admin_options_to_c(self, RD_KAFKA_ADMIN_OP_DESCRIBECLUSTER,
                                        &options, future);
@@ -2667,12 +2697,15 @@ Admin_describe_cluster(Handle *self, PyObject *args, PyObject *kwargs) {
         rd_kafka_queue_destroy(rkqu); /* drop reference from get_background */
         rd_kafka_AdminOptions_destroy(c_options);
 
+        Handle_rk_use_end(self);
         Py_RETURN_NONE;
 err:
         if (c_options) {
                 rd_kafka_AdminOptions_destroy(c_options);
                 Py_DECREF(future);
         }
+        if (entered_rk_use)
+                Handle_rk_use_end(self);
         return NULL;
 }
 
@@ -2700,6 +2733,7 @@ Admin_delete_consumer_groups(Handle *self, PyObject *args, PyObject *kwargs) {
         CallState cs;
         rd_kafka_queue_t *rkqu;
         int i;
+        int entered_rk_use = 0;
 
         static char *kws[] = {"group_ids", "future",
                               /* options */
@@ -2710,11 +2744,9 @@ Admin_delete_consumer_groups(Handle *self, PyObject *args, PyObject *kwargs) {
                 goto err;
         }
 
-        if (!self->rk) {
-                PyErr_SetString(PyExc_RuntimeError,
-                                ERR_MSG_ADMIN_CLIENT_CLOSED);
+        if (!Admin_rk_use_begin(self))
                 goto err;
-        }
+        entered_rk_use = 1;
 
         c_options = Admin_options_to_c(self, RD_KAFKA_ADMIN_OP_DELETEGROUPS,
                                        &options, future);
@@ -2778,6 +2810,7 @@ Admin_delete_consumer_groups(Handle *self, PyObject *args, PyObject *kwargs) {
         free(c_delete_group_ids);
         rd_kafka_AdminOptions_destroy(c_options);
 
+        Handle_rk_use_end(self);
         Py_RETURN_NONE;
 err:
         if (c_delete_group_ids) {
@@ -2788,6 +2821,8 @@ err:
                 rd_kafka_AdminOptions_destroy(c_options);
                 Py_DECREF(future);
         }
+        if (entered_rk_use)
+                Handle_rk_use_end(self);
         return NULL;
 }
 
@@ -2819,6 +2854,7 @@ PyObject *Admin_list_consumer_group_offsets(Handle *self,
         rd_kafka_queue_t *rkqu;
         PyObject *topic_partitions = NULL;
         char *group_id             = NULL;
+        int entered_rk_use         = 0;
 
         static char *kws[] = {"request", "future",
                               /* options */
@@ -2835,11 +2871,9 @@ PyObject *Admin_list_consumer_group_offsets(Handle *self,
                             &options.require_stable_offsets))
                 return NULL;
 
-        if (!self->rk) {
-                PyErr_SetString(PyExc_RuntimeError,
-                                ERR_MSG_ADMIN_CLIENT_CLOSED);
+        if (!Admin_rk_use_begin(self))
                 goto err;
-        }
+        entered_rk_use = 1;
 
         c_options = Admin_options_to_c(
             self, RD_KAFKA_ADMIN_OP_LISTCONSUMERGROUPOFFSETS, &options, future);
@@ -2931,6 +2965,7 @@ PyObject *Admin_list_consumer_group_offsets(Handle *self,
         Py_XDECREF(topic_partitions);
         rd_kafka_AdminOptions_destroy(c_options);
 
+        Handle_rk_use_end(self);
         Py_RETURN_NONE;
 err:
         if (c_topic_partitions) {
@@ -2950,6 +2985,8 @@ err:
         }
         Py_XDECREF(topic_partitions);
         Py_XDECREF(ConsumerGroupTopicPartitions_type);
+        if (entered_rk_use)
+                Handle_rk_use_end(self);
         return NULL;
 }
 
@@ -2982,6 +3019,7 @@ PyObject *Admin_alter_consumer_group_offsets(Handle *self,
         rd_kafka_queue_t *rkqu;
         PyObject *topic_partitions = NULL;
         char *group_id             = NULL;
+        int entered_rk_use         = 0;
 
         static char *kws[] = {"request", "future",
                               /* options */
@@ -2992,11 +3030,9 @@ PyObject *Admin_alter_consumer_group_offsets(Handle *self,
                 goto err;
         }
 
-        if (!self->rk) {
-                PyErr_SetString(PyExc_RuntimeError,
-                                ERR_MSG_ADMIN_CLIENT_CLOSED);
+        if (!Admin_rk_use_begin(self))
                 goto err;
-        }
+        entered_rk_use = 1;
 
         c_options = Admin_options_to_c(
             self, RD_KAFKA_ADMIN_OP_ALTERCONSUMERGROUPOFFSETS, &options,
@@ -3087,6 +3123,7 @@ PyObject *Admin_alter_consumer_group_offsets(Handle *self,
         rd_kafka_AdminOptions_destroy(c_options);
         rd_kafka_topic_partition_list_destroy(c_topic_partitions);
 
+        Handle_rk_use_end(self);
         Py_RETURN_NONE;
 err:
         if (c_obj) {
@@ -3106,6 +3143,8 @@ err:
         }
         Py_XDECREF(topic_partitions);
         Py_XDECREF(ConsumerGroupTopicPartitions_type);
+        if (entered_rk_use)
+                Handle_rk_use_end(self);
         return NULL;
 }
 
@@ -3128,6 +3167,7 @@ PyObject *Admin_list_offsets(Handle *self, PyObject *args, PyObject *kwargs) {
         rd_kafka_topic_partition_list_t *c_topic_partitions = NULL;
         CallState cs;
         rd_kafka_queue_t *rkqu;
+        int entered_rk_use = 0;
 
         static char *kws[] = {"topic_partitions", "future",
                               /* options */
@@ -3139,11 +3179,9 @@ PyObject *Admin_list_offsets(Handle *self, PyObject *args, PyObject *kwargs) {
                 goto err;
         }
 
-        if (!self->rk) {
-                PyErr_SetString(PyExc_RuntimeError,
-                                ERR_MSG_ADMIN_CLIENT_CLOSED);
+        if (!Admin_rk_use_begin(self))
                 goto err;
-        }
+        entered_rk_use = 1;
 
         c_options = Admin_options_to_c(self, RD_KAFKA_ADMIN_OP_LISTOFFSETS,
                                        &options, future);
@@ -3182,12 +3220,15 @@ PyObject *Admin_list_offsets(Handle *self, PyObject *args, PyObject *kwargs) {
         rd_kafka_AdminOptions_destroy(c_options);
         rd_kafka_topic_partition_list_destroy(c_topic_partitions);
 
+        Handle_rk_use_end(self);
         Py_RETURN_NONE;
 err:
         if (c_options) {
                 rd_kafka_AdminOptions_destroy(c_options);
                 Py_DECREF(future);
         }
+        if (entered_rk_use)
+                Handle_rk_use_end(self);
         return NULL;
 }
 
@@ -3213,6 +3254,7 @@ PyObject *Admin_delete_records(Handle *self, PyObject *args, PyObject *kwargs) {
         rd_kafka_topic_partition_list_t *c_topic_partition_offsets = NULL;
         CallState cs;
         rd_kafka_queue_t *rkqu;
+        int entered_rk_use = 0;
 
         static char *kws[] = {"topic_partition_offsets", "future",
                               /* options */
@@ -3224,11 +3266,9 @@ PyObject *Admin_delete_records(Handle *self, PyObject *args, PyObject *kwargs) {
                 goto err;
         }
 
-        if (!self->rk) {
-                PyErr_SetString(PyExc_RuntimeError,
-                                ERR_MSG_ADMIN_CLIENT_CLOSED);
+        if (!Admin_rk_use_begin(self))
                 goto err;
-        }
+        entered_rk_use = 1;
 
         c_options = Admin_options_to_c(self, RD_KAFKA_ADMIN_OP_DELETERECORDS,
                                        &options, future);
@@ -3273,6 +3313,7 @@ PyObject *Admin_delete_records(Handle *self, PyObject *args, PyObject *kwargs) {
 
         rd_kafka_topic_partition_list_destroy(c_topic_partition_offsets);
 
+        Handle_rk_use_end(self);
         Py_RETURN_NONE;
 err:
         if (c_obj) {
@@ -3287,6 +3328,8 @@ err:
                 rd_kafka_topic_partition_list_destroy(
                     c_topic_partition_offsets);
         }
+        if (entered_rk_use)
+                Handle_rk_use_end(self);
         return NULL;
 }
 
@@ -3312,6 +3355,7 @@ PyObject *Admin_elect_leaders(Handle *self, PyObject *args, PyObject *kwargs) {
         rd_kafka_topic_partition_list_t *c_partitions = NULL;
         CallState cs;
         rd_kafka_queue_t *rkqu;
+        int entered_rk_use = 0;
 
         static char *kws[] = {"election_type",
                               "partitions"
@@ -3326,11 +3370,9 @@ PyObject *Admin_elect_leaders(Handle *self, PyObject *args, PyObject *kwargs) {
                 goto err;
         }
 
-        if (!self->rk) {
-                PyErr_SetString(PyExc_RuntimeError,
-                                ERR_MSG_ADMIN_CLIENT_CLOSED);
+        if (!Admin_rk_use_begin(self))
                 goto err;
-        }
+        entered_rk_use = 1;
 
         c_options = Admin_options_to_c(self, RD_KAFKA_ADMIN_OP_ELECTLEADERS,
                                        &options, future);
@@ -3384,6 +3426,7 @@ PyObject *Admin_elect_leaders(Handle *self, PyObject *args, PyObject *kwargs) {
         rd_kafka_AdminOptions_destroy(c_options);
         rd_kafka_ElectLeaders_destroy(c_elect_leaders);
 
+        Handle_rk_use_end(self);
         Py_RETURN_NONE;
 
 err:
@@ -3394,6 +3437,8 @@ err:
                 rd_kafka_AdminOptions_destroy(c_options);
                 Py_DECREF(future);
         }
+        if (entered_rk_use)
+                Handle_rk_use_end(self);
         return NULL;
 }
 
@@ -3436,13 +3481,13 @@ static PyObject *Admin_poll(Handle *self, PyObject *args, PyObject *kwargs) {
         if (!PyArg_ParseTupleAndKeywords(args, kwargs, "d", kws, &tmout))
                 return NULL;
 
-        if (!self->rk) {
-                PyErr_SetString(PyExc_RuntimeError,
-                                ERR_MSG_ADMIN_CLIENT_CLOSED);
+        if (!Admin_rk_use_begin(self))
                 return NULL;
-        }
 
         r = Admin_poll0(self, (int)(tmout * 1000));
+
+        Handle_rk_use_end(self);
+
         if (r == -1)
                 return NULL;
 
@@ -3467,16 +3512,59 @@ static PyObject *Admin_exit(Handle *self, PyObject *args) {
                                &exc_traceback))
                 return NULL;
 
-        /* Cleanup: destroy admin client */
-        if (self->rk) {
-                CallState_begin(self, &cs);
+        if (!self->rk)
+                Py_RETURN_NONE;
 
-                rd_kafka_destroy(self->rk);
-                self->rk = NULL;
+        /* Calling __exit__ reentrantly from within a callback
+         * is not supported and will deadlock here.
+         * TODO NOGIL: Update documentation to highlight this.
+         */
 
-                if (!CallState_end(self, &cs))
-                        return NULL;
+        /* If there are concurrent calls to __exit__, only one of them can
+         * destroy rk, the rest wait here for the winner to finish
+         * flushing and destroying it.
+         */
+        if (!atomic_int_cas(&self->closing, 0, 1)) {
+                while (self->rk && atomic_int_get(&self->closing)) {
+                        if (!Handle_sleep(self, 100))
+                                return NULL;
+                }
+                if (!self->rk)
+                        Py_RETURN_NONE;
+
+                /* The winner got interrupted by a signal */
+                PyErr_SetString(PyExc_RuntimeError,
+                                "__exit__() was interrupted by a signal on "
+                                "another thread");
+                return NULL;
         }
+
+        /* Record which thread won, so Handle_rk_use_begin() can let a
+         * reentrant call from this same thread through while we tear down. */
+        atomic_ulong_set(&self->closing_thread, PyThread_get_thread_ident());
+
+        /* Signal in-flight calls to stop, and wait for them to finish using
+         * self->rk before destroying it -- see Handle_rk_use_begin(). New
+         * calls will see `closing` and fail with
+         * ERR_MSG_ADMIN_CLIENT_CLOSED. */
+        while (atomic_int_get(&self->active_calls) > 0) {
+                if (!Handle_sleep(self, 100)) {
+                        /* Abort the attempt: rk was never touched, so reopen
+                         * the gate for a future __exit__() attempt. */
+                        atomic_ulong_set(&self->closing_thread, 0);
+                        atomic_int_set(&self->closing, 0);
+                        return NULL;
+                }
+        }
+
+        /* Cleanup: destroy admin client */
+        CallState_begin(self, &cs);
+
+        rd_kafka_destroy(self->rk);
+        self->rk = NULL;
+
+        if (!CallState_end(self, &cs))
+                return NULL;
 
         Py_RETURN_NONE;
 }
@@ -3613,9 +3701,23 @@ static PyMethodDef Admin_methods[] = {
 
 
 static Py_ssize_t Admin__len__(Handle *self) {
-        if (!self->rk)
+        Py_ssize_t len;
+
+        /* __len__ must never raise, so we can't use Handle_rk_use_begin()
+         * (which sets an exception on failure) -- fall back to returning 0
+         * if the Handle is closed/closing. */
+        if (atomic_int_get(&self->closing) || !self->rk)
                 return 0;
-        return rd_kafka_outq_len(self->rk);
+        atomic_int_inc(&self->active_calls);
+        if (atomic_int_get(&self->closing) || !self->rk) {
+                atomic_int_dec(&self->active_calls);
+                return 0;
+        }
+
+        len = rd_kafka_outq_len(self->rk);
+
+        atomic_int_dec(&self->active_calls);
+        return len;
 }
 
 

--- a/src/confluent_kafka/src/Consumer.c
+++ b/src/confluent_kafka/src/Consumer.c
@@ -27,12 +27,6 @@
 
 #include "confluent_kafka.h"
 
-#ifdef _WIN32
-#include <windows.h>
-#else
-#include <unistd.h>
-#endif
-
 
 /****************************************************************************
  *
@@ -43,85 +37,6 @@
  *
  *
  ****************************************************************************/
-
-/**
- * @brief Serializing gate: only one caller may be inside gated Consumer C
- *        code at a time. For the sync Consumer the identity is always the
- *        calling thread's own ID. For AIOConsumer this is a temporary ID
- *        generated when the method is called.
- *
- *        If the gate is unowned, the identity becomes the owner. If
- *        identity already matches the current owner, this is a legitimate
- *        re-entrant call (gate_depth is incremented). Any other identity
- *        waits for the gate to free up, retrying at a fixed interval.
- *
- * @returns 1 once the gate is held, or 0 with a Python exception set if a
- *          signal (e.g. KeyboardInterrupt) arrived while waiting.
- */
-static int Handle_gate_enter(Handle *h) {
-        unsigned long identity = 0;
-        PyObject *value        = NULL;
-
-        if (PyContextVar_Get(Consumer_reentry_identity_var, NULL, &value) ==
-            -1)
-                return 0;
-
-        if (value && PyLong_Check(value))
-                identity = PyLong_AsUnsignedLong(value);
-        Py_XDECREF(value);
-
-        /* 0 is never a legitimate identity (neither a real thread ID nor a
-         * generated AIOConsumer identity), so treat it the same as "not set".
-         */
-        if (identity == 0)
-                identity = (unsigned long)PyThread_get_thread_ident();
-
-        while (1) {
-                unsigned long owner =
-                    atomic_ulong_get(&h->u.Consumer.gate_owner);
-
-                if (owner == identity) {
-                        /* Re-entrant call presenting the same identity that
-                         * already owns the gate.
-                         */
-                        atomic_int_inc(&h->u.Consumer.gate_depth);
-                        return 1;
-                }
-
-                if (owner == 0 &&
-                    atomic_ulong_cas(&h->u.Consumer.gate_owner, 0,
-                                     identity)) {
-                        /* Gate looked unowned and we won the race to take
-                         * it. */
-                        atomic_int_set(&h->u.Consumer.gate_depth, 1);
-                        return 1;
-                }
-
-                /* Someone else holds the gate: wait for it. */
-                CallState cs;
-                CallState_begin(h, &cs);
-                /* TODO NOGIL: Create function for below */
-#ifdef _WIN32
-                Sleep(1);
-#else
-                usleep(1000);
-#endif
-                if (!CallState_end(h, &cs))
-                        return 0; /* signal received, e.g. KeyboardInterrupt */
-        }
-}
-
-/**
- * @brief Counterpart to Handle_gate_enter(): call once per successful
- *        Handle_gate_enter(), on every return path.
- */
-static void Handle_gate_exit(Handle *h) {
-        int depth = atomic_int_dec(&h->u.Consumer.gate_depth);
-        assert(depth >= 0);
-
-        if (depth == 0)
-                atomic_ulong_set(&h->u.Consumer.gate_owner, 0);
-}
 
 static void Consumer_clear0(Handle *self) {
         if (self->u.Consumer.on_assign) {
@@ -205,7 +120,7 @@ Consumer_subscribe(Handle *self, PyObject *args, PyObject *kwargs) {
                                          &on_revoke, &on_lost))
                 return NULL;
 
-        if (!Handle_gate_enter(self))
+        if (!Handle_serialize_enter(self))
                 return NULL;
 
         if (!self->rk) {
@@ -295,7 +210,7 @@ Consumer_subscribe(Handle *self, PyObject *args, PyObject *kwargs) {
         result = Py_None;
 
 done:
-        Handle_gate_exit(self);
+        Handle_serialize_exit(self);
         return result;
 }
 
@@ -303,7 +218,7 @@ static PyObject *Consumer_unsubscribe(Handle *self, PyObject *ignore) {
         PyObject *result = NULL;
         rd_kafka_resp_err_t err;
 
-        if (!Handle_gate_enter(self))
+        if (!Handle_serialize_enter(self))
                 return NULL;
 
         if (!self->rk) {
@@ -322,7 +237,7 @@ static PyObject *Consumer_unsubscribe(Handle *self, PyObject *ignore) {
         result = Py_None;
 
 done:
-        Handle_gate_exit(self);
+        Handle_serialize_exit(self);
         return result;
 }
 
@@ -333,7 +248,7 @@ Consumer_incremental_assign(Handle *self, PyObject *tlist) {
         rd_kafka_topic_partition_list_t *c_parts;
         rd_kafka_error_t *error;
 
-        if (!Handle_gate_enter(self))
+        if (!Handle_serialize_enter(self))
                 return NULL;
 
         if (!self->rk) {
@@ -359,7 +274,7 @@ Consumer_incremental_assign(Handle *self, PyObject *tlist) {
         result = Py_None;
 
 done:
-        Handle_gate_exit(self);
+        Handle_serialize_exit(self);
         return result;
 }
 
@@ -368,7 +283,7 @@ static PyObject *Consumer_assign(Handle *self, PyObject *tlist) {
         rd_kafka_topic_partition_list_t *c_parts;
         rd_kafka_resp_err_t err;
 
-        if (!Handle_gate_enter(self))
+        if (!Handle_serialize_enter(self))
                 return NULL;
 
         if (!self->rk) {
@@ -395,7 +310,7 @@ static PyObject *Consumer_assign(Handle *self, PyObject *tlist) {
         result = Py_None;
 
 done:
-        Handle_gate_exit(self);
+        Handle_serialize_exit(self);
         return result;
 }
 
@@ -403,7 +318,7 @@ static PyObject *Consumer_unassign(Handle *self, PyObject *ignore) {
         PyObject *result = NULL;
         rd_kafka_resp_err_t err;
 
-        if (!Handle_gate_enter(self))
+        if (!Handle_serialize_enter(self))
                 return NULL;
 
         if (!self->rk) {
@@ -424,7 +339,7 @@ static PyObject *Consumer_unassign(Handle *self, PyObject *ignore) {
         result = Py_None;
 
 done:
-        Handle_gate_exit(self);
+        Handle_serialize_exit(self);
         return result;
 }
 
@@ -434,7 +349,7 @@ Consumer_incremental_unassign(Handle *self, PyObject *tlist) {
         rd_kafka_topic_partition_list_t *c_parts;
         rd_kafka_error_t *error;
 
-        if (!Handle_gate_enter(self))
+        if (!Handle_serialize_enter(self))
                 return NULL;
 
         if (!self->rk) {
@@ -460,7 +375,7 @@ Consumer_incremental_unassign(Handle *self, PyObject *tlist) {
         result = Py_None;
 
 done:
-        Handle_gate_exit(self);
+        Handle_serialize_exit(self);
         return result;
 }
 
@@ -472,7 +387,7 @@ Consumer_assignment(Handle *self, PyObject *args,
         rd_kafka_topic_partition_list_t *c_parts;
         rd_kafka_resp_err_t err;
 
-        if (!Handle_gate_enter(self))
+        if (!Handle_serialize_enter(self))
                 return NULL;
 
         if (!self->rk) {
@@ -492,7 +407,7 @@ Consumer_assignment(Handle *self, PyObject *args,
         rd_kafka_topic_partition_list_destroy(c_parts);
 
 done:
-        Handle_gate_exit(self);
+        Handle_serialize_exit(self);
         return result;
 }
 
@@ -591,20 +506,20 @@ Consumer_commit(Handle *self, PyObject *args, PyObject *kwargs) {
         struct commit_return commit_return;
         PyThreadState *thread_state;
 
-        if (!Handle_gate_enter(self)) {
+        if (!Handle_serialize_enter(self)) {
                 return NULL;
         }
 
         if (!self->rk) {
                 PyErr_SetString(PyExc_RuntimeError, ERR_MSG_CONSUMER_CLOSED);
-                Handle_gate_exit(self);
+                Handle_serialize_exit(self);
                 return NULL;
         }
 
         if (!PyArg_ParseTupleAndKeywords(args, kwargs, "|OOOO", kws,
                                          &msg, &offsets, &async_o,
                                          &async_o)) {
-                Handle_gate_exit(self);
+                Handle_serialize_exit(self);
                 return NULL;
         }
 
@@ -614,7 +529,7 @@ Consumer_commit(Handle *self, PyObject *args, PyObject *kwargs) {
         if (msg && offsets) {
                 PyErr_SetString(PyExc_ValueError,
                                 "message and offsets are mutually exclusive");
-                Handle_gate_exit(self);
+                Handle_serialize_exit(self);
                 return NULL;
         }
 
@@ -625,7 +540,7 @@ Consumer_commit(Handle *self, PyObject *args, PyObject *kwargs) {
         if (offsets) {
 
                 if (!(c_offsets = py_to_c_parts(offsets))) {
-                        Handle_gate_exit(self);
+                        Handle_serialize_exit(self);
                         return NULL;
                 }
         } else if (msg) {
@@ -637,7 +552,7 @@ Consumer_commit(Handle *self, PyObject *args, PyObject *kwargs) {
                     (PyObject *)&MessageType) {
                         PyErr_Format(PyExc_TypeError, "expected %s",
                                      MessageType.tp_name);
-                        Handle_gate_exit(self);
+                        Handle_serialize_exit(self);
                         return NULL;
                 }
 
@@ -653,7 +568,7 @@ Consumer_commit(Handle *self, PyObject *args, PyObject *kwargs) {
                                          PyUnicode_AsUTF8(errstr));
                         Py_DECREF(error);
                         Py_DECREF(errstr);
-                        Handle_gate_exit(self);
+                        Handle_serialize_exit(self);
                         return NULL;
                 }
 
@@ -709,13 +624,13 @@ Consumer_commit(Handle *self, PyObject *args, PyObject *kwargs) {
 
                 cfl_PyErr_Format(err, "Commit failed: %s",
                                  rd_kafka_err2str(err));
-                Handle_gate_exit(self);
+                Handle_serialize_exit(self);
                 return NULL;
         }
 
         if (async) {
                 /* async commit returns None when commit is in progress */
-                Handle_gate_exit(self);
+                Handle_serialize_exit(self);
                 Py_RETURN_NONE;
 
         } else {
@@ -727,7 +642,7 @@ Consumer_commit(Handle *self, PyObject *args, PyObject *kwargs) {
                 plist = c_parts_to_py(commit_return.c_parts);
                 rd_kafka_topic_partition_list_destroy(commit_return.c_parts);
 
-                Handle_gate_exit(self);
+                Handle_serialize_exit(self);
                 return plist;
         }
 }
@@ -755,7 +670,7 @@ Consumer_store_offsets(Handle *self, PyObject *args,
                 return NULL;
         }
 
-        if (!Handle_gate_enter(self))
+        if (!Handle_serialize_enter(self))
                 return NULL;
 
         if (!self->rk) {
@@ -835,7 +750,7 @@ Consumer_store_offsets(Handle *self, PyObject *args,
         result = Py_None;
 
 done:
-        Handle_gate_exit(self);
+        Handle_serialize_exit(self);
         return result;
 #endif
 }
@@ -857,7 +772,7 @@ Consumer_committed(Handle *self, PyObject *args,
                 return NULL;
         }
 
-        if (!Handle_gate_enter(self))
+        if (!Handle_serialize_enter(self))
                 return NULL;
 
         if (!self->rk) {
@@ -885,7 +800,7 @@ Consumer_committed(Handle *self, PyObject *args,
         rd_kafka_topic_partition_list_destroy(c_parts);
 
 done:
-        Handle_gate_exit(self);
+        Handle_serialize_exit(self);
         return result;
 }
 
@@ -904,7 +819,7 @@ Consumer_position(Handle *self, PyObject *args,
                 return NULL;
         }
 
-        if (!Handle_gate_enter(self))
+        if (!Handle_serialize_enter(self))
                 return NULL;
 
         if (!self->rk) {
@@ -930,7 +845,7 @@ Consumer_position(Handle *self, PyObject *args,
         rd_kafka_topic_partition_list_destroy(c_parts);
 
 done:
-        Handle_gate_exit(self);
+        Handle_serialize_exit(self);
         return result;
 }
 
@@ -948,7 +863,7 @@ Consumer_pause(Handle *self, PyObject *args, PyObject *kwargs) {
                 return NULL;
         }
 
-        if (!Handle_gate_enter(self))
+        if (!Handle_serialize_enter(self))
                 return NULL;
 
         if (!self->rk) {
@@ -971,7 +886,7 @@ Consumer_pause(Handle *self, PyObject *args, PyObject *kwargs) {
         result = Py_None;
 
 done:
-        Handle_gate_exit(self);
+        Handle_serialize_exit(self);
         return result;
 }
 
@@ -989,7 +904,7 @@ Consumer_resume(Handle *self, PyObject *args, PyObject *kwargs) {
                 return NULL;
         }
 
-        if (!Handle_gate_enter(self))
+        if (!Handle_serialize_enter(self))
                 return NULL;
 
         if (!self->rk) {
@@ -1012,7 +927,7 @@ Consumer_resume(Handle *self, PyObject *args, PyObject *kwargs) {
         result = Py_None;
 
 done:
-        Handle_gate_exit(self);
+        Handle_serialize_exit(self);
         return result;
 }
 
@@ -1032,7 +947,7 @@ static PyObject *Consumer_seek(Handle *self, PyObject *args, PyObject *kwargs) {
                 return NULL;
         }
 
-        if (!Handle_gate_enter(self))
+        if (!Handle_serialize_enter(self))
                 return NULL;
 
         if (!self->rk) {
@@ -1079,7 +994,7 @@ static PyObject *Consumer_seek(Handle *self, PyObject *args, PyObject *kwargs) {
         result = Py_None;
 
 done:
-        Handle_gate_exit(self);
+        Handle_serialize_exit(self);
         return result;
 }
 
@@ -1100,7 +1015,7 @@ Consumer_get_watermark_offsets(Handle *self, PyObject *args, PyObject *kwargs) {
                 return NULL;
         }
 
-        if (!Handle_gate_enter(self))
+        if (!Handle_serialize_enter(self))
                 return NULL;
 
         if (!self->rk) {
@@ -1137,7 +1052,7 @@ Consumer_get_watermark_offsets(Handle *self, PyObject *args, PyObject *kwargs) {
         PyTuple_SetItem(result, 1, PyLong_FromLongLong(high));
 
 done:
-        Handle_gate_exit(self);
+        Handle_serialize_exit(self);
         return result;
 }
 
@@ -1166,7 +1081,7 @@ Consumer_offsets_for_times(Handle *self, PyObject *args,
                 return NULL;
         }
 
-        if (!Handle_gate_enter(self))
+        if (!Handle_serialize_enter(self))
                 return NULL;
 
         if (!self->rk) {
@@ -1193,7 +1108,7 @@ Consumer_offsets_for_times(Handle *self, PyObject *args,
         rd_kafka_topic_partition_list_destroy(c_parts);
 
 done:
-        Handle_gate_exit(self);
+        Handle_serialize_exit(self);
         return result;
 #endif
 }
@@ -1234,7 +1149,7 @@ Consumer_poll(Handle *self, PyObject *args, PyObject *kwargs) {
                 return NULL;
         }
 
-        if (!Handle_gate_enter(self))
+        if (!Handle_serialize_enter(self))
                 return NULL;
 
         if (!self->rk) {
@@ -1303,7 +1218,7 @@ Consumer_poll(Handle *self, PyObject *args, PyObject *kwargs) {
         rd_kafka_message_destroy(rkm);
 
 done:
-        Handle_gate_exit(self);
+        Handle_serialize_exit(self);
         return result;
 }
 
@@ -1312,7 +1227,7 @@ Consumer_memberid(Handle *self, PyObject *ignore) {
         char *memberid;
         PyObject *result = NULL;
 
-        if (!Handle_gate_enter(self))
+        if (!Handle_serialize_enter(self))
                 return NULL;
 
         if (!self->rk) {
@@ -1339,7 +1254,7 @@ Consumer_memberid(Handle *self, PyObject *ignore) {
         rd_kafka_mem_free(self->rk, memberid);
 
 done:
-        Handle_gate_exit(self);
+        Handle_serialize_exit(self);
         return result;
 }
 
@@ -1381,12 +1296,12 @@ Consumer_consume(Handle *self, PyObject *args, PyObject *kwargs) {
                 return NULL;
         }
 
-        if (!Handle_gate_enter(self))
+        if (!Handle_serialize_enter(self))
                 return NULL;
 
         if (!self->rk) {
                 PyErr_SetString(PyExc_RuntimeError, ERR_MSG_CONSUMER_CLOSED);
-                Handle_gate_exit(self);
+                Handle_serialize_exit(self);
                 return NULL;
         }
 
@@ -1394,14 +1309,14 @@ Consumer_consume(Handle *self, PyObject *args, PyObject *kwargs) {
                 PyErr_SetString(
                     PyExc_ValueError,
                     "num_messages must be between 0 and 1000000 (1M)");
-                Handle_gate_exit(self);
+                Handle_serialize_exit(self);
                 return NULL;
         }
 
         rkmessages = malloc(num_messages * sizeof(rd_kafka_message_t *));
         if (!rkmessages) {
                 PyErr_NoMemory();
-                Handle_gate_exit(self);
+                Handle_serialize_exit(self);
                 return NULL;
         }
 
@@ -1415,7 +1330,7 @@ Consumer_consume(Handle *self, PyObject *args, PyObject *kwargs) {
                         rd_kafka_message_destroy(rkmessages[i]);
                 }
                 free(rkmessages);
-                Handle_gate_exit(self);
+                Handle_serialize_exit(self);
                 return NULL;
         }
 
@@ -1423,7 +1338,7 @@ Consumer_consume(Handle *self, PyObject *args, PyObject *kwargs) {
                 free(rkmessages);
                 cfl_PyErr_Format(rd_kafka_last_error(), "%s",
                                  rd_kafka_err2str(rd_kafka_last_error()));
-                Handle_gate_exit(self);
+                Handle_serialize_exit(self);
                 return NULL;
         }
 
@@ -1443,7 +1358,7 @@ Consumer_consume(Handle *self, PyObject *args, PyObject *kwargs) {
 
         free(rkmessages);
 
-        Handle_gate_exit(self);
+        Handle_serialize_exit(self);
         return msglist;
 }
 
@@ -1452,7 +1367,7 @@ static PyObject *Consumer_close(Handle *self, PyObject *ignore) {
         CallState cs;
         PyObject *result = NULL;
 
-        if (!Handle_gate_enter(self))
+        if (!Handle_serialize_enter(self))
                 return NULL;
 
         if (!self->rk) {
@@ -1480,15 +1395,15 @@ static PyObject *Consumer_close(Handle *self, PyObject *ignore) {
         result = Py_None;
 
 done:
-        Handle_gate_exit(self);
+        Handle_serialize_exit(self);
         return result;
 }
 
 static PyObject *Consumer_enter(Handle *self) {
-        if (!Handle_gate_enter(self))
+        if (!Handle_serialize_enter(self))
                 return NULL;
         Py_INCREF(self);
-        Handle_gate_exit(self);
+        Handle_serialize_exit(self);
         return (PyObject *)self;
 }
 
@@ -1496,7 +1411,7 @@ static PyObject *Consumer_exit(Handle *self, PyObject *args) {
         PyObject *exc_type, *exc_value, *exc_traceback;
         PyObject *result = NULL;
 
-        if (!Handle_gate_enter(self))
+        if (!Handle_serialize_enter(self))
                 return NULL;
 
         if (!PyArg_UnpackTuple(args, "__exit__", 3, 3, &exc_type, &exc_value,
@@ -1516,7 +1431,7 @@ static PyObject *Consumer_exit(Handle *self, PyObject *args) {
         result = Py_None;
 
 done:
-        Handle_gate_exit(self);
+        Handle_serialize_exit(self);
         return result;
 }
 
@@ -1525,7 +1440,7 @@ Consumer_consumer_group_metadata(Handle *self, PyObject *ignore) {
         rd_kafka_consumer_group_metadata_t *cgmd;
         PyObject *result = NULL;
 
-        if (!Handle_gate_enter(self))
+        if (!Handle_serialize_enter(self))
                 return NULL;
 
         if (!self->rk) {
@@ -1544,7 +1459,7 @@ Consumer_consumer_group_metadata(Handle *self, PyObject *ignore) {
         rd_kafka_consumer_group_metadata_destroy(cgmd);
 
 done:
-        Handle_gate_exit(self);
+        Handle_serialize_exit(self);
         return result; /* Possibly NULL */
 }
 

--- a/src/confluent_kafka/src/Metadata.c
+++ b/src/confluent_kafka/src/Metadata.c
@@ -366,18 +366,17 @@ PyObject *list_topics(Handle *self, PyObject *args, PyObject *kwargs) {
                                          &tmout))
                 return NULL;
 
-        if (!self->rk) {
-                PyErr_SetString(PyExc_RuntimeError, ERR_MSG_HANDLE_CLOSED);
+        if (!Handle_common_enter(self))
                 return NULL;
-        }
 
         if (topic != NULL) {
                 if (!(only_rkt = rd_kafka_topic_new(self->rk, topic, NULL))) {
-                        return PyErr_Format(
-                            PyExc_RuntimeError,
-                            "Unable to create topic object "
-                            "for \"%s\": %s",
-                            topic, rd_kafka_err2str(rd_kafka_last_error()));
+                        PyErr_Format(PyExc_RuntimeError,
+                                    "Unable to create topic object "
+                                    "for \"%s\": %s",
+                                    topic,
+                                    rd_kafka_err2str(rd_kafka_last_error()));
+                        goto end; /* result and only_rkt are NULL */
                 }
         }
 
@@ -408,6 +407,8 @@ end:
         if (only_rkt != NULL) {
                 rd_kafka_topic_destroy(only_rkt);
         }
+
+        Handle_common_exit(self);
 
         return result;
 }
@@ -608,7 +609,8 @@ PyObject *list_groups(Handle *self, PyObject *args, PyObject *kwargs) {
         const struct rd_kafka_group_list *group_list = NULL;
         const char *group                            = NULL;
         double tmout                                 = -1.0f;
-        static char *kws[] = {"group", "timeout", NULL};
+        static char *kws[]                           = {"group", "timeout",
+                                                        NULL};
 
         PyErr_WarnEx(PyExc_DeprecationWarning,
                      "list_groups() is deprecated, use list_consumer_groups() "
@@ -619,10 +621,8 @@ PyObject *list_groups(Handle *self, PyObject *args, PyObject *kwargs) {
                                          &tmout))
                 return NULL;
 
-        if (!self->rk) {
-                PyErr_SetString(PyExc_RuntimeError, ERR_MSG_HANDLE_CLOSED);
+        if (!Handle_common_enter(self))
                 return NULL;
-        }
 
         CallState_begin(self, &cs);
 
@@ -645,6 +645,7 @@ end:
         if (group_list != NULL) {
                 rd_kafka_group_list_destroy(group_list);
         }
+        Handle_common_exit(self);
         return result;
 }
 

--- a/src/confluent_kafka/src/Producer.c
+++ b/src/confluent_kafka/src/Producer.c
@@ -59,6 +59,11 @@
  *
  ****************************************************************************/
 
+static int Producer_rk_use_begin(Handle *self) {
+        return Handle_rk_use_begin(self, ERR_MSG_PRODUCER_CLOSED);
+}
+
+
 /**
  * Per-message state.
  */
@@ -302,7 +307,7 @@ Producer_produce(Handle *self, PyObject *args, PyObject *kwargs) {
         if (!dr_cb || dr_cb == Py_None)
                 dr_cb = self->u.Producer.default_dr_cb;
 
-        if (!Handle_enter_rk_use(self)) {
+        if (!Producer_rk_use_begin(self)) {
 #ifdef RD_KAFKA_V_HEADERS
                 if (rd_headers)
                         rd_kafka_headers_destroy(rd_headers);
@@ -328,7 +333,7 @@ Producer_produce(Handle *self, PyObject *args, PyObject *kwargs) {
                                 key_len, msgstate);
 #endif
 
-        Handle_exit_rk_use(self);
+        Handle_rk_use_end(self);
 
         if (err) {
                 if (msgstate)
@@ -437,12 +442,12 @@ static PyObject *Producer_poll(Handle *self, PyObject *args, PyObject *kwargs) {
         if (!PyArg_ParseTupleAndKeywords(args, kwargs, "|d", kws, &tmout))
                 return NULL;
 
-        if (!Handle_enter_rk_use(self))
+        if (!Producer_rk_use_begin(self))
                 return NULL;
 
         r = Producer_poll0(self, cfl_timeout_ms(tmout));
 
-        Handle_exit_rk_use(self);
+        Handle_rk_use_end(self);
 
         if (r == -1)
                 return NULL;
@@ -487,7 +492,7 @@ Producer_flush(Handle *self, PyObject *args, PyObject *kwargs) {
         if (!PyArg_ParseTupleAndKeywords(args, kwargs, "|d", kws, &tmout))
                 return NULL;
 
-        if (!Handle_enter_rk_use(self))
+        if (!Producer_rk_use_begin(self))
                 return NULL;
 
         total_timeout_ms = cfl_timeout_ms(tmout);
@@ -556,7 +561,7 @@ Producer_flush(Handle *self, PyObject *args, PyObject *kwargs) {
         result = cfl_PyInt_FromInt(qlen);
 
 exit:
-        Handle_exit_rk_use(self);
+        Handle_rk_use_end(self);
         return result;
 }
 
@@ -583,13 +588,7 @@ Producer_close(Handle *self, PyObject *args, PyObject *kwargs) {
          */
         if (!atomic_int_cas(&self->closing, 0, 1)) {
                 while (self->rk && atomic_int_get(&self->closing)) {
-                        CallState_begin(self, &cs);
-#ifdef _WIN32
-                        Sleep(100);
-#else
-                        usleep(100000);
-#endif
-                        if (!CallState_end(self, &cs))
+                        if (!Handle_sleep(self, 100))
                                 return NULL;
                 }
                 if (!self->rk)
@@ -602,25 +601,19 @@ Producer_close(Handle *self, PyObject *args, PyObject *kwargs) {
                 return NULL;
         }
 
-        /* Record which thread won, so Handle_enter_rk_use() can let a
+        /* Record which thread won, so Handle_rk_use_begin() can let a
          * reentrant call through if (and only if) it's this same thread --
          * i.e. close()'s own delivery callback, fired synchronously from
          * inside the flush() call below, calling back into the Producer. */
         atomic_ulong_set(&self->closing_thread, PyThread_get_thread_ident());
 
         /* Signal in-flight calls to stop, and wait for them to finish
-         * using self->rk before destroying it -- see Handle_enter_rk_use().
+         * using self->rk before destroying it -- see Handle_rk_use_begin().
          * New calls will see `closing` and fail with ERR_MSG_PRODUCER_CLOSED. */
         /* TODO NOGIL: replace this poll loop with a mutex/condvar wait so
          * close() unblocks immediately instead of up to 100ms late. */
         while (atomic_int_get(&self->active_calls) > 0) {
-                CallState_begin(self, &cs);
-#ifdef _WIN32
-                Sleep(100);
-#else
-                usleep(100000);
-#endif
-                if (!CallState_end(self, &cs)) {
+                if (!Handle_sleep(self, 100)) {
                         /* Abort the attempt: rk was never touched, so
                          * reopen the gate for a future close() attempt.
                          */
@@ -927,7 +920,7 @@ Producer_produce_batch(Handle *self, PyObject *args, PyObject *kwargs) {
                 return cfl_PyInt_FromInt(0);
         }
 
-        if (!Handle_enter_rk_use(self))
+        if (!Producer_rk_use_begin(self))
                 return NULL;
 
         /* Allocate arrays for librdkafka messages and msgstates */
@@ -960,7 +953,7 @@ cleanup:
         if (rkt)
                 rd_kafka_topic_destroy(rkt);
 
-        Handle_exit_rk_use(self);
+        Handle_rk_use_end(self);
 
         /* Cleanup resources not tied to self->rk */
         if (rkmessages)
@@ -983,7 +976,7 @@ static PyObject *Producer_init_transactions(Handle *self, PyObject *args) {
         if (!PyArg_ParseTuple(args, "|d", &tmout))
                 return NULL;
 
-        if (!Handle_enter_rk_use(self))
+        if (!Producer_rk_use_begin(self))
                 return NULL;
 
         CallState_begin(self, &cs);
@@ -1006,19 +999,19 @@ static PyObject *Producer_init_transactions(Handle *self, PyObject *args) {
         Py_INCREF(result);
 
 exit:
-        Handle_exit_rk_use(self);
+        Handle_rk_use_end(self);
         return result;
 }
 
 static PyObject *Producer_begin_transaction(Handle *self) {
         rd_kafka_error_t *error;
 
-        if (!Handle_enter_rk_use(self))
+        if (!Producer_rk_use_begin(self))
                 return NULL;
 
         error = rd_kafka_begin_transaction(self->rk);
 
-        Handle_exit_rk_use(self);
+        Handle_rk_use_end(self);
 
         if (error) {
                 cfl_PyErr_from_error_destroy(error);
@@ -1041,7 +1034,7 @@ static PyObject *Producer_send_offsets_to_transaction(Handle *self,
         if (!PyArg_ParseTuple(args, "OO|d", &offsets, &metadata, &tmout))
                 return NULL;
 
-        if (!Handle_enter_rk_use(self))
+        if (!Producer_rk_use_begin(self))
                 return NULL;
 
         if (!(c_offsets = py_to_c_parts(offsets)))
@@ -1075,7 +1068,7 @@ exit:
                 rd_kafka_consumer_group_metadata_destroy(cgmd);
         if (c_offsets)
                 rd_kafka_topic_partition_list_destroy(c_offsets);
-        Handle_exit_rk_use(self);
+        Handle_rk_use_end(self);
         return result;
 }
 
@@ -1088,7 +1081,7 @@ static PyObject *Producer_commit_transaction(Handle *self, PyObject *args) {
         if (!PyArg_ParseTuple(args, "|d", &tmout))
                 return NULL;
 
-        if (!Handle_enter_rk_use(self))
+        if (!Producer_rk_use_begin(self))
                 return NULL;
 
         CallState_begin(self, &cs);
@@ -1111,7 +1104,7 @@ static PyObject *Producer_commit_transaction(Handle *self, PyObject *args) {
         Py_INCREF(result);
 
 exit:
-        Handle_exit_rk_use(self);
+        Handle_rk_use_end(self);
         return result;
 }
 
@@ -1126,7 +1119,7 @@ static PyObject *Producer_abort_transaction(Handle *self, PyObject *args) {
 
         /* abort_transaction is called as part of close() so even if this call
          * is rejected here (because a close is in progress), it is safe.*/
-        if (!Handle_enter_rk_use(self))
+        if (!Producer_rk_use_begin(self))
                 return NULL;
 
         CallState_begin(self, &cs);
@@ -1149,7 +1142,7 @@ static PyObject *Producer_abort_transaction(Handle *self, PyObject *args) {
         Py_INCREF(result);
 
 exit:
-        Handle_exit_rk_use(self);
+        Handle_rk_use_end(self);
         return result;
 }
 
@@ -1166,7 +1159,7 @@ static void *Producer_purge(Handle *self, PyObject *args, PyObject *kwargs) {
                                          &in_flight, &blocking))
                 return NULL;
 
-        if (!Handle_enter_rk_use(self))
+        if (!Producer_rk_use_begin(self))
                 return NULL;
 
         if (in_queue)
@@ -1178,7 +1171,7 @@ static void *Producer_purge(Handle *self, PyObject *args, PyObject *kwargs) {
 
         err = rd_kafka_purge(self->rk, purge_strategy);
 
-        Handle_exit_rk_use(self);
+        Handle_rk_use_end(self);
 
         if (err) {
                 cfl_PyErr_Format(err, "Purge failed: %s",
@@ -1537,7 +1530,7 @@ static PyMethodDef Producer_methods[] = {
 static Py_ssize_t Producer__len__(Handle *self) {
         Py_ssize_t len;
 
-        /* __len__ must never raise, so we can't use Handle_enter_rk_use()
+        /* __len__ must never raise, so we can't use Handle_rk_use_begin()
          * (which sets an exception on failure) -- fall back to returning 0,
          * , if the Handle is closed/closing. */
         if (atomic_int_get(&self->closing) || !self->rk)

--- a/src/confluent_kafka/src/confluent_kafka.c
+++ b/src/confluent_kafka/src/confluent_kafka.c
@@ -31,6 +31,8 @@
 
 #ifdef _WIN32
 #include <windows.h>
+#else
+#include <unistd.h>
 #endif
 
 /**
@@ -3315,47 +3317,6 @@ int CallState_end(Handle *h, CallState *cs) {
         return 1;
 }
 
-
-/**
- * @brief Mark self->rk as in-use by the calling thread, so that close()
- *        (running concurrently on another thread) will wait for us before
- *        destroying it. Must be called before CallState_begin().
- *
- * @returns 1 if self->rk is safe to use (active_calls has been
- *          incremented; caller must call Handle_exit_rk_use() on every
- *          return path), or 0 with ERR_MSG_PRODUCER_CLOSED set if the
- *          Handle is closed/closing (nothing to undo).
- */
-int Handle_enter_rk_use(Handle *h) {
-        unsigned long self_tid = PyThread_get_thread_ident();
-
-        if ((atomic_int_get(&h->closing) &&
-             atomic_ulong_get(&h->closing_thread) != self_tid) ||
-            !h->rk) {
-                PyErr_SetString(PyExc_RuntimeError, ERR_MSG_PRODUCER_CLOSED);
-                return 0;
-        }
-        atomic_int_inc(&h->active_calls);
-        /* close() may have started between our check above and the
-         * increment; re-check now that we're counted. */
-        if ((atomic_int_get(&h->closing) &&
-             atomic_ulong_get(&h->closing_thread) != self_tid) ||
-            !h->rk) {
-                atomic_int_dec(&h->active_calls);
-                PyErr_SetString(PyExc_RuntimeError, ERR_MSG_PRODUCER_CLOSED);
-                return 0;
-        }
-        return 1;
-}
-
-/**
- * @brief Counterpart to Handle_enter_rk_use(): call on every return path
- *        after a successful Handle_enter_rk_use().
- */
-void Handle_exit_rk_use(Handle *h) {
-        atomic_int_dec(&h->active_calls);
-}
-
 /**
  * @brief Get the current thread's CallState and re-locks the GIL.
  */
@@ -3386,6 +3347,202 @@ void CallState_resume(CallState *cs) {
  */
 void CallState_crash(CallState *cs) {
         cs->crashed++;
+}
+
+
+/**
+ * @brief Mark self->rk as in-use by the calling thread, so that close()
+ *        (running concurrently on another thread) will wait for us before
+ *        destroying it. Must be called before CallState_begin().
+ *
+ * @param err_msg exception text to raise if the Handle is closed/closing,
+ *        e.g. ERR_MSG_PRODUCER_CLOSED (Producer) or
+ *        ERR_MSG_ADMIN_CLIENT_CLOSED (Admin).
+ * @returns 1 if self->rk is safe to use (active_calls has been
+ *          incremented; caller must call Handle_rk_use_end() on every
+ *          return path), or 0 with a RuntimeError(err_msg) set if the
+ *          Handle is closed/closing (nothing to undo).
+ */
+int Handle_rk_use_begin(Handle *h, const char *err_msg) {
+        unsigned long self_tid = PyThread_get_thread_ident();
+
+        if ((atomic_int_get(&h->closing) &&
+             atomic_ulong_get(&h->closing_thread) != self_tid) ||
+            !h->rk) {
+                PyErr_SetString(PyExc_RuntimeError, err_msg);
+                return 0;
+        }
+        atomic_int_inc(&h->active_calls);
+        /* close() may have started between our check above and the
+         * increment; re-check now that we're counted. */
+        if ((atomic_int_get(&h->closing) &&
+             atomic_ulong_get(&h->closing_thread) != self_tid) ||
+            !h->rk) {
+                atomic_int_dec(&h->active_calls);
+                PyErr_SetString(PyExc_RuntimeError, err_msg);
+                return 0;
+        }
+        return 1;
+}
+
+/**
+ * @brief Counterpart to Handle_rk_use_begin(): call on every return path
+ *        after a successful Handle_rk_use_begin().
+ */
+void Handle_rk_use_end(Handle *h) {
+        atomic_int_dec(&h->active_calls);
+}
+
+/**
+ * @brief Whether this Handle guards self->rk with the active_calls/closing
+ *        gate (Handle_rk_use_begin()/Handle_rk_use_end()).
+ *
+ * True for the Producer and Admin clients; false for the
+ * Consumer/ShareConsumer, which serialize access through their own
+ * reentrancy gate instead.
+ */
+static int Handle_is_rk_use_gated(Handle *h) {
+        return h->type == RD_KAFKA_PRODUCER || h->type == PY_RD_KAFKA_ADMIN;
+}
+
+/**
+ * @brief Release the GIL, sleep for `duration_ms`, then re-acquire it -- one
+ *        interruptible wait tick.
+ *
+ * @param duration_ms sleep duration in milliseconds
+ * @returns 1 if the tick completed normally, or 0 if a Python signal was
+ *          raised or a callback crashed while the GIL was released (the
+ *          caller should stop waiting and propagate the error).
+ */
+int Handle_sleep(Handle *h, int duration_ms) {
+        CallState cs;
+
+        CallState_begin(h, &cs);
+#ifdef _WIN32
+        Sleep((DWORD)duration_ms);
+#else
+        usleep((useconds_t)duration_ms * 1000);
+#endif
+        return CallState_end(h, &cs);
+}
+
+/**
+ * @brief Serializing gate for the Consumer: only one caller may be inside
+ *        gated Consumer C code at a time. For the sync Consumer the identity
+ *        is always the calling thread's own ID. For AIOConsumer this is a
+ *        temporary ID generated when the method is called.
+ *
+ *        If the gate is unowned, the identity becomes the owner. If identity
+ *        already matches the current owner, this is a legitimate re-entrant
+ *        call (gate_depth is incremented). Any other identity waits for the
+ *        gate to free up, retrying at a fixed interval.
+ *
+ *        Operates on the h->u.Consumer.* fields, so it must only be called
+ *        on Consumer handles (never Producer/Admin, which use the rk-use
+ *        gate, nor ShareConsumer, which uses a different union member).
+ *
+ * @returns 1 once the gate is held, or 0 with a Python exception set if a
+ *          signal (e.g. KeyboardInterrupt) arrived while waiting.
+ */
+int Handle_serialize_enter(Handle *h) {
+        unsigned long identity = 0;
+        PyObject *value        = NULL;
+
+        if (PyContextVar_Get(Consumer_reentry_identity_var, NULL, &value) ==
+            -1)
+                return 0;
+
+        if (value && PyLong_Check(value))
+                identity = PyLong_AsUnsignedLong(value);
+        Py_XDECREF(value);
+
+        /* 0 is never a legitimate identity (neither a real thread ID nor a
+         * generated AIOConsumer identity), so treat it the same as "not set".
+         */
+        if (identity == 0)
+                identity = (unsigned long)PyThread_get_thread_ident();
+
+        while (1) {
+                unsigned long owner =
+                    atomic_ulong_get(&h->u.Consumer.gate_owner);
+
+                if (owner == identity) {
+                        /* Re-entrant call presenting the same identity that
+                         * already owns the gate.
+                         */
+                        atomic_int_inc(&h->u.Consumer.gate_depth);
+                        return 1;
+                }
+
+                if (owner == 0 &&
+                    atomic_ulong_cas(&h->u.Consumer.gate_owner, 0,
+                                     identity)) {
+                        /* Gate looked unowned and we won the race to take
+                         * it. */
+                        atomic_int_set(&h->u.Consumer.gate_depth, 1);
+                        return 1;
+                }
+
+                /* Someone else holds the gate: wait 1ms and retry. */
+                if (!Handle_sleep(h, 1))
+                        return 0; /* signal received, e.g. KeyboardInterrupt */
+        }
+}
+
+/**
+ * @brief Counterpart to Handle_serialize_enter(): call once per successful
+ *        Handle_serialize_enter(), on every return path.
+ */
+void Handle_serialize_exit(Handle *h) {
+        int depth = atomic_int_dec(&h->u.Consumer.gate_depth);
+        assert(depth >= 0);
+
+        if (depth == 0)
+                atomic_ulong_set(&h->u.Consumer.gate_owner, 0);
+}
+
+/**
+ * @brief Entry guard for the APIs common to all client types
+ *        (list_topics(), list_groups(), set_sasl_credentials()).
+ *
+ * Dispatches to the right protection based on the client type:
+ *  - Producer/Admin (Handle_is_rk_use_gated()): the rk-use gate, which lets
+ *    parallel calls proceed while blocking a concurrent close()/__exit__().
+ *  - Consumer: the serializing gate, so these APIs obey the Consumer's
+ *    one-caller-at-a-time contract just like poll()/consume().
+ *
+ * self->rk is validated on both paths; a closed handle raises
+ * ERR_MSG_HANDLE_CLOSED (the generic message these shared APIs use).
+ *
+ * @returns 1 if it is safe to use self->rk (caller must call
+ *          Handle_common_exit() on every return path), or 0 with a Python
+ *          exception set (closed handle, or a signal while waiting).
+ */
+int Handle_common_enter(Handle *h) {
+        if (Handle_is_rk_use_gated(h))
+                return Handle_rk_use_begin(h, ERR_MSG_HANDLE_CLOSED);
+
+        /* Consumer: serialize via the Consumer gate, then verify rk (the
+         * gate itself does not NULL-check it). */
+        if (!Handle_serialize_enter(h))
+                return 0; /* signal while waiting; exception already set */
+        if (!h->rk) {
+                Handle_serialize_exit(h);
+                PyErr_SetString(PyExc_RuntimeError, ERR_MSG_HANDLE_CLOSED);
+                return 0;
+        }
+        return 1;
+}
+
+/**
+ * @brief Counterpart to Handle_common_enter(): call on every return path
+ *        after a successful Handle_common_enter().
+ */
+void Handle_common_exit(Handle *h) {
+        if (Handle_is_rk_use_gated(h))
+                Handle_rk_use_end(h);
+        else
+                Handle_serialize_exit(h);
 }
 
 
@@ -3663,6 +3820,7 @@ PyObject *set_sasl_credentials(Handle *self, PyObject *args, PyObject *kwargs) {
         const char *username = NULL;
         const char *password = NULL;
         rd_kafka_error_t *error;
+        PyObject *result = NULL;
         CallState cs;
         static char *kws[] = {"username", "password", NULL};
 
@@ -3671,21 +3829,29 @@ PyObject *set_sasl_credentials(Handle *self, PyObject *args, PyObject *kwargs) {
                 return NULL;
         }
 
+        if (!Handle_common_enter(self))
+                return NULL;
+
         CallState_begin(self, &cs);
         error = rd_kafka_sasl_set_credentials(self->rk, username, password);
 
         if (!CallState_end(self, &cs)) {
                 if (error) /* Ignore error in favour of callstate exception */
                         rd_kafka_error_destroy(error);
-                return NULL;
+                goto done; /* result stays NULL */
         }
 
         if (error) {
                 cfl_PyErr_from_error_destroy(error);
-                return NULL;
+                goto done; /* result stays NULL */
         }
 
-        Py_RETURN_NONE;
+        result = Py_None;
+        Py_INCREF(result);
+
+done:
+        Handle_common_exit(self);
+        return result;
 }
 
 
@@ -4043,7 +4209,7 @@ static PyObject *_init_cimpl(void) {
                            ConcurrentModificationException);
 
         /* ContextVar carrying the identity AIOConsumer presents to the
-         * Consumer gate for the current call -- see Handle_gate_enter()
+         * Consumer gate for the current call -- see Handle_serialize_enter()
          * in Consumer.c and confluent_kafka.aio._common. */
         PyObject *zero = PyLong_FromLong(0);
         if (!zero)

--- a/src/confluent_kafka/src/confluent_kafka.h
+++ b/src/confluent_kafka/src/confluent_kafka.h
@@ -328,7 +328,7 @@ typedef struct {
 
         /* Protects self->rk in Producer and Admin clients from being freed by
          * close() while another method is still using it.
-         * See Handle_enter_rk_use()/Handle_exit_rk_use() in confluent_kafka.c.
+         * See Handle_rk_use_begin()/Handle_rk_use_end() in confluent_kafka.c.
          */
         atomic_int_t active_calls;
         atomic_int_t closing;
@@ -368,7 +368,7 @@ typedef struct {
                         /* The following variables ensure only one caller
                          * is inside gated Consumer C code at a time; any
                          * other caller waits its turn (see
-                         * Handle_gate_enter() in Consumer.c).
+                         * Handle_serialize_enter() in Consumer.c).
                          *
                          * gate_owner identifies the current caller and is
                          * either a thread ID (PyThread_get_thread_ident(),
@@ -457,17 +457,6 @@ void CallState_begin(Handle *h, CallState *cs);
 int CallState_end(Handle *h, CallState *cs);
 
 /**
- * @brief Mark self->rk as in-use by the calling thread.
- * @returns 1 if safe to use (caller must call Handle_exit_rk_use() on every
- *          return path), 0 with ERR_MSG_PRODUCER_CLOSED set otherwise.
- */
-int Handle_enter_rk_use(Handle *h);
-/**
- * @brief Counterpart to Handle_enter_rk_use().
- */
-void Handle_exit_rk_use(Handle *h);
-
-/**
  * @brief Get the current thread's CallState and re-locks the GIL.
  */
 CallState *CallState_get(Handle *h);
@@ -480,6 +469,61 @@ void CallState_resume(CallState *cs);
  * @brief Indicate that call crashed.
  */
 void CallState_crash(CallState *cs);
+
+/**
+ * @brief Mark self->rk as in-use by the calling thread, blocking a
+ *        concurrent close()/__exit__() from freeing it until the matching
+ *        Handle_rk_use_end(). Used by the gated clients (Producer, Admin).
+ * @param err_msg exception text to raise if the Handle is closed/closing,
+ *        e.g. ERR_MSG_PRODUCER_CLOSED or ERR_MSG_ADMIN_CLIENT_CLOSED.
+ * @returns 1 if safe to use (caller must call Handle_rk_use_end() on every
+ *          return path), 0 with a RuntimeError(err_msg) set otherwise.
+ */
+int Handle_rk_use_begin(Handle *h, const char *err_msg);
+/**
+ * @brief Counterpart to Handle_rk_use_begin().
+ */
+void Handle_rk_use_end(Handle *h);
+
+/**
+ * @brief Release the GIL, sleep for `duration_ms`, then re-acquire it -- one
+ *        interruptible wait tick, used by close()/__exit__() teardown drain
+ *        loops and by the Consumer gate while it waits its turn.
+ * @param duration_ms sleep duration in milliseconds; intended for sub-second
+ *        waits.
+ * @returns 1 if the tick completed normally, 0 if a Python signal was
+ *          raised or a callback crashed while the GIL was released (the
+ *          caller should stop waiting and propagate the error).
+ */
+int Handle_sleep(Handle *h, int duration_ms);
+
+/**
+ * @brief Consumer serializing gate: only one caller at a time inside gated
+ *        Consumer C code (re-entrant calls of the same identity nest via
+ *        gate_depth).
+ * @returns 1 once held (caller must call Handle_serialize_exit()), or 0 with a
+ *          Python exception set if a signal arrived while waiting.
+ */
+int Handle_serialize_enter(Handle *h);
+/**
+ * @brief Counterpart to Handle_serialize_enter().
+ */
+void Handle_serialize_exit(Handle *h);
+
+/**
+ * @brief Entry guard for the client-agnostic APIs (list_topics(),
+ *        list_groups(), set_sasl_credentials()): takes the rk-use gate for
+ *        Producer/Admin (parallel calls) or the Consumer serializing gate
+ *        for the Consumer. Validates self->rk on both paths, raising
+ *        ERR_MSG_HANDLE_CLOSED if the handle is closed.
+ * @returns 1 if safe to use self->rk (caller must call Handle_common_exit()
+ *          on every return path), or 0 with a Python exception set.
+ */
+int Handle_common_enter(Handle *h);
+/**
+ * @brief Counterpart to Handle_common_enter().
+ */
+void Handle_common_exit(Handle *h);
 
 
 /**

--- a/tests/concurrency/test_admin_close_race.py
+++ b/tests/concurrency/test_admin_close_race.py
@@ -1,0 +1,242 @@
+#!/usr/bin/env python
+#
+# Copyright 2026 Confluent Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import threading
+import time
+
+from confluent_kafka import KafkaException
+from confluent_kafka.admin import AdminClient, ConfigResource, NewTopic, ResourceType
+from tests.concurrency._subprocess_isolation import subprocess_isolated
+
+###############################################################################
+# Tests for races between AdminClient teardown and
+# concurrent calls to other methods on the same AdminClient instance, and
+# between context-manager exit and itself. AdminClient currently has none of
+# the active_calls/closing protection Producer.close() has, so these races
+# are expected to crash or misbehave until that protection is added.
+###############################################################################
+
+_ADMIN_CONF = {'bootstrap.servers': 'localhost:9092', 'socket.timeout.ms': 10}
+ITERATIONS = 10
+NUM_WORKERS = 7
+
+
+def _race_exit_against(workers, num_workers=NUM_WORKERS):
+    """
+    Run worker(s) on `num_workers` other threads while exiting the `with`
+    block from the main thread, repeated `ITERATIONS` times against a fresh
+    AdminClient each time.
+
+    `workers` may be a single `worker(admin, stop_event)` callable, applied
+    to every thread, or a list of `num_workers` different callables (one per
+    thread) to race several different methods concurrently instead of
+    hammering a single one.
+    """
+    worker_list = workers if isinstance(workers, list) else [workers] * num_workers
+    assert len(worker_list) == num_workers
+    errors = []
+
+    for i in range(ITERATIONS):
+        stop_event = threading.Event()
+        start_barrier = threading.Barrier(num_workers + 1)
+
+        with AdminClient(_ADMIN_CONF) as admin:
+
+            def run_worker(worker):
+                try:
+                    start_barrier.wait()
+                    worker(admin, stop_event)
+                except Exception as e:  # noqa: BLE001 - want to see any exception, not just crashes
+                    errors.append((i, e))
+
+            threads = [threading.Thread(target=run_worker, args=(w,)) for w in worker_list]
+            for t in threads:
+                t.start()
+
+            start_barrier.wait()
+
+        stop_event.set()
+        for t in threads:
+            t.join(timeout=10)
+        assert all(
+            not t.is_alive() for t in threads
+        ), f"iteration {i}: a worker thread did not finish after exiting the with block"
+
+    assert not errors, f"unexpected exceptions from worker threads: {errors}"
+
+
+@subprocess_isolated
+def test_exit_races_create_topics():
+    """Exiting the `with` block concurrent with create_topics() on another thread."""
+
+    def worker(admin, stop_event):
+        while not stop_event.is_set():
+            try:
+                futmap = admin.create_topics([NewTopic('mytopic', num_partitions=1, replication_factor=1)])
+                for f in futmap.values():
+                    try:
+                        f.result(timeout=1)
+                    except Exception:  # noqa: BLE001 - broker-less errors expected, not the bug we're after
+                        pass
+            except RuntimeError as e:
+                assert 'closed' in str(e).lower(), f"unexpected RuntimeError racing teardown: {e}"
+                break
+
+    _race_exit_against(worker)
+
+
+@subprocess_isolated
+def test_exit_races_list_topics():
+    """Exiting the `with` block concurrent with list_topics() on another thread."""
+
+    def worker(admin, stop_event):
+        while not stop_event.is_set():
+            try:
+                admin.list_topics(timeout=0.05)
+            except RuntimeError as e:
+                assert 'closed' in str(e).lower(), f"unexpected RuntimeError racing teardown: {e}"
+                break
+            except Exception:  # noqa: BLE001 - librdkafka timeout/transport errors expected without a broker
+                pass
+
+    _race_exit_against(worker)
+
+
+@subprocess_isolated
+def test_exit_races_set_sasl_credentials():
+    """Exiting the `with` block concurrent with set_sasl_credentials() on another thread."""
+
+    def worker(admin, stop_event):
+        while not stop_event.is_set():
+            try:
+                admin.set_sasl_credentials('user', 'password')
+            except RuntimeError as e:
+                assert 'closed' in str(e).lower(), f"unexpected RuntimeError racing teardown: {e}"
+                break
+            except Exception:  # noqa: BLE001 - librdkafka errors possible without a SASL-configured broker
+                pass
+
+    _race_exit_against(worker)
+
+
+@subprocess_isolated
+def test_exit_races_exit():
+    """Multiple threads exiting the `with` block on the same AdminClient at once."""
+
+    def worker(admin, stop_event):
+        with admin:
+            pass
+
+    _race_exit_against(worker)
+
+
+@subprocess_isolated
+def test_exit_races_multiple_methods():
+    """Exiting the `with` block concurrent with several different Admin
+    methods at once (rather than many threads hammering the same one) --
+    closer to realistic usage, and exercises more of Admin.c's call sites
+    in a single run."""
+
+    def make_worker(call):
+        def worker(admin, stop_event):
+            while not stop_event.is_set():
+                try:
+                    call(admin)
+                except RuntimeError as e:
+                    assert 'closed' in str(e).lower(), f"unexpected RuntimeError racing teardown: {e}"
+                    break
+                except Exception:  # noqa: BLE001 - broker-less/timeout errors expected, not the bug we're after
+                    pass
+
+        return worker
+
+    def call_create_topics(admin):
+        futmap = admin.create_topics([NewTopic('mytopic', num_partitions=1, replication_factor=1)])
+        for f in futmap.values():
+            try:
+                f.result(timeout=1)
+            except Exception:  # noqa: BLE001 - broker-less errors expected, not the bug we're after
+                pass
+
+    def call_list_topics(admin):
+        admin.list_topics(timeout=0.05)
+
+    def call_describe_configs(admin):
+        resource = ConfigResource(ResourceType.TOPIC, 'mytopic')
+        futmap = admin.describe_configs([resource])
+        for f in futmap.values():
+            try:
+                f.result(timeout=1)
+            except Exception:  # noqa: BLE001 - broker-less errors expected, not the bug we're after
+                pass
+
+    def call_delete_topics(admin):
+        futmap = admin.delete_topics(['mytopic'])
+        for f in futmap.values():
+            try:
+                f.result(timeout=1)
+            except Exception:  # noqa: BLE001 - broker-less errors expected, not the bug we're after
+                pass
+
+    workers = [
+        make_worker(call_create_topics),
+        make_worker(call_list_topics),
+        make_worker(call_describe_configs),
+        make_worker(call_delete_topics),
+    ]
+
+    _race_exit_against(workers, num_workers=len(workers))
+
+
+def test_exit_waits_for_in_flight_call():
+    """__exit__() blocks until an in-flight list_topics() call finishes."""
+    admin = AdminClient(_ADMIN_CONF)
+    list_started = threading.Event()
+    list_finished_at = None
+
+    def run_list_topics():
+        nonlocal list_finished_at
+        list_started.set()
+        try:
+            admin.list_topics(timeout=5)
+        except KafkaException:
+            pass  # unreachable broker -> transport error at the end, expected
+        list_finished_at = time.monotonic()
+
+    t = threading.Thread(target=run_list_topics)
+    t.start()
+    list_started.wait()
+    time.sleep(1)  # Make sure list_topics() is genuinely in-flight (holding the gate).
+
+    exit_start = time.monotonic()
+    admin.__exit__(None, None, None)
+    exit_end = time.monotonic()
+
+    t.join(timeout=15)
+    assert not t.is_alive(), "list_topics() thread did not finish after __exit__()"
+    assert list_finished_at is not None, "list_topics() never finished"
+
+    # __exit__() must not have returned before the in-flight list_topics()
+    # released the gate.
+    assert exit_end >= list_finished_at, (
+        f"__exit__() returned at {exit_end:.2f} before in-flight list_topics() "
+        f"finished at {list_finished_at:.2f} -- it did not wait"
+    )
+    exit_duration = exit_end - exit_start
+    assert exit_duration >= 3.0, (
+        f"__exit__() returned in {exit_duration:.2f}s -- too fast to have waited "
+        f"for the in-flight list_topics() call"
+    )

--- a/tests/concurrency/test_producer_close_race.py
+++ b/tests/concurrency/test_producer_close_race.py
@@ -377,6 +377,51 @@ def test_close_completes_quickly_with_indefinite_flush_in_progress():
     )
 
 
+def test_close_waits_for_in_flight_list_topics():
+    """list_topics() goes through the rk-use gate (active_calls) and a close()
+    that starts while list_topics() is in flight must wait for it to finish before
+    tearing down self->rk, rather than racing it. Against the unreachable
+    localhost:9092, list_topics(timeout=5) blocks its full timeout, giving
+    close() a real in-flight call to wait on."""
+    producer = Producer(_PRODUCER_CONF)
+    list_started = threading.Event()
+    list_finished_at = None
+
+    def run_list_topics():
+        nonlocal list_finished_at
+        list_started.set()
+        try:
+            producer.list_topics(timeout=5)
+        except KafkaException:
+            pass  # unreachable broker -> transport error at the end, expected
+        list_finished_at = time.monotonic()
+
+    t = threading.Thread(target=run_list_topics)
+    t.start()
+    list_started.wait()
+    time.sleep(1)  # Make sure list_topics() is genuinely in-flight (holding the gate).
+
+    close_start = time.monotonic()
+    result = producer.close()
+    close_end = time.monotonic()
+
+    t.join(timeout=15)
+    assert not t.is_alive(), "list_topics() thread did not finish after close()"
+    assert list_finished_at is not None, "list_topics() never finished"
+    assert result is True, f"close() must return True, got {result!r}"
+
+    close_duration = close_end - close_start
+    # close() must not have returned before the in-flight list_topics()
+    # released the gate ...
+    assert close_end >= list_finished_at, (
+        f"close() returned at {close_end:.2f} before in-flight list_topics() "
+        f"finished at {list_finished_at:.2f} -- it did not wait"
+    )
+    assert close_duration >= 3.0, (
+        f"close() returned in {close_duration:.2f}s -- too fast to have waited " f"for the in-flight list_topics() call"
+    )
+
+
 def test_close_is_idempotent():
     """Calling close() twice, with no concurrency at all, must return True
     both times."""

--- a/tests/integration/admin/test_concurrency.py
+++ b/tests/integration/admin/test_concurrency.py
@@ -1,0 +1,349 @@
+#!/usr/bin/env python
+#
+# Copyright 2026 Confluent Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import threading
+import time
+from uuid import uuid1
+
+import pytest
+
+from confluent_kafka import KafkaError, KafkaException
+from confluent_kafka.admin import AdminClient, ConfigResource, NewTopic, ResourceType
+
+
+def prefixed_error_cb(prefix):
+    def error_cb(err):
+        print("[{}]: {}".format(prefix, err))
+
+    return error_cb
+
+
+def _new_admin(kafka_cluster, conf=None):
+    admin_conf = kafka_cluster.client_conf(conf)
+    return AdminClient(admin_conf)
+
+
+def _assert_result_or_clean_destroy(future, on_success=None, timeout=30):
+    """Wait for `future` and, if it resolved successfully, call
+    `on_success()` to verify the result further (e.g. that a created topic
+    is really visible). If it resolved with a clean KafkaError._DESTROY,
+    `on_success` is skipped -- there's nothing to verify.
+
+    rd_kafka_destroy() does not wait for in-flight background operations to
+    complete against the broker -- it cancels them with a clean
+    KafkaError._DESTROY rather than crashing, hanging, or silently dropping
+    them. Both outcomes prove the same thing (Admin_background_event_cb()
+    doesn't depend on self->rk surviving), so callers racing __exit__()
+    immediately after issuing a call should accept either.
+    """
+    try:
+        future.result(timeout=timeout)
+    except Exception as e:  # noqa: BLE001 - only _DESTROY is an accepted non-success outcome
+        if getattr(e, 'args', None) and getattr(e.args[0], 'code', lambda: None)() == KafkaError._DESTROY:
+            return
+        raise
+    if on_success:
+        on_success()
+
+
+def test_exit_before_create_topics_delivers_result(kafka_cluster):
+    """The `with` block exits right after create_topics() returns, before
+    the 10-partition topics' background events can realistically have been
+    delivered yet. __exit__() must cancel every one of them with a clean
+    KafkaError._DESTROY rather than crashing or hanging."""
+    admin = _new_admin(kafka_cluster, {'error_cb': prefixed_error_cb('test_exit_before_create_topics_delivers_result')})
+    topics = ["test_exit_races_create_topics-{}".format(uuid1()) for _ in range(5)]
+
+    with admin:
+        futmap = admin.create_topics([NewTopic(t, num_partitions=10, replication_factor=1) for t in topics])
+
+    for topic in topics:
+        with pytest.raises(KafkaException) as e:
+            futmap[topic].result(timeout=10)
+        assert e.value.args[0].code() == KafkaError._DESTROY
+
+
+def test_admin_shared_across_threads_multiple_apis(kafka_cluster):
+    """One AdminClient instance, several threads each calling a different
+    API concurrently, in a loop. All calls must succeed
+    with no crash, and every future obtained along the way must resolve
+    cleanly."""
+    iterations = 10
+    expected_retention_ms = '123456789'
+    topic = kafka_cluster.create_topic_and_wait_propogation(
+        "test_admin_shared_across_threads", conf={'config': {'retention.ms': expected_retention_ms}}
+    )
+
+    group_id = "test_admin_shared_across_threads_group-{}".format(uuid1())
+    c = kafka_cluster.consumer({'group.id': group_id, 'session.timeout.ms': 6000})
+    c.subscribe([topic])
+    c.poll(10)
+    c.close()
+
+    errors = []
+    barrier = threading.Barrier(5)
+
+    admin = _new_admin(kafka_cluster, {'error_cb': prefixed_error_cb('test_admin_shared_across_threads_multiple_apis')})
+
+    def call_create_topics():
+        try:
+            futures = []
+            created_topics = []
+            for _ in range(iterations):
+                barrier.wait()
+                new_topic = "test_admin_shared_across_threads_new-{}".format(uuid1())
+                futmap = admin.create_topics([NewTopic(new_topic, num_partitions=1, replication_factor=1)])
+                futures.append(futmap[new_topic])
+                created_topics.append(new_topic)
+            for future in futures:
+                future.result(timeout=30)
+            time.sleep(5)  # wait for metadata propagation
+            metadata = admin.list_topics(timeout=10)
+            for created_topic in created_topics:
+                assert created_topic in metadata.topics, "topic {} not found in list_topics()".format(created_topic)
+        except Exception as e:  # noqa: BLE001 - want to see any exception, not just crashes
+            errors.append(("create_topics", e))
+
+    def call_list_topics():
+        try:
+            for _ in range(iterations):
+                barrier.wait()
+                metadata = admin.list_topics(timeout=10)
+                assert topic in metadata.topics
+        except Exception as e:  # noqa: BLE001
+            errors.append(("list_topics", e))
+
+    def call_describe_configs():
+        try:
+            futures = []
+            for _ in range(iterations):
+                barrier.wait()
+                resource = ConfigResource(ResourceType.TOPIC, topic)
+                futmap = admin.describe_configs([resource])
+                futures.append(futmap[resource])
+            for future in futures:
+                config = future.result(timeout=30)
+                assert config['retention.ms'].value == expected_retention_ms, "expected retention.ms={}, got {}".format(
+                    expected_retention_ms, config['retention.ms'].value
+                )
+        except Exception as e:  # noqa: BLE001
+            errors.append(("describe_configs", e))
+
+    def call_list_consumer_groups():
+        try:
+            futures = []
+            for _ in range(iterations):
+                barrier.wait()
+                futures.append(admin.list_consumer_groups(request_timeout=10))
+            for future in futures:
+                result = future.result(timeout=30)
+                group_ids = [group.group_id for group in result.valid]
+                assert group_id in group_ids, "Consumer group {} not found".format(group_id)
+        except Exception as e:  # noqa: BLE001
+            errors.append(("list_consumer_groups", e))
+
+    def call_set_sasl_credentials():
+        try:
+            for _ in range(iterations):
+                barrier.wait()
+                result = admin.set_sasl_credentials('username', 'password')
+                assert result is None, f"set_sasl_credentials() unexpectedly returned {result!r}"
+        except Exception as e:  # noqa: BLE001
+            errors.append(("set_sasl_credentials", e))
+
+    threads = [
+        threading.Thread(target=call_create_topics),
+        threading.Thread(target=call_list_topics),
+        threading.Thread(target=call_describe_configs),
+        threading.Thread(target=call_list_consumer_groups),
+        threading.Thread(target=call_set_sasl_credentials),
+    ]
+
+    with admin:
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=60)
+
+    assert all(not t.is_alive() for t in threads), "an Admin API call thread did not finish"
+    assert not errors, f"unexpected exceptions from concurrent Admin API calls: {errors}"
+
+
+def test_exit_races_exit_with_real_in_flight_work(kafka_cluster):
+    """One thread calling poll() with a long timeout (genuinely in-flight
+    work), several other threads all calling __exit__() concurrently on
+    the same AdminClient. Whichever thread wins the CAS tears down and the
+    rest just wait for it, but every single __exit__() call -- winner or
+    loser -- must not return until poll() has actually finished."""
+    admin = _new_admin(kafka_cluster, {'error_cb': prefixed_error_cb('test_exit_races_exit_with_real_in_flight_work')})
+
+    poll_started = threading.Event()
+    poll_duration = 10
+    poll_finished_at = None
+
+    def run_poll():
+        nonlocal poll_finished_at
+        poll_started.set()
+        admin.poll(poll_duration)
+        poll_finished_at = time.monotonic()
+
+    poll_thread = threading.Thread(target=run_poll)
+    poll_thread.start()
+    poll_started.wait(timeout=5)
+    time.sleep(2)
+
+    errors = []
+    num_exit_workers = 5
+    barrier = threading.Barrier(num_exit_workers)
+    exit_started_at = [None] * num_exit_workers
+    exit_finished_at = [None] * num_exit_workers
+
+    def call_exit(index):
+        try:
+            barrier.wait()
+            exit_started_at[index] = time.monotonic()
+            admin.__exit__(None, None, None)
+            exit_finished_at[index] = time.monotonic()
+        except Exception as e:  # noqa: BLE001 - want to see any exception, not just crashes
+            errors.append(e)
+
+    exit_threads = [threading.Thread(target=call_exit, args=(i,)) for i in range(num_exit_workers)]
+    for t in exit_threads:
+        t.start()
+    for t in exit_threads:
+        t.join(timeout=30)
+    poll_thread.join(timeout=30)
+
+    assert not poll_thread.is_alive(), "poll() thread did not finish"
+    assert all(not t.is_alive() for t in exit_threads), "an __exit__() thread did not finish"
+    assert not errors, f"unexpected exceptions from concurrent __exit__() calls: {errors}"
+    assert poll_finished_at is not None, "poll() never finished"
+
+    for i, started_at in enumerate(exit_started_at):
+        assert started_at is not None, "__exit__() thread {} did not record a start time".format(i)
+        assert poll_finished_at > started_at, (
+            "poll() finished at {:.2f} before __exit__() thread {} even started at {:.2f} -- "
+            "the race wasn't exercised".format(poll_finished_at, i, started_at)
+        )
+
+    for i, finished_at in enumerate(exit_finished_at):
+        assert finished_at is not None, "__exit__() thread {} did not record a finish time".format(i)
+        assert (
+            finished_at >= poll_finished_at
+        ), "__exit__() thread {} returned at {:.2f} before poll() finished at {:.2f}".format(
+            i, finished_at, poll_finished_at
+        )
+
+
+def _submit_mixed_ops(admin, known_topic, expected_retention, missing_topic):
+    """Submit a mix of ops with deterministic outcomes and return a list of
+    zero-arg verifiers.
+
+    Each verifier asserts that THIS op's future received exactly the outcome
+    the op should get -- a success future must not raise, a failure future must
+    raise its specific error code, and a describe success must carry the known
+    topic's own config.
+    """
+    checks = []
+
+    # success: validate a brand-new topic. validate_only=True keeps the success
+    # future path exercised without actually creating (no cluster litter).
+    ok_name = "test_admin_mixed_ok-{}".format(uuid1())
+    f = admin.create_topics([NewTopic(ok_name, num_partitions=1, replication_factor=1)], validate_only=True)[ok_name]
+    checks.append(lambda f=f: f.result(timeout=30))  # must not raise
+
+    # failure: create an already-existing topic -> TOPIC_ALREADY_EXISTS
+    f = admin.create_topics([NewTopic(known_topic, num_partitions=1, replication_factor=1)])[known_topic]
+
+    def _create_exists(f=f):
+        with pytest.raises(KafkaException) as ei:
+            f.result(timeout=30)
+        assert (
+            ei.value.args[0].code() == KafkaError.TOPIC_ALREADY_EXISTS
+        ), "create(existing) got wrong outcome: {}".format(ei.value)
+
+    checks.append(_create_exists)
+
+    # success: describe the known topic -> result carries OUR retention.ms value
+    res = ConfigResource(ResourceType.TOPIC, known_topic)
+    f = admin.describe_configs([res])[res]
+
+    def _describe_known(f=f):
+        cfg = f.result(timeout=30)
+        assert (
+            cfg['retention.ms'].value == expected_retention
+        ), "describe_configs returned the wrong topic's config: retention.ms={}".format(cfg['retention.ms'].value)
+
+    checks.append(_describe_known)
+
+    # failure: delete a nonexistent topic -> UNKNOWN_TOPIC_OR_PART
+    f = admin.delete_topics([missing_topic])[missing_topic]
+
+    def _delete_missing(f=f):
+        with pytest.raises(KafkaException) as ei:
+            f.result(timeout=30)
+        assert (
+            ei.value.args[0].code() == KafkaError.UNKNOWN_TOPIC_OR_PART
+        ), "delete(missing) got wrong outcome: {}".format(ei.value)
+
+    checks.append(_delete_missing)
+
+    return checks
+
+
+def test_mixed_success_failure_outcomes_are_not_cross_delivered(kafka_cluster):
+    """Many threads submit an interleaved mix of succeeding and failing ops on
+    one shared AdminClient. Every future must receive its own correct outcome
+    -- success futures never raise, failure futures raise their specific code,
+    and describe returns the known topic's own config -- proving results are
+    not cross-delivered between concurrent operations under free-threading."""
+    expected_retention = '123456789'
+    known_topic = kafka_cluster.create_topic_and_wait_propogation(
+        "test_admin_mixed_outcomes", conf={'config': {'retention.ms': expected_retention}}
+    )
+    missing_topic = "test_admin_mixed_missing-{}".format(uuid1())
+
+    num_workers = 6
+    iterations = 10
+    barrier = threading.Barrier(num_workers)
+    errors = []
+
+    admin = _new_admin(kafka_cluster, {'error_cb': prefixed_error_cb('mixed_outcomes')})
+
+    def worker():
+        try:
+            checks = []
+            for _ in range(iterations):
+                # Align submissions across threads for the tightest interleaving.
+                # Submission returns a futmap synchronously and does not raise,
+                # so a worker can't leave the others stranded on the barrier.
+                barrier.wait()
+                checks += _submit_mixed_ops(admin, known_topic, expected_retention, missing_topic)
+            # Resolve/verify only after every op has been submitted.
+            for verify in checks:
+                verify()
+        except Exception as e:  # noqa: BLE001 - want any wrong/cross-delivered outcome, not just crashes
+            errors.append(e)
+
+    threads = [threading.Thread(target=worker) for _ in range(num_workers)]
+    with admin:
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=120)
+
+    assert all(not t.is_alive() for t in threads), "a worker thread did not finish"
+    assert not errors, "cross-delivered or incorrect outcomes: {}".format(errors)

--- a/tests/integration/consumer/test_aio_consumer_reentrancy.py
+++ b/tests/integration/consumer/test_aio_consumer_reentrancy.py
@@ -241,7 +241,12 @@ async def test_on_assign_calls_non_reentrancy_eligible_method(kafka_cluster):
 
     await consumer.subscribe([topic], on_assign=on_assign)
 
-    msg = await consumer.poll(10)
+    # Poll in a loop until msg arrives
+    msg = None
+    for _ in range(30):
+        msg = await consumer.poll(1)
+        if msg is not None:
+            break
 
     print(f"{called_by()}: pause_called={len(pause_called)}, position_results={position_results}")
     assert pause_called, "on_assign was never invoked"

--- a/tests/integration/consumer/test_consumer_concurrent_serialization.py
+++ b/tests/integration/consumer/test_consumer_concurrent_serialization.py
@@ -26,6 +26,7 @@ waits (GIL released) until the gate frees up, then proceeds -- unless it's
 the same thread re-entering, which is admitted immediately.
 """
 
+import random
 import threading
 import time
 from uuid import uuid1
@@ -429,5 +430,108 @@ def test_callback_makes_multiple_reentrant_calls(kafka_cluster):
     ], f"expected all 5 re-entrant calls to run in order, got: {calls_made}"
     assert msg is not None
     assert msg.value() == b'hello'
+
+    consumer.close()
+
+
+def test_list_topics_racing_close(kafka_cluster):
+    """consumer.list_topics() is a common API that routes through the dispatcher,
+    which for a Consumer takes the serialize gate. A worker hammers
+    list_topics() while the main thread closes the consumer at a randomized
+    moment; across many rounds every call must return metadata or, once the
+    consumer is closed, raise cleanly -- never crash or hang.
+
+    The worker does time.sleep(0) each iteration to yield the GIL; without it a
+    GIL-enabled run lets this tight loop re-grab the gate before the concurrent
+    close() can, starving close() (with the GIL off, close() races the free
+    window on another core and doesn't need the yield)."""
+    rounds = 20
+    errors = []
+
+    for r in range(rounds):
+        consumer = _new_consumer(kafka_cluster)
+        start = threading.Barrier(2)
+        stop = threading.Event()
+
+        def worker(consumer=consumer, start=start, stop=stop, r=r):
+            try:
+                start.wait()
+                while not stop.is_set():
+                    try:
+                        consumer.list_topics(timeout=1)
+                        time.sleep(0)  # yield the GIL so close() isn't starved
+                    except RuntimeError as e:
+                        assert "Handle has been closed" in str(e), f"round {r}: unexpected RuntimeError: {e!r}"
+                        break
+            except Exception as e:  # noqa: BLE001
+                errors.append((r, e))
+
+        t = threading.Thread(target=worker)
+        t.start()
+        start.wait()
+        time.sleep(random.uniform(0.0, 0.05))
+        consumer.close()
+        stop.set()
+        t.join(timeout=10)
+        assert not t.is_alive(), f"round {r}: worker thread hung after close()"
+
+    assert not errors, f"unexpected errors racing list_topics() vs close(): {errors}"
+
+
+def test_list_topics_serializes_with_poll(kafka_cluster):
+    """list_topics() takes the same serialize gate as poll(), so the two
+    colliding on one shared Consumer must serialize. poll() enters the gate
+    first and holds it for its full 10s, list_topics() arrives second and
+    must wait behind it. Both then succeed and the consumer stays usable."""
+    consumer, topic, _msg, _partitions = _subscribed_consumer(kafka_cluster, "test_list_topics_vs_poll", [b'hello'])
+
+    poll_error = None
+    list_error = None
+    list_result = None
+    list_elapsed = None
+
+    def do_poll():
+        nonlocal poll_error
+        try:
+            consumer.poll(10)
+        except Exception as e:  # noqa: BLE001
+            poll_error = e
+
+    def do_list_topics():
+        nonlocal list_error, list_result, list_elapsed
+        # Let poll() enter the gate first, so list_topics() must wait for it.
+        time.sleep(0.5)
+        t0 = time.time()
+        try:
+            list_result = consumer.list_topics(timeout=2)
+        except Exception as e:  # noqa: BLE001
+            list_error = e
+        list_elapsed = time.time() - t0
+
+    t_poll = threading.Thread(target=do_poll)
+    t_list = threading.Thread(target=do_list_topics)
+    t_poll.start()
+    t_list.start()
+    t_poll.join()
+    t_list.join()
+
+    print(f"poll_error={poll_error}, list_error={list_error}, list_elapsed={list_elapsed}")
+    assert poll_error is None, f"poll() unexpectedly failed: {poll_error!r}"
+    assert list_error is None, f"expected list_topics() to wait and then succeed, got: {list_error!r}"
+    assert list_result is not None and topic in list_result.topics, "list_topics() did not return the expected metadata"
+    # poll() holds the gate for ~10s; list_topics() (2s timeout) started right
+    # after and had to wait behind it, so its wall time must far exceed its own
+    # timeout -- proof the gate serialized them rather than letting them overlap.
+    assert list_elapsed >= 5.0, (
+        f"list_topics() returned in {list_elapsed:.2f}s -- too fast to have "
+        f"waited behind poll()'s gate hold; the two did not serialize"
+    )
+
+    # The consumer must remain usable afterward -- verify with a real poll().
+    kafka_cluster.seed_topic(topic, value_source=[b'world'])
+    msg2 = consumer.poll(5)
+    print(f"final poll after colliding list_topics()/poll(): {msg2.value() if msg2 else None}")
+    assert msg2 is not None
+    assert msg2.value() == b'world'
 
     consumer.close()

--- a/tests/integration/consumer/test_consumer_reentrancy.py
+++ b/tests/integration/consumer/test_consumer_reentrancy.py
@@ -417,3 +417,61 @@ def test_on_assign_calls_non_reentrancy_eligible_method(kafka_cluster):
     assert msg.value() == b'hello'
 
     consumer.close()
+
+
+def test_on_assign_calls_list_topics_from_callback(kafka_cluster):
+    """list_topics() is a common API that routes through the serialize gate.
+    Called from inside on_assign -- which already holds the gate for this same
+    thread identity -- it must be admitted as a re-entrant call (gate_depth
+    incremented), not deadlock."""
+    topic = kafka_cluster.create_topic_and_wait_propogation("test_on_assign_calls_list_topics")
+    kafka_cluster.seed_topic(topic, value_source=[b'hello'])
+
+    consumer = _new_consumer(kafka_cluster)
+
+    seen = {}
+
+    def on_assign(consumer, partitions):
+        consumer.assign(partitions)
+        md = consumer.list_topics(timeout=10)  # re-entrant common-API call
+        seen['topics'] = list(md.topics.keys())
+
+    consumer.subscribe([topic], on_assign=on_assign)
+
+    msg = consumer.poll(10)
+
+    print(f"seen_topics={len(seen.get('topics', []))}, msg={msg.value() if msg else None}")
+    assert 'topics' in seen, "on_assign / re-entrant list_topics() was never invoked"
+    assert topic in seen['topics'], "re-entrant list_topics() did not return the subscribed topic"
+    assert msg is not None
+    assert msg.value() == b'hello'
+
+    consumer.close()
+
+
+def test_on_assign_calls_set_sasl_credentials_from_callback(kafka_cluster):
+    """set_sasl_credentials() is a common API that routes through the serialize
+    gate. Called re-entrantly from inside on_assign it must nest via gate_depth
+    rather than deadlock; it returns None on success like a normal call."""
+    topic = kafka_cluster.create_topic_and_wait_propogation("test_on_assign_calls_set_sasl")
+    kafka_cluster.seed_topic(topic, value_source=[b'hello'])
+
+    consumer = _new_consumer(kafka_cluster)
+
+    called = []
+
+    def on_assign(consumer, partitions):
+        consumer.assign(partitions)
+        called.append(consumer.set_sasl_credentials('username', 'password'))  # re-entrant
+
+    consumer.subscribe([topic], on_assign=on_assign)
+
+    msg = consumer.poll(10)
+
+    print(f"called={called}, msg={msg.value() if msg else None}")
+    assert called, "on_assign / re-entrant set_sasl_credentials() was never invoked"
+    assert called[0] is None, f"set_sasl_credentials() should return None, got {called[0]!r}"
+    assert msg is not None
+    assert msg.value() == b'hello'
+
+    consumer.close()


### PR DESCRIPTION
This PR cherry picks commit d8584683f39a0d76baf872b4c19880faa4161a3e merged through PR #2317 in the preview branch

-------------------------------------------------------------------------------------

* Add a serializing Consumer reentrancy gate for free-threading support

Introduces gate_owner/gate_depth in Consumer.c so concurrent, cross-caller access to a single Consumer/AIOConsumer instance waits for the current caller to finish rather than being undefined behavior, since librdkafka's consumer is not thread-safe; legitimate re-entrant calls (e.g. a rebalance/commit callback calling back into the Consumer that triggered it) are still admitted immediately. AIOConsumer identity is tracked via a ContextVar since the owning logical caller can move across ThreadPoolExecutor worker threads. Includes unit and integration test coverage for both the sync Consumer and AIOConsumer.

* Trigger CLA check

* Add Integration test coverage for AIO Producer

* Add Tx related test cases + Add abort_tx call in Producer close

* Fix styling

* Serialize AIOConsumer calls that outlive their callback invocation instead of admitting them as re-entrant

* Serialize AIOConsumer calls that outlive their callback invocation instead of admitting them as re-entrant

* Trigger CLA check

* Trigger CLA check

* Add a serializing Consumer reentrancy gate for free-threading support

Introduces gate_owner/gate_depth in Consumer.c so concurrent, cross-caller access to a single Consumer/AIOConsumer instance waits for the current caller to finish rather than being undefined behavior, since librdkafka's consumer is not thread-safe; legitimate re-entrant calls (e.g. a rebalance/commit callback calling back into the Consumer that triggered it) are still admitted immediately. AIOConsumer identity is tracked via a ContextVar since the owning logical caller can move across ThreadPoolExecutor worker threads. Includes unit and integration test coverage for both the sync Consumer and AIOConsumer.

* Style fixes

* Addressed comments

* Trigger CLA check

* Address comments

* Add Tx related test cases + Add abort_tx call in Producer close

* Fix for serializing concurrent calls from a Async callback

* Fix one test case

* Fix styling

* [NOGIL] Guard AdminClient against concurrent close()-vs-method-call races

* Add handle check in common APIs and refactor overall handle logic

* Remove conflict marker

* Remove another conflict marker

* Rename handle functions

* Add more tests

* Fix flaky test

* Address comments

* Fix corrupted _common.py

* Fix other corrupted files

* Fix flaky test case

<!--
Suggested PR template: Fill/delete/add sections as needed. Optionally delete any commented block.
-->
What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include implementation strategy.
-->

Checklist
------------------
- [ ] Contains customer facing changes? Including API/behavior changes <!-- This can help identify if it has introduced any breaking changes -->
- [ ] Did you add sufficient unit test and/or integration test coverage for this PR?
  - If not, please explain why it is not required

References
----------
JIRA: 
<!--
Copy&paste links: to Jira ticket, other PRs, issues, Slack conversations...
For code bumps: link to PR, tag or GitHub `/compare/master...master`
-->

Test & Review
------------
<!--
Has it been tested? how?
Copy&paste any handy instructions, steps or requirements that can save time to the reviewer or any reader.
-->

Open questions / Follow-ups
--------------------------
<!--
Optional: anything open to discussion for the reviewer, out of scope, or follow-ups.
-->

<!--
Review stakeholders
------------------
<!--
Optional: mention stakeholders or if special context that is required to review.
-->
