### PR TITLE
[NOGIL] Make Message class methods thread safe

### DIFF
--- a/src/confluent_kafka/src/Consumer.c
+++ b/src/confluent_kafka/src/Consumer.c
@@ -1300,7 +1300,7 @@ Consumer_consume(Handle *self, PyObject *args, PyObject *kwargs) {
                               NULL};
         rd_kafka_message_t **rkmessages;
         PyObject *msglist;
-        rd_kafka_queue_t *rkqu = self->u.Consumer.rkqu;
+        rd_kafka_queue_t *rkqu;
         CallState cs;
         Py_ssize_t i, n;
 
@@ -1317,6 +1317,8 @@ Consumer_consume(Handle *self, PyObject *args, PyObject *kwargs) {
                 Handle_serialize_exit(self);
                 return NULL;
         }
+
+        rkqu = self->u.Consumer.rkqu;
 
         if (num_messages > 1000000) {
                 PyErr_SetString(

--- a/src/confluent_kafka/src/confluent_kafka.c
+++ b/src/confluent_kafka/src/confluent_kafka.c
@@ -477,40 +477,69 @@ static void cfl_PyErr_Fatal(rd_kafka_resp_err_t err, const char *reason) {
 
 
 /**
+ * @brief Return a new reference to one of the Message's PyObject fields,
+ *        or None if it is unset.
+ *
+ *        The pointer is read and INCREF'd under that field's own lock so
+ *        that a concurrent set_*() of the same field on another thread
+ *        (free-threaded builds) cannot drop the last reference between our
+ *        read and our INCREF. No-op on GIL builds.
+ */
+static PyObject *
+Message_get_field(PyObject **field, cfl_lock_t *lock) {
+        PyObject *obj;
+
+        cfl_lock(lock);
+        obj = *field;
+        Py_XINCREF(obj);
+        cfl_unlock(lock);
+
+        if (!obj)
+                Py_RETURN_NONE;
+        return obj;
+}
+
+/**
+ * @brief Replace one of the Message's PyObject fields with @p new_obj.
+ *
+ *        The swap happens under that field's own lock so it is atomic with
+ *        respect to Message_get_field() and other setters of the same
+ *        field; the old value is released only after unlocking, since a
+ *        DECREF can run arbitrary Python code (__del__).
+ */
+static PyObject *
+Message_set_field(PyObject **field, cfl_lock_t *lock, PyObject *new_obj) {
+        PyObject *old;
+
+        Py_INCREF(new_obj);
+        cfl_lock(lock);
+        old    = *field;
+        *field = new_obj;
+        cfl_unlock(lock);
+        Py_XDECREF(old);
+
+        Py_RETURN_NONE;
+}
+
+/**
  * @returns a Message's error object, if any, else None.
  * @remark The error object refcount is increased by this function.
  */
 PyObject *Message_error(Message *self, PyObject *ignore) {
-        if (self->error) {
-                Py_INCREF(self->error);
-                return self->error;
-        } else
-                Py_RETURN_NONE;
+        return Message_get_field(&self->error, &self->error_lock);
 }
 
 static PyObject *Message_value(Message *self, PyObject *ignore) {
-        if (self->value) {
-                Py_INCREF(self->value);
-                return self->value;
-        } else
-                Py_RETURN_NONE;
+        return Message_get_field(&self->value, &self->value_lock);
 }
 
 
 static PyObject *Message_key(Message *self, PyObject *ignore) {
-        if (self->key) {
-                Py_INCREF(self->key);
-                return self->key;
-        } else
-                Py_RETURN_NONE;
+        return Message_get_field(&self->key, &self->key_lock);
 }
 
 static PyObject *Message_topic(Message *self, PyObject *ignore) {
-        if (self->topic) {
-                Py_INCREF(self->topic);
-                return self->topic;
-        } else
-                Py_RETURN_NONE;
+        return Message_get_field(&self->topic, &self->topic_lock);
 }
 
 static PyObject *Message_partition(Message *self, PyObject *ignore) {
@@ -554,80 +583,55 @@ static PyObject *Message_delivery_count(Message *self, PyObject *ignore) {
 
 static PyObject *Message_headers(Message *self, PyObject *ignore) {
 #ifdef RD_KAFKA_V_HEADERS
-        if (self->headers) {
-                Py_INCREF(self->headers);
-                return self->headers;
-        } else if (self->c_headers) {
+        PyObject *headers;
+
+        cfl_lock(&self->headers_lock);
+        if (!self->headers && self->c_headers) {
                 self->headers = c_headers_to_py(self->c_headers);
-                rd_kafka_headers_destroy(self->c_headers);
-                self->c_headers = NULL;
-                Py_INCREF(self->headers);
-                return self->headers;
-        } else {
+                if (self->headers) {
+                        rd_kafka_headers_destroy(self->c_headers);
+                        self->c_headers = NULL;
+                }
+        }
+        headers = self->headers;
+        Py_XINCREF(headers);
+        cfl_unlock(&self->headers_lock);
+
+        if (!headers) {
+                if (PyErr_Occurred())
+                        return NULL;
                 Py_RETURN_NONE;
         }
+        return headers;
 #else
         Py_RETURN_NONE;
 #endif
 }
 
 static PyObject *Message_set_headers(Message *self, PyObject *new_headers) {
-        if (self->headers)
-                Py_DECREF(self->headers);
-        self->headers = new_headers;
-        Py_INCREF(self->headers);
-
-        Py_RETURN_NONE;
+        return Message_set_field(&self->headers, &self->headers_lock,
+                                 new_headers);
 }
 
 static PyObject *Message_set_value(Message *self, PyObject *new_val) {
-        if (self->value)
-                Py_DECREF(self->value);
-        self->value = new_val;
-        Py_INCREF(self->value);
-
-        Py_RETURN_NONE;
+        return Message_set_field(&self->value, &self->value_lock, new_val);
 }
 
 static PyObject *Message_set_key(Message *self, PyObject *new_key) {
-        if (self->key)
-                Py_DECREF(self->key);
-        self->key = new_key;
-        Py_INCREF(self->key);
-
-        Py_RETURN_NONE;
+        return Message_set_field(&self->key, &self->key_lock, new_key);
 }
 
 static PyObject *Message_set_topic(Message *self, PyObject *new_topic) {
-        if (self->topic)
-                Py_DECREF(self->topic);
-        self->topic = new_topic;
-        Py_INCREF(self->topic);
-
-        Py_RETURN_NONE;
+        return Message_set_field(&self->topic, &self->topic_lock, new_topic);
 }
 
 static PyObject *Message_set_error(Message *self, PyObject *new_error) {
-        if (self->error)
-                Py_DECREF(self->error);
-        self->error = new_error;
-        Py_INCREF(self->error);
-
-        Py_RETURN_NONE;
+        return Message_set_field(&self->error, &self->error_lock, new_error);
 }
 
 static PyObject *Message_reduce(Message *self, PyObject *Py_UNUSED(ignored)) {
         PyObject *Message_type = NULL;
         PyObject *result       = NULL;
-
-#ifdef RD_KAFKA_V_HEADERS
-        if (!self->headers && self->c_headers) {
-                self->headers = c_headers_to_py(self->c_headers);
-                rd_kafka_headers_destroy(self->c_headers);
-                self->c_headers = NULL;
-        }
-#endif
-
 
         Message_type = cfl_PyObject_lookup("confluent_kafka.cimpl", "Message");
 

--- a/src/confluent_kafka/src/confluent_kafka.h
+++ b/src/confluent_kafka/src/confluent_kafka.h
@@ -177,6 +177,21 @@ static inline int atomic_ulong_cas(atomic_ulong_t *p, unsigned long expected,
 #endif
 
 /**
+ * @brief Mutex for short, non-blocking C-only regions. PyMutex (3.13+) on
+ *        free-threaded builds; a no-op on GIL builds. Never hold it across
+ *        code that can run Python or block.
+ */
+#ifdef Py_GIL_DISABLED
+typedef PyMutex cfl_lock_t;
+#define cfl_lock(l)   PyMutex_Lock(l)
+#define cfl_unlock(l) PyMutex_Unlock(l)
+#else
+typedef char cfl_lock_t;
+#define cfl_lock(l)   ((void)(l))
+#define cfl_unlock(l) ((void)(l))
+#endif
+
+/**
  * Avoid unused function warnings
  */
 #if _WIN32
@@ -700,6 +715,14 @@ typedef struct {
         int16_t delivery_count; /**< Share consumer: number of times this
                                  *   record has been delivered. 1 on first
                                  *   delivery. -1 if unavailable. */
+
+        /* One lock per mutable PyObject field above: serializes concurrent
+         * get/set of the same field on a shared Message (free-threaded). */
+        cfl_lock_t topic_lock;
+        cfl_lock_t value_lock;
+        cfl_lock_t key_lock;
+        cfl_lock_t headers_lock;
+        cfl_lock_t error_lock;
 } Message;
 
 extern PyTypeObject MessageType;

--- a/tests/concurrency/test_message_thread_safety.py
+++ b/tests/concurrency/test_message_thread_safety.py
@@ -1,0 +1,215 @@
+#!/usr/bin/env python
+#
+# Copyright 2026 Confluent Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Concurrency tests for a single confluent_kafka.Message shared across threads.
+"""
+
+import itertools
+import pickle
+import threading
+import time
+
+from confluent_kafka import Consumer, KafkaError, Message, Producer
+from tests.concurrency._subprocess_isolation import subprocess_isolated
+
+_RACE_DURATION_S = 2.0
+_THREADS_PER_ROLE = 2
+
+_NUM_MESSAGES = 200
+_NUM_READERS = 8
+_HEADERS = [('h-1', b'v-1'), ('h-2', b'v-2'), ('h-none', None)]
+
+
+###############################################################################
+# Helpers
+###############################################################################
+
+
+def _run_for(workers, duration_s):
+    """
+    Run each callable in `workers` in a tight loop on its own thread for
+    `duration_s`, all released together through a Barrier. Stops early if any
+    worker raises. Returns the list of exceptions raised.
+    """
+    stop = threading.Event()
+    errors = []
+    barrier = threading.Barrier(len(workers))
+
+    def run(work):
+        try:
+            barrier.wait()
+            while not stop.is_set():
+                work()
+        except Exception as e:  # noqa: BLE001 - any failure is a test failure
+            errors.append(e)
+            stop.set()
+
+    threads = [threading.Thread(target=run, args=(w,), daemon=True) for w in workers]
+    for t in threads:
+        t.start()
+    time.sleep(duration_s)
+    stop.set()
+    for t in threads:
+        t.join(timeout=30)
+    assert all(not t.is_alive() for t in threads), "a worker thread did not finish"
+    return errors
+
+
+def _race_readers(msg, read, num_readers):
+    """
+    Release `num_readers` threads simultaneously into `read(msg)` and return
+    their results in thread order. Any exception fails the test.
+    """
+    barrier = threading.Barrier(num_readers)
+    results = [None] * num_readers
+    errors = []
+
+    def run(i):
+        try:
+            barrier.wait()
+            results[i] = read(msg)
+        except Exception as e:  # noqa: BLE001
+            errors.append(e)
+
+    threads = [threading.Thread(target=run, args=(i,), daemon=True) for i in range(num_readers)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=30)
+    assert all(not t.is_alive() for t in threads), "a reader thread did not finish"
+    assert not errors, f"reader threads raised: {errors}"
+    return results
+
+
+def _consume_messages_with_headers(count):
+    """
+    Produce `count` messages carrying _HEADERS to librdkafka's in-process mock
+    cluster and consume them back. The returned Messages still hold their
+    headers in undecoded C form, exactly as a real consumer would hand them
+    to an application.
+    """
+    producer = Producer({'test.mock.num.brokers': 1})
+    brokers = producer.list_topics(timeout=10).brokers.values()
+    bootstrap = ','.join(f'{b.host}:{b.port}' for b in brokers)
+
+    for i in range(count):
+        producer.produce('topic', value=b'm-%d' % i, headers=_HEADERS)
+    assert producer.flush(10) == 0, "not every message was delivered to the mock cluster"
+
+    consumer = Consumer({'bootstrap.servers': bootstrap, 'group.id': 'g', 'auto.offset.reset': 'earliest'})
+    consumer.subscribe(['topic'])
+    messages = []
+    deadline = time.time() + 30
+    while len(messages) < count and time.time() < deadline:
+        for msg in consumer.consume(num_messages=count - len(messages), timeout=1.0):
+            assert msg.error() is None, msg.error()
+            messages.append(msg)
+    consumer.close()
+
+    assert len(messages) == count, f"consumed {len(messages)} of {count} messages"
+    return messages
+
+
+###############################################################################
+# Getter vs setter on the same field
+###############################################################################
+
+# (field, make(i) -> a fresh value to set, valid(v) -> is v a value we set)
+_FIELDS = [
+    ('value', lambda i: b'v-%d' % i, lambda v: isinstance(v, bytes) and v.startswith(b'v-')),
+    ('key', lambda i: b'k-%d' % i, lambda v: isinstance(v, bytes) and v.startswith(b'k-')),
+    ('topic', lambda i: 't-%d' % i, lambda v: isinstance(v, str) and v.startswith('t-')),
+    ('headers', lambda i: [('h', b'%d' % i)], lambda v: isinstance(v, list) and len(v) == 1 and v[0][0] == 'h'),
+    (
+        'error',
+        lambda i: KafkaError(KafkaError._PARTITION_EOF, 'e-%d' % i),
+        lambda v: isinstance(v, KafkaError) and v.str().startswith('e-'),
+    ),
+]
+
+
+def _setter(msg, field, make):
+    set_field = getattr(msg, 'set_' + field)
+    counter = itertools.count(1)
+
+    def work():
+        # A fresh object every time, so each set_*() drops the last reference
+        # to the previous value -- that is what a racing getter must survive.
+        set_field(make(next(counter)))
+
+    return work
+
+
+def _getter(msg, field, valid):
+    get_field = getattr(msg, field)
+
+    def work():
+        v = get_field()
+        assert valid(v), f"{field}() returned {v!r}"
+
+    return work
+
+
+@subprocess_isolated
+def test_concurrent_get_and_set_same_field():
+    """For every mutable field, setters and getters hammering one shared
+    Message must never crash and getters must only ever see values that were
+    actually set."""
+    msg = Message(
+        topic='t-0',
+        partition=0,
+        offset=0,
+        key=b'k-0',
+        value=b'v-0',
+        headers=[('h', b'0')],
+        error=KafkaError(KafkaError._PARTITION_EOF, 'e-0'),
+    )
+
+    workers = []
+    for field, make, valid in _FIELDS:
+        workers += [_setter(msg, field, make) for _ in range(_THREADS_PER_ROLE)]
+        workers += [_getter(msg, field, valid) for _ in range(_THREADS_PER_ROLE)]
+
+    errors = _run_for(workers, _RACE_DURATION_S)
+    assert not errors, f"worker threads raised: {errors}"
+
+
+###############################################################################
+# Lazy header decode on a consumed Message
+###############################################################################
+
+
+@subprocess_isolated
+def test_concurrent_headers_decode_on_consumed_message():
+    """Simultaneous headers() calls on one consumed Message must decode the C
+    headers exactly once and all return the same list."""
+    for msg in _consume_messages_with_headers(_NUM_MESSAGES):
+        results = _race_readers(msg, lambda m: m.headers(), _NUM_READERS)
+        assert results == [_HEADERS] * _NUM_READERS, results
+
+
+@subprocess_isolated
+def test_concurrent_pickle_of_consumed_message():
+    """Same as above through __reduce__: simultaneous pickling of one consumed
+    Message decodes the C headers exactly once."""
+
+    def pickle_roundtrip_headers(m):
+        return pickle.loads(pickle.dumps(m)).headers()
+
+    for msg in _consume_messages_with_headers(_NUM_MESSAGES):
+        results = _race_readers(msg, pickle_roundtrip_headers, _NUM_READERS)
+        assert results == [_HEADERS] * _NUM_READERS, results


### PR DESCRIPTION

- Message class exposes getters and setters to five fields. On free threaded Python builds, calling setters and getters concurrently can cause use-after-free conditions and incorrect reference counts. 

- This PR fixes this by acquiring a lock around code snippets where we want only one thread to run at a time (critical sections). The getters and setters have been refactored as part of this process. In Message_headers, an unrelated bug related to error not being handled is also fixed.

- For the five fields that have getters and setters, we have introduced five lock fields within the Message struct.

- Also contains a minor fix in Consumer_consume method.



----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include implementation strategy.
-->

Checklist
------------------
- [ ] Contains customer facing changes? Including API/behavior changes <!-- This can help identify if it has introduced any breaking changes -->
- [ ] Did you add sufficient unit test and/or integration test coverage for this PR?
  - If not, please explain why it is not required

References
----------
JIRA: 
<!--
Copy&paste links: to Jira ticket, other PRs, issues, Slack conversations...
For code bumps: link to PR, tag or GitHub `/compare/master...master`
-->

Test & Review
------------
<!--
Has it been tested? how?
Copy&paste any handy instructions, steps or requirements that can save time to the reviewer or any reader.
-->

Open questions / Follow-ups
--------------------------
<!--
Optional: anything open to discussion for the reviewer, out of scope, or follow-ups.
-->

<!--
Review stakeholders
------------------
<!--
Optional: mention stakeholders or if special context that is required to review.
-->
