### PR TITLE
Migrate PyPI publish tokens from Vault V1 to V3

### DIFF
--- a/.semaphore/publish-pypi.yml
+++ b/.semaphore/publish-pypi.yml
@@ -13,9 +13,8 @@ blocks:
         - name: Upload
           commands:
             - checkout
-            - . vault-setup
             - export TWINE_USERNAME=__token__
-            - export TWINE_PASSWORD="$(vault kv get -format=json v1/ci/kv/pypi/pypi.org | jq -r '.data.data."confluent-kafka"')"
+            - . vault-get-secret --secret-key=pypi_token --export-as=TWINE_PASSWORD pypi/confluent-kafka
             - sem-version python 3.11
             - pip install twine
             - artifact pull workflow artifacts

--- a/.semaphore/publish-test-pypi.yml
+++ b/.semaphore/publish-test-pypi.yml
@@ -13,9 +13,8 @@ blocks:
         - name: Upload
           commands:
             - checkout
-            - . vault-setup
             - export TWINE_USERNAME=__token__
-            - export TWINE_PASSWORD="$(vault kv get -format=json v1/ci/kv/pypi/test.pypi.org | jq -r '.data.data."confluent-kafka"')"
+            - . vault-get-secret --secret-key=test_pypi_token --export-as=TWINE_PASSWORD pypi/confluent-kafka
             - sem-version python 3.11
             - pip install twine
             - artifact pull workflow artifacts


### PR DESCRIPTION
## What

Migrates both PyPI publish jobs off the shared Vault V1 path onto the dedicated V3 secret via `vault-get-secret`:

- `publish-pypi.yml`: `TWINE_PASSWORD` now from `pypi/confluent-kafka` key `pypi_token`
- `publish-test-pypi.yml`: `TWINE_PASSWORD` now from `pypi/confluent-kafka` key `test_pypi_token`

Both drop the now-unused `. vault-setup` (V1 auth) since `vault-get-secret` authenticates via OIDC itself.

## Why this is safe

- Same env var (`TWINE_PASSWORD`), same `__token__` username, same tokens — only the storage location moves from Vault V1 to V3.
- The V3 secret `semaphore/pypi/confluent-kafka` (keys `pypi_token` for prod PyPI, `test_pypi_token` for test PyPI) is provisioned by cire-vault PR #4182 with a dedicated `confluent-kafka-python` role scoped to this repo via Semaphore OIDC. `--vault-role` defaults to the repo name, which matches the role — no flag needed.
- Previously this repo's job could read every project's token out of the shared `v1/ci/kv/pypi/*` blob; now it can read only its own.

## ⚠️ Merge order

Do **not** merge until cire-vault #4182 is applied **and** the two token values are uploaded to `stag/kv/semaphore/pypi/confluent-kafka` (keys `pypi_token`, `test_pypi_token`).
